### PR TITLE
fix: prevent transfers of removedLiquidity

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -570,7 +570,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     }
 
     /// @notice update user position data following a token transfer
-    /// @dev token transfers are only allowed if you transfer your entire balance of a given tokenId and the recipient has none
+    /// @dev token transfers are only allowed if you transfer your entire liquidity of a given chunk and the recipient has none
     /// @param from The address of the sender
     /// @param to The address of the recipient
     /// @param id The tokenId being transferred'
@@ -1339,7 +1339,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     /// @param tokenType The tokenType of the position (the token it started as)
     /// @param tickLower The lower end of the tick range for the position (int24)
     /// @param tickUpper The upper end of the tick range for the position (int24)
-    /// @return accountLiquidities The amount of liquidity that has been shorted/added to the Uniswap contract (removedLiquidity:netLiquidity -> rightSlot:leftSlot)
+    /// @return accountLiquidities The amount of liquidity that has been shorted/added to the Uniswap contract (netLiquidity:removedLiquidity -> rightSlot:leftSlot)
     function getAccountLiquidity(
         address univ3pool,
         address owner,

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -618,7 +618,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
 
             // Revert if sender has long positions in that chunk or the entire liquidity is not being transferred
             uint256 fromLiq = s_accountLiquidity[positionKey_from];
-            if (fromLiq != liquidityChunk) revert Errors.TransferFailed();
+            if (fromLiq != liquidityChunk.liquidity()) revert Errors.TransferFailed();
 
             int256 fromBase = s_accountFeesBase[positionKey_from];
 

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -616,9 +616,9 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                 (s_accountFeesBase[positionKey_to] != 0)
             ) revert Errors.TransferFailed();
 
-            // Revert if not all balance is transferred
+            // Revert if sender has long positions in that chunk or the entire liquidity is not being transferred
             uint256 fromLiq = s_accountLiquidity[positionKey_from];
-            if (fromLiq.rightSlot() != liquidityChunk.liquidity()) revert Errors.TransferFailed();
+            if (fromLiq != liquidityChunk) revert Errors.TransferFailed();
 
             int256 fromBase = s_accountFeesBase[positionKey_from];
 

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -3000,7 +3000,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
         uint256 tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(
             0,
-            bound(optionRatio, 1, 128),
+            bound(optionRatio, 1, 127),
             isWETH,
             0,
             1,

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -2916,6 +2916,113 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         sfpm.safeTransferFrom(Alice, Bob, tokenId, transferSize, "");
     }
 
+    // mint a short leg, long some of that leg, then transfer the long leg
+    // should fail as you shouldnt be able to transfer removedliquidity
+    function test_Fail_afterTokenTransfer_LongChunkTransferredSolo(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            1,
+            0,
+            strike,
+            width
+        );
+
+        sfpm.mintTokenizedPosition(
+            tokenId1,
+            uint128(positionSize * 2),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            1,
+            1,
+            0,
+            strike,
+            width
+        );
+
+        sfpm.mintTokenizedPosition(
+            tokenId2,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        vm.expectRevert(Errors.TransferFailed.selector);
+
+        sfpm.safeTransferFrom(Alice, Bob, tokenId2, positionSize, "");
+    }
+
+    // mint a position with a long and short touch to a leg then transfer it
+    // should fail as you shouldnt be able to transfer removedliquidity
+    function test_Fail_afterTokenTransfer_LongChunkAndShortChunk(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed,
+        uint256 optionRatio
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            bound(optionRatio, 1, 128),
+            isWETH,
+            0,
+            1,
+            0,
+            strike,
+            width
+        );
+
+        tokenId1 = tokenId1.addLeg(1, 1, isWETH, 1, 1, 1, strike, width);
+
+        sfpm.mintTokenizedPosition(
+            tokenId1,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        vm.expectRevert(Errors.TransferFailed.selector);
+
+        sfpm.safeTransferFrom(Alice, Bob, tokenId1, positionSize, "");
+    }
+
     function test_Fail_afterTokenTransfer_RecipientAlreadyOwns(
         uint256 x,
         uint256 widthSeed,


### PR DESCRIPTION
We need to disable transfers of removedLiquidity because they can result in misrepresentation of the liquidity utilization/premium multiplier to protocols if chunks are transferred to them before users mint any positions there.

Also, they shouldn't be possible anyway in general because having a long position means that there's a corresponding short position (i.e >1 touches to a chunk)