### PR TITLE
fix: prevent self-DOS at high liquidity utilization

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1080,10 +1080,17 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
             collectedAmounts
         );
 
-        s_accountPremiumOwed[positionKey] = s_accountPremiumOwed[positionKey].add(deltaPremiumOwed);
-        s_accountPremiumGross[positionKey] = s_accountPremiumGross[positionKey].add(
-            deltaPremiumGross
-        );
+        // note: these are allowed to overflow because the alternative results in a possible DOS with stuck positions at high multipliers
+        // protocols that make use of these values should/will implement a cap to the liquidity utilization to prevent extremely high long premium multipliers
+        // when most of the liquidity is removed. There is no need for such a cap
+        unchecked {
+            s_accountPremiumOwed[positionKey] =
+                s_accountPremiumOwed[positionKey] +
+                deltaPremiumOwed;
+            s_accountPremiumGross[positionKey] =
+                s_accountPremiumGross[positionKey] +
+                deltaPremiumGross;
+        }
     }
 
     /// @notice Compute the feesGrowth * liquidity / 2**128 by reading feeGrowthInside0LastX128 and feeGrowthInside1LastX128 from univ3pool.positions.

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1269,20 +1269,24 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         unchecked {
             uint256 totalLiquidity = netLiquidity + removedLiquidity;
 
-            uint128 premium0X64_base;
-            uint128 premium1X64_base;
+            uint256 premium0X64_base;
+            uint256 premium1X64_base;
 
             {
                 uint128 collected0 = uint128(collectedAmounts.rightSlot());
                 uint128 collected1 = uint128(collectedAmounts.leftSlot());
 
                 // compute the base premium as collected * total / net^2 (from Eqn 3)
-                premium0X64_base = Math
-                    .mulDiv(collected0, totalLiquidity * 2 ** 64, netLiquidity ** 2)
-                    .toUint128();
-                premium1X64_base = Math
-                    .mulDiv(collected1, totalLiquidity * 2 ** 64, netLiquidity ** 2)
-                    .toUint128();
+                premium0X64_base = Math.mulDiv(
+                    collected0,
+                    totalLiquidity * 2 ** 64,
+                    netLiquidity ** 2
+                );
+                premium1X64_base = Math.mulDiv(
+                    collected1,
+                    totalLiquidity * 2 ** 64,
+                    netLiquidity ** 2
+                );
             }
 
             {
@@ -1292,12 +1296,12 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                     // compute the owed premium (from Eqn 3)
                     uint256 numerator = netLiquidity + (removedLiquidity / 2 ** VEGOID);
 
-                    premium0X64_owed = Math
-                        .mulDiv(premium0X64_base, numerator, totalLiquidity)
-                        .toUint128();
-                    premium1X64_owed = Math
-                        .mulDiv(premium1X64_base, numerator, totalLiquidity)
-                        .toUint128();
+                    premium0X64_owed = uint128(
+                        Math.mulDiv(premium0X64_base, numerator, totalLiquidity)
+                    );
+                    premium1X64_owed = uint128(
+                        Math.mulDiv(premium1X64_base, numerator, totalLiquidity)
+                    );
 
                     deltaPremiumOwed = uint256(0).toRightSlot(premium0X64_owed).toLeftSlot(
                         premium1X64_owed
@@ -1314,12 +1318,12 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                         totalLiquidity *
                         removedLiquidity +
                         ((removedLiquidity ** 2) / 2 ** (VEGOID));
-                    premium0X64_gross = Math
-                        .mulDiv(premium0X64_base, numerator, totalLiquidity ** 2)
-                        .toUint128();
-                    premium1X64_gross = Math
-                        .mulDiv(premium1X64_base, numerator, totalLiquidity ** 2)
-                        .toUint128();
+                    premium0X64_gross = uint128(
+                        Math.mulDiv(premium0X64_base, numerator, totalLiquidity ** 2)
+                    );
+                    premium1X64_gross = uint128(
+                        Math.mulDiv(premium1X64_base, numerator, totalLiquidity ** 2)
+                    );
                     deltaPremiumGross = uint256(0).toRightSlot(premium0X64_gross).toLeftSlot(
                         premium1X64_gross
                     );

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -3662,7 +3662,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         sfpm.mintTokenizedPosition(
             tokenIdLong,
-            uint128((positionSize * (2 ** 64 - 1)) / 2 ** 64),
+            uint128(Math.mulDiv64(positionSize, (2 ** 64 - 1))),
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );
@@ -3702,7 +3702,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         // this succeeding is the test - it should overflow cleanly instead of reverting and DOS-ing the positions
         sfpm.burnTokenizedPosition(
             tokenIdLong,
-            uint128((positionSize * (2 ** 64 - 1)) / 2 ** 64),
+            uint128(Math.mulDiv64(positionSize, (2 ** 64 - 1))),
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -3611,6 +3611,115 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         assertApproxEqAbs(premium1Short, premium1ShortOld, premiaError1[0]);
     }
 
+    // make sure that we allow the premium to overflow and it does not revert when too much is accumulated with a huge multiplier
+    function test_Success_PremiumDOSPrevention(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed,
+        uint256 swapSize
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getInRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenIdShort = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            1,
+            0,
+            strike,
+            width
+        );
+
+        sfpm.mintTokenizedPosition(
+            tokenIdShort,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        uint256 tokenIdLong = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            1,
+            1,
+            0,
+            strike,
+            width
+        );
+
+        // mint a long position with 1 wei of liquidity less than available, resulting in a huge multiplier
+        uint256 longPositionSize = isWETH == 0
+            ? LiquidityAmounts.getLiquidityForAmount0(sqrtLower, sqrtUpper, positionSize)
+            : LiquidityAmounts.getLiquidityForAmount1(sqrtLower, sqrtUpper, positionSize);
+
+        sfpm.mintTokenizedPosition(
+            tokenIdLong,
+            uint128(longPositionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        changePrank(Bob);
+
+        swapSize = bound(swapSize, 10 ** 15, 10 ** 19);
+
+        router.exactInputSingle(
+            ISwapRouter.ExactInputSingleParams(
+                isWETH == 0 ? token0 : token1,
+                isWETH == 1 ? token0 : token1,
+                fee,
+                Bob,
+                block.timestamp,
+                swapSize,
+                0,
+                0
+            )
+        );
+
+        router.exactOutputSingle(
+            ISwapRouter.ExactOutputSingleParams(
+                isWETH == 1 ? token0 : token1,
+                isWETH == 0 ? token0 : token1,
+                fee,
+                Bob,
+                block.timestamp,
+                swapSize - (swapSize * fee) / 1_000_000,
+                type(uint256).max,
+                0
+            )
+        );
+
+        changePrank(Alice);
+
+        // this succeeding is the test - it should overflow cleanly instead of reverting and DOS-ing the positions
+        sfpm.burnTokenizedPosition(
+            tokenIdLong,
+            uint128(longPositionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        sfpm.burnTokenizedPosition(
+            tokenIdShort,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+    }
+
     /*//////////////////////////////////////////////////////////////
                                  SANITY
     //////////////////////////////////////////////////////////////*/

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -3662,7 +3662,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         sfpm.mintTokenizedPosition(
             tokenIdLong,
-            uint128(Math.mulDiv64(positionSize, (2 ** 64 - 1))),
+            uint128(Math.mulDiv(positionSize, (2 ** 64 - 1), 2 ** 64)),
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );
@@ -3671,38 +3671,40 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         uint256 swapSize = 10 ** 20;
 
-        router.exactInputSingle(
-            ISwapRouter.ExactInputSingleParams(
-                isWETH == 0 ? token0 : token1,
-                isWETH == 1 ? token0 : token1,
-                fee,
-                Bob,
-                block.timestamp,
-                swapSize,
-                0,
-                0
-            )
-        );
+        for (uint256 i = 0; i < 500; ++i) {
+            router.exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(
+                    isWETH == 0 ? token0 : token1,
+                    isWETH == 1 ? token0 : token1,
+                    fee,
+                    Bob,
+                    block.timestamp,
+                    swapSize,
+                    0,
+                    0
+                )
+            );
 
-        router.exactOutputSingle(
-            ISwapRouter.ExactOutputSingleParams(
-                isWETH == 1 ? token0 : token1,
-                isWETH == 0 ? token0 : token1,
-                fee,
-                Bob,
-                block.timestamp,
-                swapSize - (swapSize * fee) / 1_000_000,
-                type(uint256).max,
-                0
-            )
-        );
+            router.exactOutputSingle(
+                ISwapRouter.ExactOutputSingleParams(
+                    isWETH == 1 ? token0 : token1,
+                    isWETH == 0 ? token0 : token1,
+                    fee,
+                    Bob,
+                    block.timestamp,
+                    swapSize - (swapSize * fee) / 1_000_000,
+                    type(uint256).max,
+                    0
+                )
+            );
+        }
 
         changePrank(Alice);
 
         // this succeeding is the test - it should overflow cleanly instead of reverting and DOS-ing the positions
         sfpm.burnTokenizedPosition(
             tokenIdLong,
-            uint128(Math.mulDiv64(positionSize, (2 ** 64 - 1))),
+            uint128(Math.mulDiv(positionSize, (2 ** 64 - 1), 2 ** 64)),
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -3615,11 +3615,9 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     function test_Success_PremiumDOSPrevention(
         uint256 x,
         uint256 widthSeed,
-        int256 strikeSeed,
-        uint256 positionSizeSeed,
-        uint256 swapSize
+        int256 strikeSeed
     ) public {
-        _initPool(x);
+        _initPool(0);
 
         (int24 width, int24 strike) = PositionUtils.getInRangeSW(
             widthSeed,
@@ -3628,7 +3626,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             currentTick
         );
 
-        populatePositionData(width, strike, positionSizeSeed);
+        populatePositionData(width, strike, type(uint256).max);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
         uint256 tokenIdShort = uint256(0).addUniv3pool(poolId).addLeg(
@@ -3661,20 +3659,17 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
 
         // mint a long position with 1 wei of liquidity less than available, resulting in a huge multiplier
-        uint256 longPositionSize = isWETH == 0
-            ? LiquidityAmounts.getLiquidityForAmount0(sqrtLower, sqrtUpper, positionSize)
-            : LiquidityAmounts.getLiquidityForAmount1(sqrtLower, sqrtUpper, positionSize);
 
         sfpm.mintTokenizedPosition(
             tokenIdLong,
-            uint128(longPositionSize),
+            uint128((positionSize * (2 ** 64 - 1)) / 2 ** 64),
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );
 
         changePrank(Bob);
 
-        swapSize = bound(swapSize, 10 ** 15, 10 ** 19);
+        uint256 swapSize = 10 ** 20;
 
         router.exactInputSingle(
             ISwapRouter.ExactInputSingleParams(
@@ -3707,7 +3702,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         // this succeeding is the test - it should overflow cleanly instead of reverting and DOS-ing the positions
         sfpm.burnTokenizedPosition(
             tokenIdLong,
-            uint128(longPositionSize),
+            uint128((positionSize * (2 ** 64 - 1)) / 2 ** 64),
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );


### PR DESCRIPTION
Protocols that use the SFPM are expected to set a cap on liquidity utilization to stop the long premium multiplier from getting ridiculously high. This means that the premium will always be grounded in reality, so it would be difficult or impossible to overflow the owed/gross premium accumulators.

The same cannot be said for independent SFPM users. They don't need the accountPremium accumulators at all, so there are no adverse effects to selling liquidity in a given chunk and then longing most or all of it. Despite this, the calculations are still performed, and if they push the liquidity high enough, especially on certain pools, their burn transactions may revert due to the premium (bolstered by an inflated multiplier) overflowing its container.

The solution is just to allow the account premium accumulators to overflow. Reverting if they overflow isn't productive because it just prevents positions from being burnt instead of simply resetting the accumulator like Uniswap does. If they do overflow, it can be handled gracefully in SFPM-based protocols by either resetting the premium accumulation or counting across 0.