### PR TITLE
fix: prevent reentrancy on uninitialized pools

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -371,10 +371,11 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
             poolId = PanopticMath.getFinalPoolId(poolId, token0, token1, fee);
         }
         // store the poolId => UniswapV3Pool information in a mapping
-        // `locked` can be initialized to false because the pool address makes the slot nonzero
+        // `locked` being initialized to false is gas-efficient because the pool address makes the slot nonzero
+        // note: we preserve the state of `locked` to prevent reentering a pool by initializing it during the reentrant call
         s_poolContext[poolId] = PoolAddressAndLock({
             pool: IUniswapV3Pool(univ3pool),
-            locked: false
+            locked: s_poolContext[poolId].locked
         });
 
         // store the UniswapV3Pool => poolId information in a mapping

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,7 +24,7 @@ viaIR = true
 
 [fuzz]
 # temporary workaround while we figure out perf issues + configure different test sets + profiles
-runs = 5
+runs = 1
 max_test_rejects = 9_999_999
 [rpc_endpoints]
 sepolia = 'https://eth-sepolia.g.alchemy.com/v2/vevMezCXoFshwV190wQcekYwQflctBeE'

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -25,7 +25,7 @@ import {PanopticHelper} from "@periphery/PanopticHelper.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {PositionUtils} from "../testUtils/PositionUtils.sol";
 import {UniPoolPriceMock} from "../testUtils/PriceMocks.sol";
-import {ReenterMint, ReenterBurn, ReenterInitialize} from "../testUtils/ReentrancyMocks.sol";
+import {ReenterMint, ReenterBurn, Reenter1155Initialize} from "../testUtils/ReentrancyMocks.sol";
 
 contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
     constructor(IUniswapV3Factory _factory) SemiFungiblePositionManager(_factory) {}
@@ -3658,7 +3658,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         int256 strikeSeed,
         uint256 positionSizeSeed
     ) public {
-        _initPool(x);
+        _initWorld(x);
 
         (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
             widthSeed,
@@ -3681,25 +3681,10 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             width
         );
 
-        // replace the Uniswap pool with a mock contract that can answer some queries correctly,
-        // but will attempt to callback with mintTokenizedPosition on any other call
-        vm.etch(address(pool), address(new ReenterInitialize()).code);
+        // allow Alice to try to initialize and then reenter when getting the onERC1155Received callback
+        vm.etch(address(Alice), address(new Reenter1155Initialize()).code);
 
-        ReenterInitialize(address(pool)).construct(
-            ReenterInitialize.Slot0(
-                TickMath.getSqrtRatioAtTick(currentTick),
-                currentTick,
-                0,
-                0,
-                0,
-                0,
-                true
-            ),
-            address(token0),
-            address(token1),
-            fee,
-            tickSpacing
-        );
+        Reenter1155Initialize(Alice).construct(address(token0), address(token1), fee, poolId);
 
         vm.expectRevert(Errors.ReentrantCall.selector);
 

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -25,7 +25,7 @@ import {PanopticHelper} from "@periphery/PanopticHelper.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {PositionUtils} from "../testUtils/PositionUtils.sol";
 import {UniPoolPriceMock} from "../testUtils/PriceMocks.sol";
-import {ReenterMint, ReenterBurn} from "../testUtils/ReentrancyMocks.sol";
+import {ReenterMint, ReenterBurn, ReenterInitialize} from "../testUtils/ReentrancyMocks.sol";
 
 contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
     constructor(IUniswapV3Factory _factory) SemiFungiblePositionManager(_factory) {}
@@ -1803,65 +1803,6 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
                          OUT-OF-RANGE MINTS: -
     //////////////////////////////////////////////////////////////*/
 
-    function test_Fail_mintTokenizedPosition_ReentrancyLock(
-        uint256 x,
-        uint256 widthSeed,
-        int256 strikeSeed,
-        uint256 positionSizeSeed
-    ) public {
-        _initPool(x);
-
-        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
-            widthSeed,
-            strikeSeed,
-            uint24(tickSpacing),
-            currentTick
-        );
-
-        populatePositionData(width, strike, positionSizeSeed);
-
-        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
-
-        // replace the Uniswap pool with a mock contract that can answer some queries correctly,
-        // but will attempt to callback with mintTokenizedPosition on any other call
-        vm.etch(address(pool), address(new ReenterMint()).code);
-
-        ReenterMint(address(pool)).construct(
-            ReenterMint.Slot0(
-                TickMath.getSqrtRatioAtTick(currentTick),
-                currentTick,
-                0,
-                0,
-                0,
-                0,
-                true
-            ),
-            address(token0),
-            address(token1),
-            fee,
-            tickSpacing
-        );
-
-        vm.expectRevert(Errors.ReentrantCall.selector);
-
-        sfpm.mintTokenizedPosition(
-            tokenId,
-            uint128(positionSize),
-            TickMath.MIN_TICK,
-            TickMath.MAX_TICK
-        );
-    }
-
     function test_Fail_mintTokenizedPosition_positionSize0(
         uint256 x,
         uint256 widthSeed,
@@ -2557,77 +2498,6 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             int256(IERC20Partial(token1).balanceOf(Alice)),
             int256(balance1Before) + amount1MovedBurn,
             10
-        );
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                               BURNING: +
-    //////////////////////////////////////////////////////////////*/
-
-    function test_Fail_burnTokenizedPosition_ReentrancyLock(
-        uint256 x,
-        uint256 widthSeed,
-        int256 strikeSeed,
-        uint256 positionSizeSeed,
-        uint256 positionSizeBurnSeed
-    ) public {
-        _initPool(x);
-
-        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
-            widthSeed,
-            strikeSeed,
-            uint24(tickSpacing),
-            currentTick
-        );
-
-        populatePositionData(width, strike, positionSizeSeed, positionSizeBurnSeed);
-
-        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
-
-        sfpm.mintTokenizedPosition(
-            tokenId,
-            uint128(positionSize),
-            TickMath.MIN_TICK,
-            TickMath.MAX_TICK
-        );
-
-        // replace the Uniswap pool with a mock that responds correctly to queries but calls back on
-        // any other operations
-        vm.etch(address(pool), address(new ReenterBurn()).code);
-
-        ReenterBurn(address(pool)).construct(
-            ReenterBurn.Slot0(
-                TickMath.getSqrtRatioAtTick(currentTick),
-                currentTick,
-                0,
-                0,
-                0,
-                0,
-                true
-            ),
-            address(token0),
-            address(token1),
-            fee,
-            tickSpacing
-        );
-
-        vm.expectRevert(Errors.ReentrantCall.selector);
-
-        sfpm.burnTokenizedPosition(
-            tokenId,
-            uint128(positionSizeBurn),
-            TickMath.MIN_TICK,
-            TickMath.MAX_TICK
         );
     }
 
@@ -3716,6 +3586,196 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
         assertApproxEqAbs(premium0Short, premium0ShortOld, premiaError0[0]);
         assertApproxEqAbs(premium1Short, premium1ShortOld, premiaError1[0]);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               REENTRANCY
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Fail_mintTokenizedPosition_ReentrancyLock(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        // replace the Uniswap pool with a mock contract that can answer some queries correctly,
+        // but will attempt to callback with mintTokenizedPosition on any other call
+        vm.etch(address(pool), address(new ReenterMint()).code);
+
+        ReenterMint(address(pool)).construct(
+            ReenterMint.Slot0(
+                TickMath.getSqrtRatioAtTick(currentTick),
+                currentTick,
+                0,
+                0,
+                0,
+                0,
+                true
+            ),
+            address(token0),
+            address(token1),
+            fee,
+            tickSpacing
+        );
+
+        vm.expectRevert(Errors.ReentrantCall.selector);
+
+        sfpm.mintTokenizedPosition(
+            tokenId,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+    }
+
+    // make sure reentrancy lock state is persisted through pool init
+    function test_Fail_mintTokenizedPosition_ReentrancyLock_Uninitialized(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        // replace the Uniswap pool with a mock contract that can answer some queries correctly,
+        // but will attempt to callback with mintTokenizedPosition on any other call
+        vm.etch(address(pool), address(new ReenterInitialize()).code);
+
+        ReenterInitialize(address(pool)).construct(
+            ReenterInitialize.Slot0(
+                TickMath.getSqrtRatioAtTick(currentTick),
+                currentTick,
+                0,
+                0,
+                0,
+                0,
+                true
+            ),
+            address(token0),
+            address(token1),
+            fee,
+            tickSpacing
+        );
+
+        vm.expectRevert(Errors.ReentrantCall.selector);
+
+        sfpm.mintTokenizedPosition(
+            tokenId,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+    }
+
+    function test_Fail_burnTokenizedPosition_ReentrancyLock(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed,
+        uint256 positionSizeBurnSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed, positionSizeBurnSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        sfpm.mintTokenizedPosition(
+            tokenId,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        // replace the Uniswap pool with a mock that responds correctly to queries but calls back on
+        // any other operations
+        vm.etch(address(pool), address(new ReenterBurn()).code);
+
+        ReenterBurn(address(pool)).construct(
+            ReenterBurn.Slot0(
+                TickMath.getSqrtRatioAtTick(currentTick),
+                currentTick,
+                0,
+                0,
+                0,
+                0,
+                true
+            ),
+            address(token0),
+            address(token1),
+            fee,
+            tickSpacing
+        );
+
+        vm.expectRevert(Errors.ReentrantCall.selector);
+
+        sfpm.burnTokenizedPosition(
+            tokenId,
+            uint128(positionSizeBurn),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/testUtils/ReentrancyMocks.sol
+++ b/test/foundry/testUtils/ReentrancyMocks.sol
@@ -54,7 +54,7 @@ contract ReenterBurn {
     }
 
     fallback() external {
-        if (activated)
+        if (!activated)
             SemiFungiblePositionManagerHarness(msg.sender).burnTokenizedPosition(
                 uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
                 0,
@@ -112,7 +112,7 @@ contract ReenterMint {
     }
 
     fallback() external {
-        if (activated)
+        if (!activated)
             SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
     }
 }
@@ -164,9 +164,9 @@ contract ReenterInitialize {
     }
 
     fallback() external {
-        if (activated)
+        if (!activated)
             SemiFungiblePositionManagerHarness(msg.sender).initializeAMMPool(token0, token1, fee);
-        if (activated)
+        if (!activated)
             SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
     }
 }

--- a/test/foundry/testUtils/ReentrancyMocks.sol
+++ b/test/foundry/testUtils/ReentrancyMocks.sol
@@ -37,6 +37,8 @@ contract ReenterBurn {
     address public token1;
     uint24 public fee;
 
+    bool activated;
+
     function construct(
         Slot0 memory _slot0,
         address _token0,
@@ -52,12 +54,14 @@ contract ReenterBurn {
     }
 
     fallback() external {
-        SemiFungiblePositionManagerHarness(msg.sender).burnTokenizedPosition(
-            uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
-            0,
-            0,
-            0
-        );
+        if (activated)
+            SemiFungiblePositionManagerHarness(msg.sender).burnTokenizedPosition(
+                uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
+                0,
+                0,
+                0
+            );
+        activated = true;
     }
 }
 
@@ -91,6 +95,8 @@ contract ReenterMint {
     address public token1;
     uint24 public fee;
 
+    bool activated;
+
     function construct(
         Slot0 memory _slot0,
         address _token0,
@@ -106,6 +112,61 @@ contract ReenterMint {
     }
 
     fallback() external {
-        SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
+        if (activated)
+            SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
+    }
+}
+
+contract ReenterInitialize {
+    // ensure storage conflicts don't occur with etched contract
+    uint256[65535] private __gap;
+
+    struct Slot0 {
+        // the current price
+        uint160 sqrtPriceX96;
+        // the current tick
+        int24 tick;
+        // the most-recently updated index of the observations array
+        uint16 observationIndex;
+        // the current maximum number of observations that are being stored
+        uint16 observationCardinality;
+        // the next maximum number of observations to store, triggered in observations.write
+        uint16 observationCardinalityNext;
+        // the current protocol fee as a percentage of the swap fee taken on withdrawal
+        // represented as an integer denominator (1/x)%
+        uint8 feeProtocol;
+        // whether the pool is locked
+        bool unlocked;
+    }
+
+    Slot0 public slot0;
+
+    int24 public tickSpacing;
+
+    address public token0;
+    address public token1;
+    uint24 public fee;
+
+    bool activated;
+
+    function construct(
+        Slot0 memory _slot0,
+        address _token0,
+        address _token1,
+        uint24 _fee,
+        int24 _tickSpacing
+    ) public {
+        slot0 = _slot0;
+        token0 = _token0;
+        token1 = _token1;
+        fee = _fee;
+        tickSpacing = _tickSpacing;
+    }
+
+    fallback() external {
+        if (activated)
+            SemiFungiblePositionManagerHarness(msg.sender).initializeAMMPool(token0, token1, fee);
+        if (activated)
+            SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
     }
 }

--- a/test/foundry/testUtils/ReentrancyMocks.sol
+++ b/test/foundry/testUtils/ReentrancyMocks.sol
@@ -67,6 +67,8 @@ contract ReenterBurn {
 }
 
 contract ReenterMint {
+    using TokenId for uint256;
+
     // ensure storage conflicts don't occur with etched contract
     uint256[65535] private __gap;
 
@@ -117,7 +119,12 @@ contract ReenterMint {
         activated = true;
 
         if (reenter)
-            SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
+            SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(
+                uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
+                0,
+                0,
+                0
+            );
     }
 }
 

--- a/test/foundry/testUtils/ReentrancyMocks.sol
+++ b/test/foundry/testUtils/ReentrancyMocks.sol
@@ -54,14 +54,15 @@ contract ReenterBurn {
     }
 
     fallback() external {
-        if (!activated)
+        bool reenter = !activated;
+        activated = true;
+        if (reenter)
             SemiFungiblePositionManagerHarness(msg.sender).burnTokenizedPosition(
                 uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
                 0,
                 0,
                 0
             );
-        activated = true;
     }
 }
 
@@ -112,61 +113,44 @@ contract ReenterMint {
     }
 
     fallback() external {
-        if (!activated)
+        bool reenter = !activated;
+        activated = true;
+
+        if (reenter)
             SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
     }
 }
 
-contract ReenterInitialize {
-    // ensure storage conflicts don't occur with etched contract
-    uint256[65535] private __gap;
-
-    struct Slot0 {
-        // the current price
-        uint160 sqrtPriceX96;
-        // the current tick
-        int24 tick;
-        // the most-recently updated index of the observations array
-        uint16 observationIndex;
-        // the current maximum number of observations that are being stored
-        uint16 observationCardinality;
-        // the next maximum number of observations to store, triggered in observations.write
-        uint16 observationCardinalityNext;
-        // the current protocol fee as a percentage of the swap fee taken on withdrawal
-        // represented as an integer denominator (1/x)%
-        uint8 feeProtocol;
-        // whether the pool is locked
-        bool unlocked;
-    }
-
-    Slot0 public slot0;
-
-    int24 public tickSpacing;
-
+// through ERC1155 transfer
+contract Reenter1155Initialize {
     address public token0;
     address public token1;
     uint24 public fee;
+    uint64 poolId;
 
     bool activated;
 
-    function construct(
-        Slot0 memory _slot0,
-        address _token0,
-        address _token1,
-        uint24 _fee,
-        int24 _tickSpacing
-    ) public {
-        slot0 = _slot0;
+    function construct(address _token0, address _token1, uint24 _fee, uint64 _poolId) public {
         token0 = _token0;
         token1 = _token1;
         fee = _fee;
-        tickSpacing = _tickSpacing;
+        poolId = _poolId;
     }
 
-    fallback() external {
-        if (!activated)
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes memory
+    ) public returns (bytes4) {
+        bool reenter = !activated;
+        activated = true;
+
+        if (reenter)
             SemiFungiblePositionManagerHarness(msg.sender).initializeAMMPool(token0, token1, fee);
-        if (!activated)
-            SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(0, 0, 0, 0);
+        if (reenter)
+            SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(poolId, 0, 0, 0);
+        return this.onERC1155Received.selector;
     }
 }


### PR DESCRIPTION
It's possible to reenter an uninitialized SFPM pool by initializing it during a reentrant call because the lock is reset. To fix this, we just persist the lock state through initialization.