### PR TITLE
fix: add reentrancy checks to SFPM transfer functions

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -537,37 +537,58 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                     TRANSFER HOOK IMPLEMENTATIONS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice called after batch transfers (NOT mints or burns)
-    /// @param from The address of the sender
-    /// @param to The address of the recipient
-    /// @param ids The tokenIds being transferred
-    /// @param amounts The amounts of each token being transferred
-    function afterTokenTransfer(
+    /// @notice Transfer a single token from one user to another
+    /// @dev supports token approvals
+    /// @param from the user to transfer tokens from
+    /// @param to the user to transfer tokens to
+    /// @param id the ERC1155 token id to transfer
+    /// @param amount the amount of tokens to transfer
+    /// @param data optional data to include in the receive hook
+    function safeTransferFrom(
         address from,
         address to,
-        uint256[] memory ids,
-        uint256[] memory amounts
-    ) internal override {
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) public override {
+        // we don't need to reentrancy lock on transfers, but we can't allow transfers for a pool during mint/burn with a reentrant call
+        // so just check if there is an active reentrancy lock for the relevant pool on the token we're transferring
+        if (s_poolContext[id.univ3pool()].locked) revert Errors.ReentrantCall();
+
+        // update the position data
+        registerTokenTransfer(from, to, id, amount);
+
+        // transfer the token (note that all state updates are completed before reentrancy is possible through onReceived callbacks)
+        super.safeTransferFrom(from, to, id, amount, data);
+    }
+
+    /// @notice Transfer multiple tokens from one user to another
+    /// @dev supports token approvals
+    /// @dev ids and amounts must be of equal length
+    /// @param from the user to transfer tokens from
+    /// @param to the user to transfer tokens to
+    /// @param ids the ERC1155 token ids to transfer
+    /// @param amounts the amounts of tokens to transfer
+    /// @param data optional data to include in the receive hook
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) public override {
+        // we don't need to reentrancy lock on transfers, but we can't allow transfers for a pool during mint/burn with a reentrant call
+        // so just check if there is an active reentrancy lock for the relevant pool on each token
         for (uint256 i = 0; i < ids.length; ) {
+            if (s_poolContext[ids[i].univ3pool()].locked) revert Errors.ReentrantCall();
             registerTokenTransfer(from, to, ids[i], amounts[i]);
             unchecked {
                 ++i;
             }
         }
-    }
 
-    /// @notice called after single transfers (NOT mints or burns)
-    /// @param from The address of the sender
-    /// @param to The address of the recipient
-    /// @param id The tokenId being transferred
-    /// @param amount The amount of the token being transferred
-    function afterTokenTransfer(
-        address from,
-        address to,
-        uint256 id,
-        uint256 amount
-    ) internal override {
-        registerTokenTransfer(from, to, id, amount);
+        // transfer the token (note that all state updates are completed before reentrancy is possible)
+        super.safeBatchTransferFrom(from, to, ids, amounts, data);
     }
 
     /// @notice update user position data following a token transfer

--- a/contracts/tokens/ERC1155Minimal.sol
+++ b/contracts/tokens/ERC1155Minimal.sol
@@ -93,7 +93,7 @@ abstract contract ERC1155 {
         uint256 id,
         uint256 amount,
         bytes calldata data
-    ) public {
+    ) public virtual {
         if (!(msg.sender == from || isApprovedForAll[from][msg.sender])) revert NotAuthorized();
 
         balanceOf[from][id] -= amount;
@@ -102,8 +102,6 @@ abstract contract ERC1155 {
         unchecked {
             balanceOf[to][id] += amount;
         }
-
-        afterTokenTransfer(from, to, id, amount);
 
         emit TransferSingle(msg.sender, from, to, id, amount);
 
@@ -155,8 +153,6 @@ abstract contract ERC1155 {
                 ++i;
             }
         }
-
-        afterTokenTransfer(from, to, ids, amounts);
 
         emit TransferBatch(msg.sender, from, to, ids, amounts);
 
@@ -238,34 +234,4 @@ abstract contract ERC1155 {
 
         emit TransferSingle(msg.sender, from, address(0), id, amount);
     }
-
-    /*//////////////////////////////////////////////////////////////
-                            TRANSFER HOOKS
-    //////////////////////////////////////////////////////////////*/
-
-    /// @notice Internal hook to be called after a batch token transfer
-    /// @dev this can be implemented in a child contract to add additional logic
-    /// @param from the user to transfer tokens from
-    /// @param to the user to transfer tokens to
-    /// @param ids the ERC1155 token ids being transferred
-    /// @param amounts the amounts of tokens to transfer
-    function afterTokenTransfer(
-        address from,
-        address to,
-        uint256[] memory ids,
-        uint256[] memory amounts
-    ) internal virtual;
-
-    /// @notice Internal hook to be called after a single token transfer
-    /// @dev this can be implemented in a child contract to add additional logic
-    /// @param from the user to transfer tokens from
-    /// @param to the user to transfer tokens to
-    /// @param id the ERC1155 token id being transferred
-    /// @param amount the amount of tokens to transfer
-    function afterTokenTransfer(
-        address from,
-        address to,
-        uint256 id,
-        uint256 amount
-    ) internal virtual;
 }

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -25,7 +25,7 @@ import {PanopticHelper} from "@periphery/PanopticHelper.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {PositionUtils} from "../testUtils/PositionUtils.sol";
 import {UniPoolPriceMock} from "../testUtils/PriceMocks.sol";
-import {ReenterMint, ReenterBurn, Reenter1155Initialize} from "../testUtils/ReentrancyMocks.sol";
+import {ReenterMint, ReenterBurn, Reenter1155Initialize, ReenterTransferSingle, ReenterTransferBatch} from "../testUtils/ReentrancyMocks.sol";
 
 contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
     constructor(IUniswapV3Factory _factory) SemiFungiblePositionManager(_factory) {}
@@ -3627,6 +3627,126 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         ReenterMint(address(pool)).construct(
             ReenterMint.Slot0(
+                TickMath.getSqrtRatioAtTick(currentTick),
+                currentTick,
+                0,
+                0,
+                0,
+                0,
+                true
+            ),
+            address(token0),
+            address(token1),
+            fee,
+            tickSpacing
+        );
+
+        vm.expectRevert(Errors.ReentrantCall.selector);
+
+        sfpm.mintTokenizedPosition(
+            tokenId,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+    }
+
+    // make sure single transfers check reentrancy lock state
+    function test_Fail_TransferSingle_ReentrancyLock(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        // replace the Uniswap pool with a mock contract that can answer some queries correctly,
+        // but will attempt to callback with mintTokenizedPosition on any other call
+        vm.etch(address(pool), address(new ReenterTransferSingle()).code);
+
+        ReenterTransferSingle(address(pool)).construct(
+            ReenterTransferSingle.Slot0(
+                TickMath.getSqrtRatioAtTick(currentTick),
+                currentTick,
+                0,
+                0,
+                0,
+                0,
+                true
+            ),
+            address(token0),
+            address(token1),
+            fee,
+            tickSpacing
+        );
+
+        vm.expectRevert(Errors.ReentrantCall.selector);
+
+        sfpm.mintTokenizedPosition(
+            tokenId,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+    }
+
+    // make sure batch transfers check reentrancy lock state
+    function test_Fail_TransferBatch_ReentrancyLock(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        // replace the Uniswap pool with a mock contract that can answer some queries correctly,
+        // but will attempt to callback with mintTokenizedPosition on any other call
+        vm.etch(address(pool), address(new ReenterTransferBatch()).code);
+
+        ReenterTransferBatch(address(pool)).construct(
+            ReenterTransferBatch.Slot0(
                 TickMath.getSqrtRatioAtTick(currentTick),
                 currentTick,
                 0,

--- a/test/foundry/testUtils/ReentrancyMocks.sol
+++ b/test/foundry/testUtils/ReentrancyMocks.sol
@@ -128,6 +128,134 @@ contract ReenterMint {
     }
 }
 
+contract ReenterTransferSingle {
+    using TokenId for uint256;
+
+    // ensure storage conflicts don't occur with etched contract
+    uint256[65535] private __gap;
+
+    struct Slot0 {
+        // the current price
+        uint160 sqrtPriceX96;
+        // the current tick
+        int24 tick;
+        // the most-recently updated index of the observations array
+        uint16 observationIndex;
+        // the current maximum number of observations that are being stored
+        uint16 observationCardinality;
+        // the next maximum number of observations to store, triggered in observations.write
+        uint16 observationCardinalityNext;
+        // the current protocol fee as a percentage of the swap fee taken on withdrawal
+        // represented as an integer denominator (1/x)%
+        uint8 feeProtocol;
+        // whether the pool is locked
+        bool unlocked;
+    }
+
+    Slot0 public slot0;
+
+    int24 public tickSpacing;
+
+    address public token0;
+    address public token1;
+    uint24 public fee;
+
+    bool activated;
+
+    function construct(
+        Slot0 memory _slot0,
+        address _token0,
+        address _token1,
+        uint24 _fee,
+        int24 _tickSpacing
+    ) public {
+        slot0 = _slot0;
+        token0 = _token0;
+        token1 = _token1;
+        fee = _fee;
+        tickSpacing = _tickSpacing;
+    }
+
+    fallback() external {
+        bool reenter = !activated;
+        activated = true;
+
+        if (reenter)
+            SemiFungiblePositionManagerHarness(msg.sender).safeTransferFrom(
+                address(0),
+                address(0),
+                uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
+                0,
+                ""
+            );
+    }
+}
+
+contract ReenterTransferBatch {
+    using TokenId for uint256;
+
+    // ensure storage conflicts don't occur with etched contract
+    uint256[65535] private __gap;
+
+    struct Slot0 {
+        // the current price
+        uint160 sqrtPriceX96;
+        // the current tick
+        int24 tick;
+        // the most-recently updated index of the observations array
+        uint16 observationIndex;
+        // the current maximum number of observations that are being stored
+        uint16 observationCardinality;
+        // the next maximum number of observations to store, triggered in observations.write
+        uint16 observationCardinalityNext;
+        // the current protocol fee as a percentage of the swap fee taken on withdrawal
+        // represented as an integer denominator (1/x)%
+        uint8 feeProtocol;
+        // whether the pool is locked
+        bool unlocked;
+    }
+
+    Slot0 public slot0;
+
+    int24 public tickSpacing;
+
+    address public token0;
+    address public token1;
+    uint24 public fee;
+
+    bool activated;
+
+    function construct(
+        Slot0 memory _slot0,
+        address _token0,
+        address _token1,
+        uint24 _fee,
+        int24 _tickSpacing
+    ) public {
+        slot0 = _slot0;
+        token0 = _token0;
+        token1 = _token1;
+        fee = _fee;
+        tickSpacing = _tickSpacing;
+    }
+
+    fallback() external {
+        bool reenter = !activated;
+        activated = true;
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this)));
+        if (reenter)
+            SemiFungiblePositionManagerHarness(msg.sender).safeBatchTransferFrom(
+                address(0),
+                address(0),
+                ids,
+                new uint256[](1),
+                ""
+            );
+    }
+}
+
 // through ERC1155 transfer
 contract Reenter1155Initialize {
     address public token0;

--- a/test/foundry/tokens/ERC1155Minimal.t.sol
+++ b/test/foundry/tokens/ERC1155Minimal.t.sol
@@ -13,20 +13,6 @@ contract ERC1155MinimalHarness is ERC1155 {
     function mint(address account, uint256 id, uint256 amount) public {
         _mint(account, id, amount);
     }
-
-    function afterTokenTransfer(
-        address from,
-        address to,
-        uint256[] memory ids,
-        uint256[] memory amounts
-    ) internal virtual override {}
-
-    function afterTokenTransfer(
-        address from,
-        address to,
-        uint256 id,
-        uint256 amount
-    ) internal virtual override {}
 }
 
 contract ERC1155Minimal is Test {


### PR DESCRIPTION
The SFPM transfers allow transferring tokens of reentrancy locked pools right now, which can create issues with ERC777 tokens that can make reentrant calls to transfer tokens before the fee growth accumulators are updated. If the fee growth is transferred to another account prematurely, that account will potentially be able to collect more fees than they are due since the differences between the current and stored fee growths will be incorrect.