### PR TITLE
feat: improve precision on `convert` functions

### DIFF
--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -331,7 +331,7 @@ library PanopticMath {
         unchecked {
             // the tick 443636 is the maximum price where (price) * 2**192 fits into a uint256 (< 2**256-1)
             // above that tick, we are forced to reduce the amount of decimals in the final price by 2**64 to 2**128
-            if (sqrtPriceX96 < 340275971719517849884101479065584693834) {
+            if (sqrtPriceX96 < type(uint128).max) {
                 return Math.mulDiv192(amount, uint256(sqrtPriceX96) ** 2);
             } else {
                 return Math.mulDiv128(amount, Math.mulDiv64(sqrtPriceX96, sqrtPriceX96));
@@ -348,7 +348,7 @@ library PanopticMath {
         unchecked {
             // the tick 443636 is the maximum price where (price) * 2**192 fits into a uint256 (< 2**256-1)
             // above that tick, we are forced to reduce the amount of decimals in the final price by 2**64 to 2**128
-            if (sqrtPriceX96 < 340275971719517849884101479065584693834) {
+            if (sqrtPriceX96 < type(uint128).max) {
                 return Math.mulDiv(amount, 2 ** 192, uint256(sqrtPriceX96) ** 2);
             } else {
                 return Math.mulDiv(amount, 2 ** 128, Math.mulDiv64(sqrtPriceX96, sqrtPriceX96));
@@ -365,7 +365,7 @@ library PanopticMath {
         unchecked {
             // the tick 443636 is the maximum price where (price) * 2**192 fits into a uint256 (< 2**256-1)
             // above that tick, we are forced to reduce the amount of decimals in the final price by 2**64 to 2**128
-            if (sqrtPriceX96 < 340275971719517849884101479065584693834) {
+            if (sqrtPriceX96 < type(uint128).max) {
                 int256 absResult = Math
                     .mulDiv192(Math.absUint(amount), uint256(sqrtPriceX96) ** 2)
                     .toInt256();
@@ -388,7 +388,7 @@ library PanopticMath {
         unchecked {
             // the tick 443636 is the maximum price where (price) * 2**192 fits into a uint256 (< 2**256-1)
             // above that tick, we are forced to reduce the amount of decimals in the final price by 2**64 to 2**128
-            if (sqrtPriceX96 < 340275971719517849884101479065584693834) {
+            if (sqrtPriceX96 < type(uint128).max) {
                 int256 absResult = Math
                     .mulDiv(Math.absUint(amount), 2 ** 192, uint256(sqrtPriceX96) ** 2)
                     .toInt256();

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -543,7 +543,7 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         // make sure nothing overflows
-        if (sqrtRatio < 340275971719517849884101479065584693834) {
+        if (sqrtRatio < type(uint128).max) {
             uint256 priceX192 = uint256(sqrtRatio) ** 2;
 
             unchecked {
@@ -583,7 +583,7 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         // make sure nothing overflows
-        if (sqrtRatio < 340275971719517849884101479065584693834) {
+        if (sqrtRatio < type(uint128).max) {
             uint256 priceX192 = uint256(sqrtRatio) ** 2;
 
             unchecked {
@@ -624,7 +624,7 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         // make sure nothing overflows
-        if (sqrtRatio < 340275971719517849884101479065584693834) {
+        if (sqrtRatio < type(uint128).max) {
             uint256 priceX192 = uint256(sqrtRatio) ** 2;
 
             unchecked {
@@ -664,7 +664,7 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         // make sure nothing overflows
-        if (sqrtRatio < 340275971719517849884101479065584693834) {
+        if (sqrtRatio < type(uint128).max) {
             uint256 priceX192 = uint256(sqrtRatio) ** 2;
 
             unchecked {
@@ -695,7 +695,7 @@ contract PanopticMathTest is Test, PositionUtils {
     function test_Success_convert0to1_PriceX192_Uint(uint256 amount, uint256 sqrtPriceSeed) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, TickMath.MIN_SQRT_RATIO, 340275971719517849884101479065584693833)
+            bound(sqrtPriceSeed, TickMath.MIN_SQRT_RATIO, type(uint128).max)
         );
 
         uint256 priceX192 = uint256(sqrtPrice) ** 2;
@@ -719,7 +719,7 @@ contract PanopticMathTest is Test, PositionUtils {
     ) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, TickMath.MIN_SQRT_RATIO, 340275971719517849884101479065584693833)
+            bound(sqrtPriceSeed, TickMath.MIN_SQRT_RATIO, type(uint128).max)
         );
 
         uint256 priceX192 = uint256(sqrtPrice) ** 2;
@@ -926,7 +926,7 @@ contract PanopticMathTest is Test, PositionUtils {
     function test_Success_convert0to1_PriceX128_Uint(uint256 amount, uint256 sqrtPriceSeed) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, 340275971719517849884101479065584693834, TickMath.MAX_SQRT_RATIO)
+            bound(sqrtPriceSeed, type(uint128).max, TickMath.MAX_SQRT_RATIO)
         );
 
         uint256 priceX128 = FullMath.mulDiv(sqrtPrice, sqrtPrice, 2 ** 64);
@@ -950,7 +950,7 @@ contract PanopticMathTest is Test, PositionUtils {
     ) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, 340275971719517849884101479065584693834, TickMath.MAX_SQRT_RATIO)
+            bound(sqrtPriceSeed, type(uint128).max, TickMath.MAX_SQRT_RATIO)
         );
 
         uint256 priceX128 = FullMath.mulDiv(sqrtPrice, sqrtPrice, 2 ** 64);
@@ -969,7 +969,7 @@ contract PanopticMathTest is Test, PositionUtils {
     function test_Success_convert0to1_PriceX128_Int(int256 amount, uint256 sqrtPriceSeed) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, 340275971719517849884101479065584693834, TickMath.MAX_SQRT_RATIO)
+            bound(sqrtPriceSeed, type(uint128).max, TickMath.MAX_SQRT_RATIO)
         );
 
         uint256 priceX128 = FullMath.mulDiv(sqrtPrice, sqrtPrice, 2 ** 64);
@@ -996,7 +996,7 @@ contract PanopticMathTest is Test, PositionUtils {
     ) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, 340275971719517849884101479065584693834, TickMath.MAX_SQRT_RATIO)
+            bound(sqrtPriceSeed, type(uint128).max, TickMath.MAX_SQRT_RATIO)
         );
 
         uint256 priceX128 = FullMath.mulDiv(sqrtPrice, sqrtPrice, 2 ** 64);
@@ -1020,7 +1020,7 @@ contract PanopticMathTest is Test, PositionUtils {
     ) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, 340275971719517849884101479065584693834, TickMath.MAX_SQRT_RATIO)
+            bound(sqrtPriceSeed, type(uint128).max, TickMath.MAX_SQRT_RATIO)
         );
 
         uint256 priceX128 = FullMath.mulDiv(sqrtPrice, sqrtPrice, 2 ** 64);
@@ -1042,7 +1042,7 @@ contract PanopticMathTest is Test, PositionUtils {
     function test_Success_convert1to0_PriceX128_Uint(uint256 amount, uint256 sqrtPriceSeed) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, 340275971719517849884101479065584693834, TickMath.MAX_SQRT_RATIO)
+            bound(sqrtPriceSeed, type(uint128).max, TickMath.MAX_SQRT_RATIO)
         );
 
         uint256 priceX128 = FullMath.mulDiv(sqrtPrice, sqrtPrice, 2 ** 64);
@@ -1063,7 +1063,7 @@ contract PanopticMathTest is Test, PositionUtils {
     function test_Success_convert1to0_PriceX128_Int(int256 amount, uint256 sqrtPriceSeed) public {
         // above this tick we use 128-bit precision because of overflow issues
         uint160 sqrtPrice = uint160(
-            bound(sqrtPriceSeed, 340275971719517849884101479065584693834, TickMath.MAX_SQRT_RATIO)
+            bound(sqrtPriceSeed, type(uint128).max, TickMath.MAX_SQRT_RATIO)
         );
 
         uint256 priceX128 = FullMath.mulDiv(sqrtPrice, sqrtPrice, 2 ** 64);


### PR DESCRIPTION
We use the sqrtPriceX128 at the maximum possible tick value, 443636, to decide where to drop the precision by 64 bits, but the price can actually go all the way to 2^128-1. This means we're leaving some free precision on the table between 443636 and 443637, so this PR is to bump up the transition point to 2^128-1 (same as Uniswap's equivalent in the Quoter library)