### PR TITLE
fix: prevent overflows of removedLiquidity

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -958,8 +958,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         uint128 updatedLiquidity;
         uint256 isLong = TokenId.isLong(_tokenId, _leg);
         uint256 currentLiquidity = s_accountLiquidity[positionKey]; //cache
-
-        unchecked {
+        {
             // did we have liquidity already deployed in Uniswap for this chunk range from some past mint?
 
             // s_accountLiquidity is a LeftRight. The right slot represents the liquidity currently sold (added) in the AMM owned by the user
@@ -990,14 +989,20 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                     // so we revert in this case
                     revert Errors.NotEnoughLiquidity();
                 } else {
-                    // we want to move less than what already sits in uniswap, no problem:
-                    updatedLiquidity = startingLiquidity - chunkLiquidity;
+                    // startingLiquidity is >= chunkLiquidity, so no possible underflow
+                    unchecked {
+                        // we want to move less than what already sits in uniswap, no problem:
+                        updatedLiquidity = startingLiquidity - chunkLiquidity;
+                    }
                 }
 
                 /// @dev If the isLong flag is 1=long and the position is minted, then this is opening a long position
                 /// @dev so the amount of short liquidity should increase.
                 if (!_isBurn) {
-                    removedLiquidity += chunkLiquidity;
+                    // we can't remove more liquidity than we add in the first place, so this can't overflow
+                    unchecked {
+                        removedLiquidity += chunkLiquidity;
+                    }
                 }
             }
 

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -3776,4 +3776,51 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             d1 = -(swapAmount > 0 ? swapAmount : (-swapAmount * price) / 10 ** 6);
         }
     }
+
+    function test_Fail_RemovedLiquidity_Overflow() public {
+        _initPool(0);
+
+        // need a super wide position to exxagerate position size units
+        _cacheWorldState(USDC_WETH_30);
+        sfpm.initializeAMMPool(token0, token1, fee);
+
+        int24 width = 4090;
+        int24 strike = 0;
+        populatePositionData(width, strike, 0, 0);
+
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        sfpm.mintTokenizedPosition(
+            tokenId,
+            uint128(1_000_000),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
+
+        for (uint256 i = 0; i < 10; i++) {
+            sfpm.mintTokenizedPosition(tokenId, uint128(922), TickMath.MIN_TICK, TickMath.MAX_TICK);
+
+            sfpm.burnTokenizedPosition(tokenId, uint128(462), TickMath.MIN_TICK, TickMath.MAX_TICK);
+        }
+
+        vm.expectRevert();
+        sfpm.burnTokenizedPosition(
+            tokenId,
+            uint128(10 * (922 - 462)),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+    }
 }


### PR DESCRIPTION
removedLiquidity can be overflowed by accumulating tokens corresponding to a greater amount of liquidity than what was initially removed. For some liquidity chunks, 1 unit of positionSize corresponds to <1 unit of liquidity, so the liquidity returned can be greater than the liquidity removed if that accumulated fractional liquidity adds up to 1 or more.