### PR TITLE
test: use older block number because Circle broke our tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -11,7 +11,7 @@ viaIR = false
 eth_rpc_url = "https://eth-mainnet.g.alchemy.com/v2/vevMezCXoFshwV190wQcekYwQflctBeE"
 
 [profile.ci_test]
-fork_block_number = 17237181
+fork_block_number = 18963715
 
 [profile.ci_sizes]
 optimizer_runs = 18_000

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,7 +10,7 @@ optimizer_runs = 18_000
 viaIR = false
 eth_rpc_url = "https://eth-mainnet.g.alchemy.com/v2/vevMezCXoFshwV190wQcekYwQflctBeE"
 
-[profile.test]
+[profile.ci_test]
 fork_block_number = 17237181
 
 [profile.ci_sizes]


### PR DESCRIPTION
Circle upgraded the USDC implementation on its proxy for the first time in 3 years a bit ago (https://etherscan.io/tx/0xae3ad89e569f27d47a8a02999a6d937c12aaa6bc50e66650e7cbd3244bde9951)
which broke the storage slot finder that we use to find the balance slot for a user in order to grant them tokens (`deal`).
Not 100% sure what the problem is with the new contract, but for now we need to fall back to an old block number with the old implementation. Having the latest block number is convenient, but it doesn't work right now :(