### PR TITLE
feat: use virtual shares for force exercises instead of delegation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           FOUNDRY_PROFILE: ci_test
         run: |
-          forge test --fork-url http://localhost:8545 -vvv --fuzz-runs 1000
+          forge test --fork-url http://localhost:8545 -vvv --fuzz-runs 1000 --match-test test_Success_forceExercise
         id: forge-test
 
   contract_sizes:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           FOUNDRY_PROFILE: ci_test
         run: |
-          forge test --fork-url http://localhost:8545 -vvv --fuzz-runs 1000 --match-test test_Success_forceExercise
+          forge test --fork-url http://localhost:8545 -vvv --fuzz-runs 1000
         id: forge-test
 
   contract_sizes:

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1016,6 +1016,23 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         _transferFrom(delegator, delegatee, shares);
     }
 
+    /// @notice Delegate and transfer shares corresponding to the incoming assets from the protocol to `delegatee`.
+    /// @dev This is controlled by the Panoptic Pool - not individual users.
+    /// @param delegatee The delegatee to send shares to - the recipient of the shares.
+    /// @param assets The assets to which the shares delegated correspond.
+    function delegate(address delegatee, uint256 assets) external onlyPanopticPool {
+        balanceOf[delegatee] += convertToShares(assets);
+    }
+
+    /// @notice Refunds delegated tokens back to the protocol
+    /// @dev Assumes that `delegatee` has enough money to pay for the refund
+    /// @param delegatee The account refunding tokens to 'delegatee'.
+    /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative.
+    function refund(address delegatee, uint256 assets) external onlyPanopticPool {
+        // round up in favor of the protocol
+        balanceOf[delegatee] -= Math.mulDivRoundingUp(assets, totalSupply, totalAssets());
+    }
+
     /// @notice Revoke previously delegated shares. The opposite of 'delegate'.
     /// @param delegator The delegator to send shares *to* (because we are revoking - opposite when we delegate).
     /// @param delegatee The delegatee to send shares *from* (because we are revoking - opposite when we delegate).
@@ -1079,7 +1096,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @dev Assumes that the refunder has enough money to pay for the refund
     /// @dev can handle negative refund amounts that go from refundee to refunder in the case of high exercise fees.
     /// @param refunder The account refunding tokens to 'refundee'.
-    /// @param refundee The amount being refunded to.
+    /// @param refundee The account being refunded to.
     /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative.
     function refund(address refunder, address refundee, int256 assets) external onlyPanopticPool {
         if (assets > 0) {

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1030,7 +1030,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative.
     function refund(address delegatee, uint256 assets) external onlyPanopticPool {
         // round up in favor of the protocol
-        balanceOf[delegatee] -= Math.mulDivRoundingUp(assets, totalSupply, totalAssets());
+        balanceOf[delegatee] -= convertToShares(assets);
     }
 
     /// @notice Revoke previously delegated shares. The opposite of 'delegate'.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1031,7 +1031,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param delegatee The account refunding tokens to 'delegatee'.
     /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative.
     function refund(address delegatee, uint256 assets) external onlyPanopticPool {
-        // round up in favor of the protocol
         balanceOf[delegatee] -= convertToShares(assets);
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1018,6 +1018,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Delegate and transfer shares corresponding to the incoming assets from the protocol to `delegatee`.
     /// @dev This is controlled by the Panoptic Pool - not individual users.
+    /// @dev mints virtual/temporary shares so a position can be settled - the total supply is not affected.
     /// @param delegatee The delegatee to send shares to - the recipient of the shares.
     /// @param assets The assets to which the shares delegated correspond.
     function delegate(address delegatee, uint256 assets) external onlyPanopticPool {
@@ -1026,6 +1027,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Refunds delegated tokens back to the protocol
     /// @dev Assumes that `delegatee` has enough money to pay for the refund
+    /// @dev burns virtual/temporary shares after a position has been settled - the total supply is not affected.
     /// @param delegatee The account refunding tokens to 'delegatee'.
     /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative.
     function refund(address delegatee, uint256 assets) external onlyPanopticPool {

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1029,7 +1029,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @dev Assumes that `delegatee` has enough money to pay for the refund
     /// @dev burns virtual/temporary shares after a position has been settled - the total supply is not affected.
     /// @param delegatee The account refunding tokens to 'delegatee'.
-    /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative.
+    /// @param assets The amount of assets to which the shares to refund to the protocol correspond.
     function refund(address delegatee, uint256 assets) external onlyPanopticPool {
         balanceOf[delegatee] -= convertToShares(assets);
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1129,12 +1129,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         s_collateralToken0.refund(
             account,
             msg.sender,
-            delegatedAmounts.rightSlot() - refundAmounts.rightSlot()
+            refundAmounts.rightSlot() - delegatedAmounts.rightSlot()
         );
         s_collateralToken1.refund(
             account,
             msg.sender,
-            delegatedAmounts.leftSlot() - refundAmounts.leftSlot()
+            refundAmounts.leftSlot() - delegatedAmounts.leftSlot()
         );
 
         // refund the protocol any virtual shares

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1117,7 +1117,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         s_collateralToken0.delegate(account, uint128(delegatedAmounts.rightSlot()));
         s_collateralToken1.delegate(account, uint128(delegatedAmounts.leftSlot()));
 
-        // Liquidate positions
+        // Exercise the option
         // Note: tick limits are not applied here since it is not the exercisor's position being liquidated
         _burnAllOptionsFrom(account, 0, 0, touchedId);
 
@@ -1126,6 +1126,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         refundAmounts = _getRefundAmounts(account, refundAmounts, twapTick);
 
+        // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
         s_collateralToken0.refund(
             account,
             msg.sender,
@@ -1137,7 +1138,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             refundAmounts.leftSlot() - delegatedAmounts.leftSlot()
         );
 
-        // refund the protocol any virtual shares
+        // refund the protocol any virtual shares after settling the difference with the exercisor
         s_collateralToken0.refund(account, uint128(delegatedAmounts.rightSlot()));
         s_collateralToken1.refund(account, uint128(delegatedAmounts.leftSlot()));
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1138,8 +1138,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         );
 
         // refund the protocol any virtual shares
-        s_collateralToken0.refund(msg.sender, uint128(delegatedAmounts.rightSlot()));
-        s_collateralToken1.refund(msg.sender, uint128(delegatedAmounts.leftSlot()));
+        s_collateralToken0.refund(account, uint128(delegatedAmounts.rightSlot()));
+        s_collateralToken1.refund(account, uint128(delegatedAmounts.leftSlot()));
 
         // update the current tick after any ITM swaps
         (, currentTick, , , , , ) = s_univ3pool.slot0();

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1113,11 +1113,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
             );
         }
 
-        // Liquidator must delegate the notional amount of tokens needed for exercising.
-        s_collateralToken0.delegate(msg.sender, account, uint128(delegatedAmounts.rightSlot()));
-        s_collateralToken1.delegate(msg.sender, account, uint128(delegatedAmounts.leftSlot()));
+        // The protocol delegates some virtual shares to ensure the burn can be settled.
+        s_collateralToken0.delegate(account, uint128(delegatedAmounts.rightSlot()));
+        s_collateralToken1.delegate(account, uint128(delegatedAmounts.leftSlot()));
 
-        // Rescue and liquidate positions
+        // Liquidate positions
         // Note: tick limits are not applied here since it is not the exercisor's position being liquidated
         _burnAllOptionsFrom(account, 0, 0, touchedId);
 
@@ -1126,8 +1126,20 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         refundAmounts = _getRefundAmounts(account, refundAmounts, twapTick);
 
-        s_collateralToken0.refund(account, msg.sender, refundAmounts.rightSlot());
-        s_collateralToken1.refund(account, msg.sender, refundAmounts.leftSlot());
+        s_collateralToken0.refund(
+            account,
+            msg.sender,
+            delegatedAmounts.rightSlot() - refundAmounts.rightSlot()
+        );
+        s_collateralToken1.refund(
+            account,
+            msg.sender,
+            delegatedAmounts.leftSlot() - refundAmounts.leftSlot()
+        );
+
+        // refund the protocol any virtual shares
+        s_collateralToken0.refund(msg.sender, uint128(delegatedAmounts.rightSlot()));
+        s_collateralToken1.refund(msg.sender, uint128(delegatedAmounts.leftSlot()));
 
         // update the current tick after any ITM swaps
         (, currentTick, , , , , ) = s_univ3pool.slot0();

--- a/contracts/tokens/ERC20Minimal.sol
+++ b/contracts/tokens/ERC20Minimal.sol
@@ -123,9 +123,9 @@ abstract contract ERC20Minimal {
         // Cannot overflow because the sum of all user
         // balances can't exceed the max uint256 value.
         unchecked {
-            totalSupply += amount;
             balanceOf[to] += amount;
         }
+        totalSupply += amount;
 
         emit Transfer(address(0), to, amount);
     }

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -194,6 +194,14 @@ contract PanopticPoolHarness is PanopticPool {
         collateralToken.delegate(delegator, delegatee, assets);
     }
 
+    function delegate(
+        address delegatee,
+        uint128 assets,
+        CollateralTracker collateralToken
+    ) external {
+        collateralToken.delegate(msg.sender, delegatee, assets);
+    }
+
     // mimics an internal Panoptic pool  revoke call onto the collateral tracker
     function revoke(
         address delegator,
@@ -202,6 +210,15 @@ contract PanopticPoolHarness is PanopticPool {
         CollateralTracker collateralToken
     ) external {
         collateralToken.revoke(delegator, delegatee, requestedAmount);
+    }
+
+    function refund(
+        address delegator,
+        address delegatee,
+        int256 requestedAmount,
+        CollateralTracker collateralToken
+    ) external {
+        collateralToken.refund(delegator, delegatee, requestedAmount);
     }
 
     function getTWAP() external returns (int24 twapTick) {
@@ -1319,7 +1336,48 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertApproxEqAbs(sharesBefore1, sharesAfter1, 5);
     }
 
-    // transfer from delgatee to delegator
+    function test_Success_delegate_virtual(uint256 x, uint104 assets) public {
+        // fuzz
+        _initWorld(x);
+
+        // Invoke all interactions with the Collateral Tracker from user Bob
+        vm.startPrank(Bob);
+
+        // give Bob the max amount of tokens
+        _grantTokens(Bob);
+
+        // approve collateral tracker to move tokens on Bob's behalf
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+
+        // deposit a number of assets determined via fuzzing
+        // equal deposits for both collateral token pairs for testing purposes
+        collateralToken0.deposit(assets, Bob);
+        collateralToken1.deposit(assets, Bob);
+
+        // check delegatee balance before
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
+
+        uint256 convertedShares = convertToShares(1_000_000_000, collateralToken0);
+
+        // invoke delegate transactions from the Panoptic pool
+        panopticPool.delegate(Alice, assets, collateralToken0);
+
+        panopticPool.delegate(Alice, assets, collateralToken1);
+
+        // check delegatee balance after
+        uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
+        uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
+
+        // make sure price stays the same
+        assertEq(convertedShares, convertToShares(1_000_000_000, collateralToken0));
+
+        assertApproxEqAbs(sharesBefore0, sharesAfter0, 5);
+        assertApproxEqAbs(sharesBefore1, sharesAfter1, 5);
+    }
+
+    // transfer from delegatee to delegator
     function test_Success_revoke(uint256 x, uint104 shares) public {
         {
             // fuzz

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1354,6 +1354,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // give Bob the max amount of tokens
         _grantTokens(Bob);
 
+        // approve collateral tracker to move tokens on Bob's behalf
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+
         // deposit a number of assets determined via fuzzing
         // equal deposits for both collateral token pairs for testing purposes
         collateralToken0.deposit(assets, Bob);
@@ -1404,7 +1408,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 type(uint104).max
             );
 
-            // approve collateral tracker to move tokens on Bob's behalf
+            // approve collateral tracker to move tokens on Alice's behalf
             IERC20Partial(token0).approve(address(collateralToken0), assetsToken0);
             IERC20Partial(token1).approve(address(collateralToken1), assetsToken1);
 
@@ -1512,6 +1516,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1,
                 type(uint104).max
             );
+            
+            // approve collateral tracker to move tokens on Alice's behalf
+            IERC20Partial(token0).approve(address(collateralToken0), assetsToken0);
+            IERC20Partial(token1).approve(address(collateralToken1), assetsToken1);
 
             // deposit a number of assets determined via fuzzing
             // equal deposits for both collateral token pairs for testing purposes
@@ -1577,8 +1585,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
 
         // invoke delegate transactions from the Panoptic pool
-        panopticPool.refund(Bob, Alice, int256(uint256(shares)), collateralToken0);
-        panopticPool.refund(Bob, Alice, int256(uint256(shares)), collateralToken1);
+        panopticPool.refund(Alice, Bob, int256(uint256(shares)), collateralToken0);
+        panopticPool.refund(Alice, Bob, int256(uint256(shares)), collateralToken1);
 
         // check delegatee balance after
         uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
@@ -1612,9 +1620,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
 
         // invoke delegate transactions from the Panoptic pool
-        panopticPool.refund(Bob, Alice, -int256(uint256(assets)), collateralToken0);
+        panopticPool.refund(Alice, Bob, -int256(uint256(assets)), collateralToken0);
 
-        panopticPool.refund(Bob, Alice, -int256(uint256(assets)), collateralToken1);
+        panopticPool.refund(Alice, Bob, -int256(uint256(assets)), collateralToken1);
 
         // check delegatee balance after
         uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
@@ -1625,7 +1633,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
     }
 
     // access control on delegate/revoke/settlement functions
-    function test_Fail_All_OnlyPanopticPool(address caller) public {
+    function test_Fail_All_OnlyPanopticPool(uint256 x, address caller) public {
+        _initWorld(x);
         vm.assume(caller != address(panopticPool));
 
         vm.prank(caller);

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -221,6 +221,14 @@ contract PanopticPoolHarness is PanopticPool {
         collateralToken.refund(delegator, delegatee, requestedAmount);
     }
 
+    function refund(
+        address delegatee,
+        uint256 requestedAmount,
+        CollateralTracker collateralToken
+    ) external {
+        collateralToken.refund(delegatee, requestedAmount);
+    }
+
     function getTWAP() external returns (int24 twapTick) {
         return PanopticPool.getUniV3TWAP();
     }
@@ -1346,16 +1354,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // give Bob the max amount of tokens
         _grantTokens(Bob);
 
-        // approve collateral tracker to move tokens on Bob's behalf
-        IERC20Partial(token0).approve(address(collateralToken0), assets);
-        IERC20Partial(token1).approve(address(collateralToken1), assets);
-
         // deposit a number of assets determined via fuzzing
         // equal deposits for both collateral token pairs for testing purposes
         collateralToken0.deposit(assets, Bob);
         collateralToken1.deposit(assets, Bob);
 
-        // check delegatee balance before
+        // get amount of shares being delegated
         uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
         uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
 
@@ -1370,7 +1374,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
         uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
 
-        // make sure price stays the same
+        // make sure share price stays the same
         assertEq(convertedShares, convertToShares(1_000_000_000, collateralToken0));
 
         assertApproxEqAbs(sharesBefore0, sharesAfter0, 5);
@@ -1485,6 +1489,167 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 assetsAfter0 = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
 
         assertApproxEqAbs(assetsBefore0, assetsAfter0, 5);
+    }
+
+    function test_Success_refund_virtual(uint256 x, uint104 shares) public {
+        {
+            // fuzz
+            _initWorld(x);
+
+            // Invoke all interactions with the Collateral Tracker from user Alice
+            vm.startPrank(Alice);
+
+            // give Bob the max amount of tokens
+            _grantTokens(Alice);
+
+            uint256 assetsToken0 = bound(
+                convertToAssets(shares, collateralToken0),
+                1,
+                type(uint104).max
+            );
+            uint256 assetsToken1 = bound(
+                convertToAssets(shares, collateralToken1),
+                1,
+                type(uint104).max
+            );
+
+            // deposit a number of assets determined via fuzzing
+            // equal deposits for both collateral token pairs for testing purposes
+            collateralToken0.deposit(uint128(assetsToken0), Alice);
+            collateralToken1.deposit(uint128(assetsToken1), Alice);
+        }
+
+        // check delegator balance before
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Alice);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Alice);
+
+        uint256 convertedShares = convertToShares(1_000_000_000, collateralToken0);
+
+        // invoke delegate transactions from the Panoptic pool
+        panopticPool.refund(Alice, shares, collateralToken0);
+        panopticPool.refund(Alice, shares, collateralToken1);
+
+        // make sure share price stays the same
+        assertEq(convertedShares, convertToShares(1_000_000_000, collateralToken0));
+
+        // check delegatee balance after
+        uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
+        uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
+
+        assertApproxEqAbs(sharesBefore0, sharesAfter0, 5);
+        assertApproxEqAbs(sharesBefore1, sharesAfter1, 5);
+    }
+
+    function test_success_refund_positive(uint256 x, uint104 shares) public {
+        {
+            // fuzz
+            _initWorld(x);
+
+            // Invoke all interactions with the Collateral Tracker from user Alice
+            vm.startPrank(Alice);
+
+            // give Bob the max amount of tokens
+            _grantTokens(Alice);
+
+            uint256 assetsToken0 = bound(
+                convertToAssets(shares, collateralToken0),
+                1,
+                type(uint104).max
+            );
+            uint256 assetsToken1 = bound(
+                convertToAssets(shares, collateralToken1),
+                1,
+                type(uint104).max
+            );
+
+            // approve collateral tracker to move tokens on Bob's behalf
+            IERC20Partial(token0).approve(address(collateralToken0), assetsToken0);
+            IERC20Partial(token1).approve(address(collateralToken1), assetsToken1);
+
+            // deposit a number of assets determined via fuzzing
+            // equal deposits for both collateral token pairs for testing purposes
+            collateralToken0.deposit(uint128(assetsToken0), Alice);
+            collateralToken1.deposit(uint128(assetsToken1), Alice);
+        }
+
+        // check delegator balance before
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
+
+        // invoke delegate transactions from the Panoptic pool
+        panopticPool.refund(Bob, Alice, int256(uint256(shares)), collateralToken0);
+        panopticPool.refund(Bob, Alice, int256(uint256(shares)), collateralToken1);
+
+        // check delegatee balance after
+        uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
+        uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
+
+        assertApproxEqAbs(sharesBefore0, sharesAfter0, 5);
+        assertApproxEqAbs(sharesBefore1, sharesAfter1, 5);
+    }
+
+    function test_success_refund_negative(uint256 x, uint104 assets) public {
+        // fuzz
+        _initWorld(x);
+
+        // Invoke all interactions with the Collateral Tracker from user Bob
+        vm.startPrank(Bob);
+
+        // give Bob the max amount of tokens
+        _grantTokens(Bob);
+
+        // approve collateral tracker to move tokens on Bob's behalf
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+
+        // deposit a number of assets determined via fuzzing
+        // equal deposits for both collateral token pairs for testing purposes
+        collateralToken0.deposit(assets, Bob);
+        collateralToken1.deposit(assets, Bob);
+
+        // check delegatee balance before
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
+
+        // invoke delegate transactions from the Panoptic pool
+        panopticPool.refund(Bob, Alice, -int256(uint256(assets)), collateralToken0);
+
+        panopticPool.refund(Bob, Alice, -int256(uint256(assets)), collateralToken1);
+
+        // check delegatee balance after
+        uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
+        uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
+
+        assertApproxEqAbs(sharesBefore0, sharesAfter0, 5);
+        assertApproxEqAbs(sharesBefore1, sharesAfter1, 5);
+    }
+
+    // access control on delegate/revoke/settlement functions
+    function test_Fail_All_OnlyPanopticPool(address caller) public{
+        vm.assume(caller != address(panopticPool));
+
+        vm.prank(caller);
+
+        vm.expectRevert(Errors.NotPanopticPool.selector);
+        collateralToken0.delegate(address(0), address(0), 0);
+
+        vm.expectRevert(Errors.NotPanopticPool.selector);
+        collateralToken0.delegate(address(0), 0);
+
+        vm.expectRevert(Errors.NotPanopticPool.selector);
+        collateralToken0.refund(address(0), 0);
+
+        vm.expectRevert(Errors.NotPanopticPool.selector);
+        collateralToken0.revoke(address(0), address(0), 0);
+
+        vm.expectRevert(Errors.NotPanopticPool.selector);
+        collateralToken0.refund(address(0), address(0), 0);
+
+        vm.expectRevert(Errors.NotPanopticPool.selector);
+        collateralToken0.takeCommissionAddData(0, 0, 0, 0);
+
+        vm.expectRevert(Errors.NotPanopticPool.selector);
+        collateralToken0.exercise(address(0), 0, 0, 0, 0);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1625,7 +1625,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
     }
 
     // access control on delegate/revoke/settlement functions
-    function test_Fail_All_OnlyPanopticPool(address caller) public{
+    function test_Fail_All_OnlyPanopticPool(address caller) public {
         vm.assume(caller != address(panopticPool));
 
         vm.prank(caller);

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1516,7 +1516,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1,
                 type(uint104).max
             );
-
+            
             // approve collateral tracker to move tokens on Alice's behalf
             IERC20Partial(token0).approve(address(collateralToken0), assetsToken0);
             IERC20Partial(token1).approve(address(collateralToken1), assetsToken1);
@@ -1528,8 +1528,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         }
 
         // check delegator balance before
-        uint256 sharesBefore0 = collateralToken0.balanceOf(Alice);
-        uint256 sharesBefore1 = collateralToken1.balanceOf(Alice);
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
 
         uint256 convertedShares = convertToShares(1_000_000_000, collateralToken0);
 
@@ -1581,8 +1581,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         }
 
         // check delegator balance before
-        uint256 sharesBefore0 = collateralToken0.balanceOf(Alice);
-        uint256 sharesBefore1 = collateralToken1.balanceOf(Alice);
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
 
         // invoke delegate transactions from the Panoptic pool
         panopticPool.refund(Alice, Bob, int256(uint256(shares)), collateralToken0);
@@ -1592,8 +1592,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
         uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
 
-        assertApproxEqAbs(sharesBefore0 - sharesAfter0, shares, 5);
-        assertApproxEqAbs(sharesBefore1 - sharesAfter1, shares, 5);
+        assertApproxEqAbs(sharesBefore0, sharesAfter0, 5);
+        assertApproxEqAbs(sharesBefore1, sharesAfter1, 5);
     }
 
     function test_success_refund_negative(uint256 x, uint104 assets) public {

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1581,8 +1581,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         }
 
         // check delegator balance before
-        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
-        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Alice);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Alice);
 
         // invoke delegate transactions from the Panoptic pool
         panopticPool.refund(Alice, Bob, int256(uint256(shares)), collateralToken0);
@@ -1592,8 +1592,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
         uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
 
-        assertApproxEqAbs(sharesBefore0, sharesAfter0, 5);
-        assertApproxEqAbs(sharesBefore1, sharesAfter1, 5);
+        assertApproxEqAbs(sharesBefore0 - sharesAfter0, shares, 5);
+        assertApproxEqAbs(sharesBefore1 - sharesAfter1, shares, 5);
     }
 
     function test_success_refund_negative(uint256 x, uint104 assets) public {

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1516,7 +1516,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1,
                 type(uint104).max
             );
-            
+
             // approve collateral tracker to move tokens on Alice's behalf
             IERC20Partial(token0).approve(address(collateralToken0), assetsToken0);
             IERC20Partial(token1).approve(address(collateralToken1), assetsToken1);


### PR DESCRIPTION
Currently, we require force exercisors to delegate 100% of the collateral that could be required to exercise an option to ensure it can be burned (the exercised account must be solvent, but they may not have the right tokens to exercise the option on their own). 

This results in force exercising being significantly capital-intensive, especially for larger options that could require a large amount of tokens to be provided upfront. 

Because the only purpose of the delegation is to ensure that the burn settlement logic can execute without reverting, it's not necessarily important for the force exercisor to be the one that provides the tokens. In fact, we can even accomplish the same purpose by minting temporary (or "virtual") shares to the exercised account, without requiring anyone to provide tokens upfront!

This change can make force exercises less capital-intensive as well as simplifying the force exercise calculation on the UI and increasing the probability a user will be able to generate a valid force exercise sequence.

To accomplish this, we add counterparts of the `delegate` and `refund` function that mint and burn shares to the exercised account without updating `totalSupply`. The flow goes like so:
1. Call `delegate(delegatee, uint256)` to mint virtual shares to the delegatee, ensuring the position burn can be settled
2. Burn the position
3. Call `refund(delegator, delegatee, uint256)` to settle the force exercise fee and any substitute tokens (i.e if the position needed USDC to burn but the account only had ETH, so we send USDC to the delegator from the delegatee and get ETH back) between the delegator and delegatee
4. Call `refund(delegatee, uint256)` to burn the virtual shares that were minted to the delegatee

We can do this for liquidations too, but it's less of an urgent UX improvement and the delegatedAmounts are more difficult to get.