### PR TITLE
fix: consistent behavior on premium rollover

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1649,7 +1649,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     positionSize,
                     s_tickSpacing
                 );
-                
+
                 uint256[2] memory premiumAccumulators;
                 {
                     uint256 tokenType = TokenId.tokenType(tokenId, leg);
@@ -1675,18 +1675,24 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         .toRightSlot(
                             int128(
                                 int256(
-                                    ((premiumAccumulators[0] >= premiumAccumulatorsLast[0] ? premiumAccumulators[0] - premiumAccumulatorsLast[0] :
-                                    premiumAccumulators[0] + (type(uint128).max - premiumAccumulatorsLast[0])) *
-                                        (liquidityChunk.liquidity())) / 2 ** 64
+                                    ((
+                                        premiumAccumulators[0] >= premiumAccumulatorsLast[0]
+                                            ? premiumAccumulators[0] - premiumAccumulatorsLast[0]
+                                            : premiumAccumulators[0] +
+                                                (type(uint128).max - premiumAccumulatorsLast[0])
+                                    ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )
                         )
                         .toLeftSlot(
                             int128(
                                 int256(
-                                    ((premiumAccumulators[1] >= premiumAccumulatorsLast[1] ? premiumAccumulators[1] - premiumAccumulatorsLast[1] :
-                                    premiumAccumulators[1] + (type(uint128).max - premiumAccumulatorsLast[1])) *
-                                        (liquidityChunk.liquidity())) / 2 ** 64
+                                    ((
+                                        premiumAccumulators[1] >= premiumAccumulatorsLast[1]
+                                            ? premiumAccumulators[1] - premiumAccumulatorsLast[1]
+                                            : premiumAccumulators[1] +
+                                                (type(uint128).max - premiumAccumulatorsLast[1])
+                                    ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )
                         );

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1671,6 +1671,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         premiumAccumulatorsLast[0] = premiumAccumulatorLast.rightSlot();
                         premiumAccumulatorsLast[1] = premiumAccumulatorLast.leftSlot();
                     }
+
+                    // if the premium accumulatorLast is higher than current, it means the premium accumulator has overflowed and rolled over at least once
+                    // we can account for one rollover by doing (acc_cur + (acc_max - acc_last))
+                    // if there are multiple rollovers or the rollover goes past the last accumulator, rolled over fees will just remain unclaimed
                     int256 legPremia = int256(0)
                         .toRightSlot(
                             int128(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1643,31 +1643,40 @@ contract PanopticPool is ERC1155Holder, Multicall {
         for (uint256 leg = 0; leg < numLegs; ) {
             uint256 isLong = tokenId.isLong(leg);
             if ((isLong == 1) || computeAllPremia) {
-                uint256 tokenType = TokenId.tokenType(tokenId, leg);
                 uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
                     tokenId,
                     leg,
                     positionSize,
                     s_tickSpacing
                 );
-
-                (uint256 premiumAccumulator0, uint256 premiumAccumulator1) = sfpm.getAccountPremium(
-                    address(s_univ3pool),
-                    address(this),
-                    tokenType,
-                    liquidityChunk.tickLower(),
-                    liquidityChunk.tickUpper(),
-                    atTick,
-                    isLong
-                );
+                
+                uint256[2] memory premiumAccumulators;
+                {
+                    uint256 tokenType = TokenId.tokenType(tokenId, leg);
+                    (premiumAccumulators[0], premiumAccumulators[1]) = sfpm.getAccountPremium(
+                        address(s_univ3pool),
+                        address(this),
+                        tokenType,
+                        liquidityChunk.tickLower(),
+                        liquidityChunk.tickUpper(),
+                        atTick,
+                        isLong
+                    );
+                }
 
                 unchecked {
-                    uint256 premiumAccumulatorLast = s_options[owner][tokenId][leg];
+                    uint256[2] memory premiumAccumulatorsLast;
+                    {
+                        uint256 premiumAccumulatorLast = s_options[owner][tokenId][leg];
+                        premiumAccumulatorsLast[0] = premiumAccumulatorLast.rightSlot();
+                        premiumAccumulatorsLast[1] = premiumAccumulatorLast.leftSlot();
+                    }
                     int256 legPremia = int256(0)
                         .toRightSlot(
                             int128(
                                 int256(
-                                    ((premiumAccumulator0 - premiumAccumulatorLast.rightSlot()) *
+                                    ((premiumAccumulators[0] >= premiumAccumulatorsLast[0] ? premiumAccumulators[0] - premiumAccumulatorsLast[0] :
+                                    premiumAccumulators[0] + (type(uint128).max - premiumAccumulatorsLast[0])) *
                                         (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )
@@ -1675,7 +1684,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         .toLeftSlot(
                             int128(
                                 int256(
-                                    ((premiumAccumulator1 - premiumAccumulatorLast.leftSlot()) *
+                                    ((premiumAccumulators[1] >= premiumAccumulatorsLast[1] ? premiumAccumulators[1] - premiumAccumulatorsLast[1] :
+                                    premiumAccumulators[1] + (type(uint128).max - premiumAccumulatorsLast[1])) *
                                         (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1685,7 +1685,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                                             ? premiumAccumulators.rightSlot() -
                                                 premiumAccumulatorLast.rightSlot()
                                             : premiumAccumulators.rightSlot() +
-                                                (type(uint128).max -
+                                                uint256(type(uint128).max -
                                                     premiumAccumulatorLast.rightSlot())
                                     ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )
@@ -1700,7 +1700,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                                             ? premiumAccumulators.leftSlot() -
                                                 premiumAccumulatorLast.leftSlot()
                                             : premiumAccumulators.leftSlot() +
-                                                (type(uint128).max -
+                                                uint256(type(uint128).max -
                                                     premiumAccumulatorLast.leftSlot())
                                     ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1650,27 +1650,27 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     s_tickSpacing
                 );
 
-                uint256[2] memory premiumAccumulators;
+                uint256 premiumAccumulators;
                 {
                     uint256 tokenType = TokenId.tokenType(tokenId, leg);
-                    (premiumAccumulators[0], premiumAccumulators[1]) = sfpm.getAccountPremium(
-                        address(s_univ3pool),
-                        address(this),
-                        tokenType,
-                        liquidityChunk.tickLower(),
-                        liquidityChunk.tickUpper(),
-                        atTick,
-                        isLong
+                    int24 _atTick = atTick;
+                    (uint128 premiumAccumulator0, uint128 premiumAccumulator1) = sfpm
+                        .getAccountPremium(
+                            address(s_univ3pool),
+                            address(this),
+                            tokenType,
+                            liquidityChunk.tickLower(),
+                            liquidityChunk.tickUpper(),
+                            _atTick,
+                            isLong
+                        );
+                    premiumAccumulators = uint256(0).toRightSlot(premiumAccumulator0).toLeftSlot(
+                        premiumAccumulator1
                     );
                 }
 
                 unchecked {
-                    uint256[2] memory premiumAccumulatorsLast;
-                    {
-                        uint256 premiumAccumulatorLast = s_options[owner][tokenId][leg];
-                        premiumAccumulatorsLast[0] = premiumAccumulatorLast.rightSlot();
-                        premiumAccumulatorsLast[1] = premiumAccumulatorLast.leftSlot();
-                    }
+                    uint256 premiumAccumulatorLast = s_options[owner][tokenId][leg];
 
                     // if the premium accumulatorLast is higher than current, it means the premium accumulator has overflowed and rolled over at least once
                     // we can account for one rollover by doing (acc_cur + (acc_max - acc_last))
@@ -1679,11 +1679,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         .toRightSlot(
                             int128(
                                 int256(
-                                    ((
-                                        premiumAccumulators[0] >= premiumAccumulatorsLast[0]
-                                            ? premiumAccumulators[0] - premiumAccumulatorsLast[0]
-                                            : premiumAccumulators[0] +
-                                                (type(uint128).max - premiumAccumulatorsLast[0])
+                                    (uint256(
+                                        premiumAccumulators.rightSlot() >=
+                                            premiumAccumulatorLast.rightSlot()
+                                            ? premiumAccumulators.rightSlot() -
+                                                premiumAccumulatorLast.rightSlot()
+                                            : premiumAccumulators.rightSlot() +
+                                                (type(uint128).max -
+                                                    premiumAccumulatorLast.rightSlot())
                                     ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )
@@ -1691,11 +1694,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         .toLeftSlot(
                             int128(
                                 int256(
-                                    ((
-                                        premiumAccumulators[1] >= premiumAccumulatorsLast[1]
-                                            ? premiumAccumulators[1] - premiumAccumulatorsLast[1]
-                                            : premiumAccumulators[1] +
-                                                (type(uint128).max - premiumAccumulatorsLast[1])
+                                    (uint256(
+                                        premiumAccumulators.leftSlot() >=
+                                            premiumAccumulatorLast.leftSlot()
+                                            ? premiumAccumulators.leftSlot() -
+                                                premiumAccumulatorLast.leftSlot()
+                                            : premiumAccumulators.leftSlot() +
+                                                (type(uint128).max -
+                                                    premiumAccumulatorLast.leftSlot())
                                     ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1685,8 +1685,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
                                             ? premiumAccumulators.rightSlot() -
                                                 premiumAccumulatorLast.rightSlot()
                                             : premiumAccumulators.rightSlot() +
-                                                uint256(type(uint128).max -
-                                                    premiumAccumulatorLast.rightSlot())
+                                                uint256(
+                                                    type(uint128).max -
+                                                        premiumAccumulatorLast.rightSlot()
+                                                )
                                     ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )
@@ -1700,8 +1702,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
                                             ? premiumAccumulators.leftSlot() -
                                                 premiumAccumulatorLast.leftSlot()
                                             : premiumAccumulators.leftSlot() +
-                                                uint256(type(uint128).max -
-                                                    premiumAccumulatorLast.leftSlot())
+                                                uint256(
+                                                    type(uint128).max -
+                                                        premiumAccumulatorLast.leftSlot()
+                                                )
                                     ) * (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1649,7 +1649,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     positionSize,
                     s_tickSpacing
                 );
-
+                
                 uint256[2] memory premiumAccumulators;
                 {
                     uint256 tokenType = TokenId.tokenType(tokenId, leg);
@@ -1675,24 +1675,18 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         .toRightSlot(
                             int128(
                                 int256(
-                                    ((
-                                        premiumAccumulators[0] >= premiumAccumulatorsLast[0]
-                                            ? premiumAccumulators[0] - premiumAccumulatorsLast[0]
-                                            : premiumAccumulators[0] +
-                                                (type(uint128).max - premiumAccumulatorsLast[0])
-                                    ) * (liquidityChunk.liquidity())) / 2 ** 64
+                                    ((premiumAccumulators[0] >= premiumAccumulatorsLast[0] ? premiumAccumulators[0] - premiumAccumulatorsLast[0] :
+                                    premiumAccumulators[0] + (type(uint128).max - premiumAccumulatorsLast[0])) *
+                                        (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )
                         )
                         .toLeftSlot(
                             int128(
                                 int256(
-                                    ((
-                                        premiumAccumulators[1] >= premiumAccumulatorsLast[1]
-                                            ? premiumAccumulators[1] - premiumAccumulatorsLast[1]
-                                            : premiumAccumulators[1] +
-                                                (type(uint128).max - premiumAccumulatorsLast[1])
-                                    ) * (liquidityChunk.liquidity())) / 2 ** 64
+                                    ((premiumAccumulators[1] >= premiumAccumulatorsLast[1] ? premiumAccumulators[1] - premiumAccumulatorsLast[1] :
+                                    premiumAccumulators[1] + (type(uint128).max - premiumAccumulatorsLast[1])) *
+                                        (liquidityChunk.liquidity())) / 2 ** 64
                                 )
                             )
                         );

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1113,12 +1113,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         // note: these are allowed to overflow because the alternative results in a possible DOS with stuck positions at high multipliers
         // protocols that make use of these values should/will implement a cap to the liquidity utilization to prevent extremely high long premium multipliers
         // when most of the liquidity is removed. There is no need for such a cap
-        s_accountPremiumOwed[positionKey] = s_accountPremiumOwed[positionKey].addUnchecked(
-            deltaPremiumOwed
-        );
-        s_accountPremiumGross[positionKey] = s_accountPremiumGross[positionKey].addUnchecked(
-            deltaPremiumGross
-        );
+        s_accountPremiumOwed[positionKey] =
+            s_accountPremiumOwed[positionKey].addUnchecked(deltaPremiumOwed);
+        s_accountPremiumGross[positionKey] =
+            s_accountPremiumGross[positionKey].addUnchecked(deltaPremiumGross);
     }
 
     /// @notice Compute the feesGrowth * liquidity / 2**128 by reading feeGrowthInside0LastX128 and feeGrowthInside1LastX128 from univ3pool.positions.

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1113,10 +1113,12 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         // note: these are allowed to overflow because the alternative results in a possible DOS with stuck positions at high multipliers
         // protocols that make use of these values should/will implement a cap to the liquidity utilization to prevent extremely high long premium multipliers
         // when most of the liquidity is removed. There is no need for such a cap
-        s_accountPremiumOwed[positionKey] =
-            s_accountPremiumOwed[positionKey].addUnchecked(deltaPremiumOwed);
-        s_accountPremiumGross[positionKey] =
-            s_accountPremiumGross[positionKey].addUnchecked(deltaPremiumGross);
+        s_accountPremiumOwed[positionKey] = s_accountPremiumOwed[positionKey].addUnchecked(
+            deltaPremiumOwed
+        );
+        s_accountPremiumGross[positionKey] = s_accountPremiumGross[positionKey].addUnchecked(
+            deltaPremiumGross
+        );
     }
 
     /// @notice Compute the feesGrowth * liquidity / 2**128 by reading feeGrowthInside0LastX128 and feeGrowthInside1LastX128 from univ3pool.positions.

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1113,14 +1113,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         // note: these are allowed to overflow because the alternative results in a possible DOS with stuck positions at high multipliers
         // protocols that make use of these values should/will implement a cap to the liquidity utilization to prevent extremely high long premium multipliers
         // when most of the liquidity is removed. There is no need for such a cap
-        unchecked {
-            s_accountPremiumOwed[positionKey] =
-                s_accountPremiumOwed[positionKey] +
-                deltaPremiumOwed;
-            s_accountPremiumGross[positionKey] =
-                s_accountPremiumGross[positionKey] +
-                deltaPremiumGross;
-        }
+        s_accountPremiumOwed[positionKey] =
+            s_accountPremiumOwed[positionKey].addUnchecked(deltaPremiumOwed);
+        s_accountPremiumGross[positionKey] =
+            s_accountPremiumGross[positionKey].addUnchecked(deltaPremiumGross);
     }
 
     /// @notice Compute the feesGrowth * liquidity / 2**128 by reading feeGrowthInside0LastX128 and feeGrowthInside1LastX128 from univ3pool.positions.
@@ -1471,9 +1467,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                     amountToCollect
                 );
                 // Extract the account liquidity for a given uniswap pool, owner, token type, and ticks
+                // allow rollover to remain consistent with actual behavior
                 acctPremia = isLong == 1
-                    ? acctPremia.add(deltaPremiumOwed)
-                    : acctPremia.add(deltaPremiumGross);
+                    ? acctPremia.addUnchecked(deltaPremiumOwed)
+                    : acctPremia.addUnchecked(deltaPremiumGross);
             }
         }
 

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -294,14 +294,17 @@ library LeftRight {
                 );
         }
     }
-    
+
     /// @notice Adds two leftRights, allowing overflow to occur within slots without leaking into the other slot
     /// @param x the augend
     /// @param y the addend
     /// @return z the sum x + y
     function addUnchecked(uint256 x, uint256 y) internal pure returns (uint256 z) {
         unchecked {
-            return z.toRightSlot(x.rightSlot() + y.rightSlot()).toLeftSlot(x.leftSlot() + y.leftSlot());
+            return
+                z.toRightSlot(x.rightSlot() + y.rightSlot()).toLeftSlot(
+                    x.leftSlot() + y.leftSlot()
+                );
         }
     }
 

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -294,17 +294,14 @@ library LeftRight {
                 );
         }
     }
-
+    
     /// @notice Adds two leftRights, allowing overflow to occur within slots without leaking into the other slot
     /// @param x the augend
     /// @param y the addend
     /// @return z the sum x + y
     function addUnchecked(uint256 x, uint256 y) internal pure returns (uint256 z) {
         unchecked {
-            return
-                z.toRightSlot(x.rightSlot() + y.rightSlot()).toLeftSlot(
-                    x.leftSlot() + y.leftSlot()
-                );
+            return z.toRightSlot(x.rightSlot() + y.rightSlot()).toLeftSlot(x.leftSlot() + y.leftSlot());
         }
     }
 

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -294,6 +294,16 @@ library LeftRight {
                 );
         }
     }
+    
+    /// @notice Adds two leftRights, allowing overflow to occur within slots without leaking into the other slot
+    /// @param x the augend
+    /// @param y the addend
+    /// @return z the sum x + y
+    function addUnchecked(uint256 x, uint256 y) internal pure returns (uint256 z) {
+        unchecked {
+            return z.toRightSlot(x.rightSlot() + y.rightSlot()).toLeftSlot(x.leftSlot() + y.leftSlot());
+        }
+    }
 
     /// @notice Multiply two int256 bit LeftRight-encoded words; revert on overflow.
     /// @param x the multiplicand

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -191,7 +191,6 @@ contract Misctest is Test, PositionUtils{
 
 
     function test_success_PremiumRollover() public {
-
         SwapperC swapperc = new SwapperC();
         changePrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -272,7 +271,7 @@ contract Misctest is Test, PositionUtils{
         // If it overflows multiple times, we leave some fees unclaimed, but that's fine. Can't be exploited.
         pp.burnOptions(tokenId, new uint256[](0), 0, 0);
 
-        // make sure Alice actually is credited fees
+        // make sure Alice is credited (not debited!) a reasonable amount of fees
         assertEq(int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore), 997570);
     }
 }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1,0 +1,278 @@
+import "forge-std/Test.sol";
+import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
+import {PanopticPool} from "@contracts/PanopticPool.sol";
+import {CollateralTracker} from "@contracts/CollateralTracker.sol";
+import {PanopticFactory} from "@contracts/PanopticFactory.sol";
+import {PanopticHelper} from "@contracts/periphery/PanopticHelper.sol";
+import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
+import {ERC20S} from ".../../scripts/tokens/ERC20S.sol";
+import {IUniswapV3Factory} from "v3-core/interfaces/IUniswapV3Factory.sol";
+import {IUniswapV3Pool} from "v3-core/interfaces/IUniswapV3Pool.sol";
+import {TokenId} from "@types/TokenId.sol";
+import {PanopticMath} from "@libraries/PanopticMath.sol";
+import {CallbackLib} from "@libraries/CallbackLib.sol";
+import {SafeTransferLib} from "@libraries/SafeTransferLib.sol";
+import {PositionUtils} from "../testUtils/PositionUtils.sol";
+contract SwapperC {
+    function uniswapV3SwapCallback(
+        int256 amount0Delta,
+        int256 amount1Delta,
+        bytes calldata data
+    ) external {
+        // Decode the swap callback data, checks that the UniswapV3Pool has the correct address.
+        CallbackLib.CallbackData memory decoded = abi.decode(data, (CallbackLib.CallbackData));
+
+        // Extract the address of the token to be sent (amount0 -> token0, amount1 -> token1)
+        address token = amount0Delta > 0
+            ? address(decoded.poolFeatures.token0)
+            : address(decoded.poolFeatures.token1);
+
+        // Transform the amount to pay to uint256 (take positive one from amount0 and amount1)
+        // the pool will always pass one delta with a positive sign and one with a negative sign or zero,
+        // so this logic always picks the correct delta to pay
+        uint256 amountToPay = amount0Delta > 0 ? uint256(amount0Delta) : uint256(amount1Delta);
+
+        // Pay the required token from the payer to the caller of this contract
+        SafeTransferLib.safeTransferFrom(token, decoded.payer, msg.sender, amountToPay);
+    }
+
+    function uniswapV3MintCallback(
+        uint256 amount0Owed,
+        uint256 amount1Owed,
+        bytes calldata data
+    ) external {
+        // Decode the mint callback data
+        CallbackLib.CallbackData memory decoded = abi.decode(data, (CallbackLib.CallbackData));
+
+        // Sends the amount0Owed and amount1Owed quantities provided
+        if (amount0Owed > 0)
+            SafeTransferLib.safeTransferFrom(
+                decoded.poolFeatures.token0,
+                decoded.payer,
+                msg.sender,
+                amount0Owed
+            );
+        if (amount1Owed > 0)
+            SafeTransferLib.safeTransferFrom(
+                decoded.poolFeatures.token1,
+                decoded.payer,
+                msg.sender,
+                amount1Owed
+            );
+    }
+
+    function mint(IUniswapV3Pool pool, int24 tickLower, int24 tickUpper, uint128 liquidity) public {
+        pool.mint(address(this), tickLower, tickUpper, liquidity, abi.encode(
+            CallbackLib.CallbackData({
+                poolFeatures: CallbackLib.PoolFeatures({
+                    token0: pool.token0(),
+                    token1: pool.token1(),
+                    fee: pool.fee()
+                }),
+                payer: msg.sender
+            })
+        ));
+    }
+
+    function burn(IUniswapV3Pool pool, int24 tickLower, int24 tickUpper, uint128 liquidity) public {
+        pool.burn(tickLower, tickUpper, liquidity);
+    }
+
+    function swapTo(IUniswapV3Pool pool, uint160 sqrtPriceX96) public {
+        (uint160 sqrtPriceX96Before, , , , , , ) = pool.slot0();
+
+        if (sqrtPriceX96Before == sqrtPriceX96) return;
+
+        (int256 amount0, int256 amount1) = pool.swap(
+            msg.sender,
+            sqrtPriceX96Before > sqrtPriceX96 ? true : false,
+            type(int128).max,
+            sqrtPriceX96,
+            abi.encode(
+                CallbackLib.CallbackData({
+                    poolFeatures: CallbackLib.PoolFeatures({
+                        token0: pool.token0(),
+                        token1: pool.token1(),
+                        fee: pool.fee()
+                    }),
+                    payer: msg.sender
+                })
+        ));
+    }
+    
+    }
+
+// mostly just fixed one-off tests/PoC
+contract Misctest is Test, PositionUtils{
+    using TokenId for uint256;
+    // the instance of SFPM we are testing
+    SemiFungiblePositionManager sfpm;
+
+    // reference implemenatations used by the factory
+    address poolReference;
+
+    address collateralReference;
+
+    // Mainnet factory address - SFPM is dependent on this for several checks and callbacks
+    IUniswapV3Factory V3FACTORY = IUniswapV3Factory(0x1F98431c8aD98523631AE4a59f267346ea31F984);
+
+    // Mainnet router address - used for swaps to test fees/premia
+    ISwapRouter router = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+
+    PanopticFactory factory;
+    PanopticPool pp;
+    CollateralTracker ct0;
+    CollateralTracker ct1;
+    PanopticHelper ph;
+
+    IUniswapV3Pool uniPool;
+    ERC20S token0;
+    ERC20S token1;
+
+    address Deployer = address(0x1234);
+    address Alice = address(0x123456);
+    address Bob = address(0x12345678);
+    address Swapper = address(0x123456789);
+    address Charlie = address(0x1234567891);
+    address Seller = address(0x12345678912);
+
+    function setUp() public {
+        vm.startPrank(Deployer);
+
+        sfpm = new SemiFungiblePositionManager(V3FACTORY);
+
+        ph = new PanopticHelper(sfpm);
+
+        // deploy reference pool and collateral token
+        poolReference = address(new PanopticPool(sfpm));
+        collateralReference = address(new CollateralTracker());
+        token0 = new ERC20S("token0", "T0", 18);
+        token1 = new ERC20S("token1", "T1", 18);
+        uniPool = IUniswapV3Pool(V3FACTORY.createPool(address(token0), address(token1), 500));
+
+        // This price causes exactly one unit of liquidity to be minted
+        // above here reverts b/c 0 liquidity cannot be minted
+        IUniswapV3Pool(uniPool).initialize(10**17 * 2**96);
+
+        factory = new PanopticFactory(address(token1), sfpm, V3FACTORY, poolReference, collateralReference);
+
+        token0.mint(Deployer, type(uint104).max);
+        token1.mint(Deployer, type(uint104).max);
+        token0.approve(address(factory), type(uint104).max);
+        token1.approve(address(factory), type(uint104).max);
+
+        pp = PanopticPool(address(factory.deployNewPool(address(token0), address(token1), 500, 1337)));
+
+        changePrank(Alice);
+
+        token0.mint(Alice, type(uint104).max);
+        token1.mint(Alice, type(uint104).max);
+
+        ct0 = pp.collateralToken0();
+        ct1 = pp.collateralToken1();
+
+        token0.approve(address(ct0), type(uint104).max);
+        token1.approve(address(ct1), type(uint104).max);
+
+        ct0.deposit(type(uint104).max, Alice);
+        ct1.deposit(type(uint104).max, Alice);        
+
+        changePrank(Bob);
+
+        token0.mint(Bob, type(uint104).max);
+        token1.mint(Bob, type(uint104).max);
+
+        token0.approve(address(ct0), type(uint104).max);
+        token1.approve(address(ct1), type(uint104).max);
+
+        ct0.deposit(type(uint104).max, Bob);
+        ct1.deposit(type(uint104).max, Bob);       
+    }
+
+
+    function test_success_PremiumRollover() public {
+
+        SwapperC swapperc = new SwapperC();
+        changePrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // move back to price=1
+        swapperc.swapTo(uniPool, 2**96);
+
+        // JIT a bunch of liquidity so swaps at mint can happen normally
+        swapperc.mint(uniPool, -10, 10, 10**18);
+
+        // L = 1    
+        uniPool.liquidity();
+
+        uint256 tokenId = uint256(0).addUniv3pool(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                4094
+            );    
+
+        uint256[] memory posIdList = new uint256[](1);
+        posIdList[0] = tokenId;
+        
+        changePrank(Bob);
+        // mint 1 liquidity unit of wideish centered position
+        pp.mintOptions(posIdList, 3, 0, 0, 0);
+
+        changePrank(Swapper);
+        swapperc.burn(uniPool, -10, 10, 10**18);
+
+        // L = 2    
+        uniPool.liquidity();
+
+        // accumulate the maximum fees per liq SFPM supports
+        accruePoolFeesInRange(address(uniPool), 1, 2**64-1, 2**64-1);
+
+        changePrank(Swapper);
+        swapperc.mint(uniPool, -10, 10, 10**18);
+
+        changePrank(Bob);
+        // works fine
+        pp.burnOptions(tokenId, new uint256[](0), 0, 0);
+
+        uint256 balanceBefore = ct0.convertToAssets(ct0.balanceOf(Alice));
+
+        changePrank(Alice);
+
+        // lock in almost-overflowed fees per liquidity 
+        pp.mintOptions(posIdList, 1000, 0, 0, 0);
+
+        changePrank(Swapper);
+        swapperc.burn(uniPool, -10, 10, 10**18);
+
+        // overflow back to ~1_000_000 (fees per liq)
+        accruePoolFeesInRange(address(uniPool), 413, 1_000_000, 1_000_000);
+        
+        // this should behave like the actual accumulator does and rollover, not revert on overflow
+        (uint256 premium0, uint256 premium1) = sfpm.getAccountPremium(address(uniPool), address(pp), 0, -20470, 20470, 0, 0);
+        assertEq(premium0, 44646762138360822200777);
+        assertEq(premium1, 44646762138360822200777);
+
+        changePrank(Swapper);
+        swapperc.mint(uniPool, -10, 10, 10**18);
+        changePrank(Alice);
+        
+        // tough luck... PLPs just stole ~2**64 tokens per liquidity Alice had because of an overflow
+        // Alice can be frontrun if her transaction goes to a public mempool (or is otherwise anticipated),
+        // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!) 
+        // + fee to move price initially (if applicable)
+        // The solution is to wrap around the overflow once (so if the accumulator goes down, the fees are acc_current + (acc_max - acc_prev)
+        // If it overflows multiple times, we leave some fees unclaimed, but that's fine. Can't be exploited.
+        pp.burnOptions(tokenId, new uint256[](0), 0, 0);
+
+        // make sure Alice actually is credited fees
+        assertEq(int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore), 997570);
+    }
+}

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -13,6 +13,7 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 import {CallbackLib} from "@libraries/CallbackLib.sol";
 import {SafeTransferLib} from "@libraries/SafeTransferLib.sol";
 import {PositionUtils} from "../testUtils/PositionUtils.sol";
+
 contract SwapperC {
     function uniswapV3SwapCallback(
         int256 amount0Delta,
@@ -62,16 +63,22 @@ contract SwapperC {
     }
 
     function mint(IUniswapV3Pool pool, int24 tickLower, int24 tickUpper, uint128 liquidity) public {
-        pool.mint(address(this), tickLower, tickUpper, liquidity, abi.encode(
-            CallbackLib.CallbackData({
-                poolFeatures: CallbackLib.PoolFeatures({
-                    token0: pool.token0(),
-                    token1: pool.token1(),
-                    fee: pool.fee()
-                }),
-                payer: msg.sender
-            })
-        ));
+        pool.mint(
+            address(this),
+            tickLower,
+            tickUpper,
+            liquidity,
+            abi.encode(
+                CallbackLib.CallbackData({
+                    poolFeatures: CallbackLib.PoolFeatures({
+                        token0: pool.token0(),
+                        token1: pool.token1(),
+                        fee: pool.fee()
+                    }),
+                    payer: msg.sender
+                })
+            )
+        );
     }
 
     function burn(IUniswapV3Pool pool, int24 tickLower, int24 tickUpper, uint128 liquidity) public {
@@ -97,13 +104,13 @@ contract SwapperC {
                     }),
                     payer: msg.sender
                 })
-        ));
+            )
+        );
     }
-    
-    }
+}
 
 // mostly just fixed one-off tests/PoC
-contract Misctest is Test, PositionUtils{
+contract Misctest is Test, PositionUtils {
     using TokenId for uint256;
     // the instance of SFPM we are testing
     SemiFungiblePositionManager sfpm;
@@ -152,16 +159,24 @@ contract Misctest is Test, PositionUtils{
 
         // This price causes exactly one unit of liquidity to be minted
         // above here reverts b/c 0 liquidity cannot be minted
-        IUniswapV3Pool(uniPool).initialize(10**17 * 2**96);
+        IUniswapV3Pool(uniPool).initialize(10 ** 17 * 2 ** 96);
 
-        factory = new PanopticFactory(address(token1), sfpm, V3FACTORY, poolReference, collateralReference);
+        factory = new PanopticFactory(
+            address(token1),
+            sfpm,
+            V3FACTORY,
+            poolReference,
+            collateralReference
+        );
 
         token0.mint(Deployer, type(uint104).max);
         token1.mint(Deployer, type(uint104).max);
         token0.approve(address(factory), type(uint104).max);
         token1.approve(address(factory), type(uint104).max);
 
-        pp = PanopticPool(address(factory.deployNewPool(address(token0), address(token1), 500, 1337)));
+        pp = PanopticPool(
+            address(factory.deployNewPool(address(token0), address(token1), 500, 1337))
+        );
 
         changePrank(Alice);
 
@@ -175,7 +190,7 @@ contract Misctest is Test, PositionUtils{
         token1.approve(address(ct1), type(uint104).max);
 
         ct0.deposit(type(uint104).max, Alice);
-        ct1.deposit(type(uint104).max, Alice);        
+        ct1.deposit(type(uint104).max, Alice);
 
         changePrank(Bob);
 
@@ -186,9 +201,8 @@ contract Misctest is Test, PositionUtils{
         token1.approve(address(ct1), type(uint104).max);
 
         ct0.deposit(type(uint104).max, Bob);
-        ct1.deposit(type(uint104).max, Bob);       
+        ct1.deposit(type(uint104).max, Bob);
     }
-
 
     function test_success_PremiumRollover() public {
         SwapperC swapperc = new SwapperC();
@@ -199,43 +213,43 @@ contract Misctest is Test, PositionUtils{
         token1.approve(address(swapperc), type(uint128).max);
 
         // move back to price=1
-        swapperc.swapTo(uniPool, 2**96);
+        swapperc.swapTo(uniPool, 2 ** 96);
 
         // JIT a bunch of liquidity so swaps at mint can happen normally
-        swapperc.mint(uniPool, -10, 10, 10**18);
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
 
-        // L = 1    
+        // L = 1
         uniPool.liquidity();
 
         uint256 tokenId = uint256(0).addUniv3pool(PanopticMath.getPoolId(address(uniPool))).addLeg(
-                0,
-                1,
-                1,
-                0,
-                0,
-                0,
-                0,
-                4094
-            );    
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            4094
+        );
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
-        
+
         changePrank(Bob);
         // mint 1 liquidity unit of wideish centered position
         pp.mintOptions(posIdList, 3, 0, 0, 0);
 
         changePrank(Swapper);
-        swapperc.burn(uniPool, -10, 10, 10**18);
+        swapperc.burn(uniPool, -10, 10, 10 ** 18);
 
-        // L = 2    
+        // L = 2
         uniPool.liquidity();
 
         // accumulate the maximum fees per liq SFPM supports
-        accruePoolFeesInRange(address(uniPool), 1, 2**64-1, 2**64-1);
+        accruePoolFeesInRange(address(uniPool), 1, 2 ** 64 - 1, 2 ** 64 - 1);
 
         changePrank(Swapper);
-        swapperc.mint(uniPool, -10, 10, 10**18);
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
 
         changePrank(Bob);
         // works fine
@@ -245,27 +259,35 @@ contract Misctest is Test, PositionUtils{
 
         changePrank(Alice);
 
-        // lock in almost-overflowed fees per liquidity 
+        // lock in almost-overflowed fees per liquidity
         pp.mintOptions(posIdList, 1000, 0, 0, 0);
 
         changePrank(Swapper);
-        swapperc.burn(uniPool, -10, 10, 10**18);
+        swapperc.burn(uniPool, -10, 10, 10 ** 18);
 
         // overflow back to ~1_000_000 (fees per liq)
         accruePoolFeesInRange(address(uniPool), 413, 1_000_000, 1_000_000);
-        
+
         // this should behave like the actual accumulator does and rollover, not revert on overflow
-        (uint256 premium0, uint256 premium1) = sfpm.getAccountPremium(address(uniPool), address(pp), 0, -20470, 20470, 0, 0);
+        (uint256 premium0, uint256 premium1) = sfpm.getAccountPremium(
+            address(uniPool),
+            address(pp),
+            0,
+            -20470,
+            20470,
+            0,
+            0
+        );
         assertEq(premium0, 44646762138360822200777);
         assertEq(premium1, 44646762138360822200777);
 
         changePrank(Swapper);
-        swapperc.mint(uniPool, -10, 10, 10**18);
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
         changePrank(Alice);
-        
+
         // tough luck... PLPs just stole ~2**64 tokens per liquidity Alice had because of an overflow
         // Alice can be frontrun if her transaction goes to a public mempool (or is otherwise anticipated),
-        // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!) 
+        // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!)
         // + fee to move price initially (if applicable)
         // The solution is to wrap around the overflow once (so if the accumulator goes down, the fees are acc_current + (acc_max - acc_prev)
         // If it overflows multiple times, we leave some fees unclaimed, but that's fine. Can't be exploited.

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -13,7 +13,6 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 import {CallbackLib} from "@libraries/CallbackLib.sol";
 import {SafeTransferLib} from "@libraries/SafeTransferLib.sol";
 import {PositionUtils} from "../testUtils/PositionUtils.sol";
-
 contract SwapperC {
     function uniswapV3SwapCallback(
         int256 amount0Delta,
@@ -63,22 +62,16 @@ contract SwapperC {
     }
 
     function mint(IUniswapV3Pool pool, int24 tickLower, int24 tickUpper, uint128 liquidity) public {
-        pool.mint(
-            address(this),
-            tickLower,
-            tickUpper,
-            liquidity,
-            abi.encode(
-                CallbackLib.CallbackData({
-                    poolFeatures: CallbackLib.PoolFeatures({
-                        token0: pool.token0(),
-                        token1: pool.token1(),
-                        fee: pool.fee()
-                    }),
-                    payer: msg.sender
-                })
-            )
-        );
+        pool.mint(address(this), tickLower, tickUpper, liquidity, abi.encode(
+            CallbackLib.CallbackData({
+                poolFeatures: CallbackLib.PoolFeatures({
+                    token0: pool.token0(),
+                    token1: pool.token1(),
+                    fee: pool.fee()
+                }),
+                payer: msg.sender
+            })
+        ));
     }
 
     function burn(IUniswapV3Pool pool, int24 tickLower, int24 tickUpper, uint128 liquidity) public {
@@ -104,13 +97,13 @@ contract SwapperC {
                     }),
                     payer: msg.sender
                 })
-            )
-        );
+        ));
     }
-}
+    
+    }
 
 // mostly just fixed one-off tests/PoC
-contract Misctest is Test, PositionUtils {
+contract Misctest is Test, PositionUtils{
     using TokenId for uint256;
     // the instance of SFPM we are testing
     SemiFungiblePositionManager sfpm;
@@ -159,24 +152,16 @@ contract Misctest is Test, PositionUtils {
 
         // This price causes exactly one unit of liquidity to be minted
         // above here reverts b/c 0 liquidity cannot be minted
-        IUniswapV3Pool(uniPool).initialize(10 ** 17 * 2 ** 96);
+        IUniswapV3Pool(uniPool).initialize(10**17 * 2**96);
 
-        factory = new PanopticFactory(
-            address(token1),
-            sfpm,
-            V3FACTORY,
-            poolReference,
-            collateralReference
-        );
+        factory = new PanopticFactory(address(token1), sfpm, V3FACTORY, poolReference, collateralReference);
 
         token0.mint(Deployer, type(uint104).max);
         token1.mint(Deployer, type(uint104).max);
         token0.approve(address(factory), type(uint104).max);
         token1.approve(address(factory), type(uint104).max);
 
-        pp = PanopticPool(
-            address(factory.deployNewPool(address(token0), address(token1), 500, 1337))
-        );
+        pp = PanopticPool(address(factory.deployNewPool(address(token0), address(token1), 500, 1337)));
 
         changePrank(Alice);
 
@@ -190,7 +175,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), type(uint104).max);
 
         ct0.deposit(type(uint104).max, Alice);
-        ct1.deposit(type(uint104).max, Alice);
+        ct1.deposit(type(uint104).max, Alice);        
 
         changePrank(Bob);
 
@@ -201,8 +186,9 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), type(uint104).max);
 
         ct0.deposit(type(uint104).max, Bob);
-        ct1.deposit(type(uint104).max, Bob);
+        ct1.deposit(type(uint104).max, Bob);       
     }
+
 
     function test_success_PremiumRollover() public {
         SwapperC swapperc = new SwapperC();
@@ -213,43 +199,43 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         // move back to price=1
-        swapperc.swapTo(uniPool, 2 ** 96);
+        swapperc.swapTo(uniPool, 2**96);
 
         // JIT a bunch of liquidity so swaps at mint can happen normally
-        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+        swapperc.mint(uniPool, -10, 10, 10**18);
 
-        // L = 1
+        // L = 1    
         uniPool.liquidity();
 
         uint256 tokenId = uint256(0).addUniv3pool(PanopticMath.getPoolId(address(uniPool))).addLeg(
-            0,
-            1,
-            1,
-            0,
-            0,
-            0,
-            0,
-            4094
-        );
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                0,
+                4094
+            );    
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
-
+        
         changePrank(Bob);
         // mint 1 liquidity unit of wideish centered position
         pp.mintOptions(posIdList, 3, 0, 0, 0);
 
         changePrank(Swapper);
-        swapperc.burn(uniPool, -10, 10, 10 ** 18);
+        swapperc.burn(uniPool, -10, 10, 10**18);
 
-        // L = 2
+        // L = 2    
         uniPool.liquidity();
 
         // accumulate the maximum fees per liq SFPM supports
-        accruePoolFeesInRange(address(uniPool), 1, 2 ** 64 - 1, 2 ** 64 - 1);
+        accruePoolFeesInRange(address(uniPool), 1, 2**64-1, 2**64-1);
 
         changePrank(Swapper);
-        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+        swapperc.mint(uniPool, -10, 10, 10**18);
 
         changePrank(Bob);
         // works fine
@@ -259,35 +245,27 @@ contract Misctest is Test, PositionUtils {
 
         changePrank(Alice);
 
-        // lock in almost-overflowed fees per liquidity
+        // lock in almost-overflowed fees per liquidity 
         pp.mintOptions(posIdList, 1000, 0, 0, 0);
 
         changePrank(Swapper);
-        swapperc.burn(uniPool, -10, 10, 10 ** 18);
+        swapperc.burn(uniPool, -10, 10, 10**18);
 
         // overflow back to ~1_000_000 (fees per liq)
         accruePoolFeesInRange(address(uniPool), 413, 1_000_000, 1_000_000);
-
+        
         // this should behave like the actual accumulator does and rollover, not revert on overflow
-        (uint256 premium0, uint256 premium1) = sfpm.getAccountPremium(
-            address(uniPool),
-            address(pp),
-            0,
-            -20470,
-            20470,
-            0,
-            0
-        );
+        (uint256 premium0, uint256 premium1) = sfpm.getAccountPremium(address(uniPool), address(pp), 0, -20470, 20470, 0, 0);
         assertEq(premium0, 44646762138360822200777);
         assertEq(premium1, 44646762138360822200777);
 
         changePrank(Swapper);
-        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+        swapperc.mint(uniPool, -10, 10, 10**18);
         changePrank(Alice);
-
+        
         // tough luck... PLPs just stole ~2**64 tokens per liquidity Alice had because of an overflow
         // Alice can be frontrun if her transaction goes to a public mempool (or is otherwise anticipated),
-        // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!)
+        // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!) 
         // + fee to move price initially (if applicable)
         // The solution is to wrap around the overflow once (so if the accumulator goes down, the fees are acc_current + (acc_max - acc_prev)
         // If it overflows multiple times, we leave some fees unclaimed, but that's fine. Can't be exploited.

--- a/test/foundry/testUtils/PositionUtils.sol
+++ b/test/foundry/testUtils/PositionUtils.sol
@@ -1219,10 +1219,12 @@ contract PositionUtils is Test {
         // distribute accrued fee amount to Uniswap pool
         deal(
             IUniswapV3Pool(uniPool).token0(),
+            uniPool,
             (IUniswapV3Pool(uniPool).liquidity() * posFees0) / posLiq
         );
         deal(
             IUniswapV3Pool(uniPool).token1(),
+            uniPool,
             (IUniswapV3Pool(uniPool).liquidity() * posFees1) / posLiq
         );
 

--- a/test/foundry/types/LeftRight.t.sol
+++ b/test/foundry/types/LeftRight.t.sol
@@ -217,11 +217,12 @@ contract LeftRightTest is Test {
         xx = harness.toRightSlot(xx, v);
 
         unchecked {
-            uint256 other = harness.add(x, xx);
+            uint256 other = harness.addUnchecked(x, xx);
             assertEq(uint128(harness.leftSlot(other)), y + u);
             assertEq(uint128(harness.rightSlot(other)), z + v);
         }
     }
+
 
     function test_Success_AddUintInt(uint128 y, uint128 z, int128 u, int128 v) public {
         uint256 x = 0;

--- a/test/foundry/types/LeftRight.t.sol
+++ b/test/foundry/types/LeftRight.t.sol
@@ -223,7 +223,6 @@ contract LeftRightTest is Test {
         }
     }
 
-
     function test_Success_AddUintInt(uint128 y, uint128 z, int128 u, int128 v) public {
         uint256 x = 0;
         x = harness.toLeftSlot(x, y);

--- a/test/foundry/types/LeftRight.t.sol
+++ b/test/foundry/types/LeftRight.t.sol
@@ -192,6 +192,38 @@ contract LeftRightTest is Test {
         }
     }
 
+    function test_Success_AddUintsUnchecked(uint128 y, uint128 z, uint128 u, uint128 v) public {
+        uint256 x = 0;
+        x = harness.toLeftSlot(x, y);
+        x = harness.toRightSlot(x, z);
+        assertEq(uint128(harness.leftSlot(x)), y);
+        assertEq(uint128(harness.rightSlot(x)), z);
+
+        // try swapping order
+        x = 0;
+        x = harness.toRightSlot(x, y);
+        x = harness.toLeftSlot(x, z);
+        assertEq(uint128(harness.leftSlot(x)), z);
+        assertEq(uint128(harness.rightSlot(x)), y);
+
+        x = 0;
+        x = harness.toLeftSlot(x, y);
+        x = harness.toRightSlot(x, z);
+        assertEq(uint128(harness.leftSlot(x)), y);
+        assertEq(uint128(harness.rightSlot(x)), z);
+
+        uint256 xx = 0;
+        xx = harness.toLeftSlot(xx, u);
+        xx = harness.toRightSlot(xx, v);
+
+        unchecked {
+            uint256 other = harness.add(x, xx);
+            assertEq(uint128(harness.leftSlot(other)), y + u);
+            assertEq(uint128(harness.rightSlot(other)), z + v);
+        }
+    }
+
+
     function test_Success_AddUintInt(uint128 y, uint128 z, int128 u, int128 v) public {
         uint256 x = 0;
         x = harness.toLeftSlot(x, y);

--- a/test/foundry/types/harnesses/LeftRightHarness.sol
+++ b/test/foundry/types/harnesses/LeftRightHarness.sol
@@ -210,6 +210,11 @@ contract LeftRightHarness {
         return r;
     }
 
+    function addUnchecked(uint256 x, uint256 y) public view returns (uint256) {
+        uint256 r = LeftRight.addUnchecked(x, y);
+        return r;
+    }
+
     /**
      * @notice Subtract two int256 bit LeftRight-encoded words; rectify to 0 on negative result.
      * @param x the minuend


### PR DESCRIPTION
It turns out that it is actually very possible to overflow the x64 premium accumulators in the SFPM by minting positions in low-liquidity areas on pools with a small full-range deployment, even with our general assumptions about the number of tokens passing through the system not exceeding 2**127-1 holding

In the SFPM, premium accumulator rollovers leak between slots (tokens) b/c unchecked addition of leftRights. Also, getAccountPremium (with the correct atTick passed) reverts on overflow instead of rolling over, which is not consistent with the actual behavior when the positions are closed. I added a new `addUnchecked` function that adds leftRights while allowing them to rollover without leaking into other slots, so we just use this whenever adding up premium in the SFPM to make the behavior consistent.

In the PanopticPool, rollovers are not handled at all and actually cause erroneous transfers from sellers to PLPs (negative fees):
```
// tough luck... PLPs just stole ~2**64 tokens per liquidity Alice had because of an overflow
// Alice can be frontrun if her transaction goes to a public mempool (or is otherwise anticipated),
// so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!) 
// + fee to move price initially (if applicable)
// The solution is to wrap around the overflow once (so if the accumulator goes down, the fees are acc_current + (acc_max - acc_prev)
// If it overflows multiple times, we leave some fees unclaimed, but that's fine. Can't be exploited.
```
 
Run `test_success_PremiumRollover` on the previous version of the contracts to demonstrate the issues