### PR TITLE
feat: implement more conservative collateral requirements for long risk-partnered positions

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1696,6 +1696,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         uint256 tokenType = tokenId.tokenType(index);
 
+        // compute the max loss of the spread
+
         // if asset is NOT the same as the tokenType, the required amount is simply the difference in notional values
         // ie. asset = 1, tokenType = 0:
         if (tokenId.asset(index) != tokenType) {
@@ -1734,11 +1736,18 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             }
         }
 
-        // add the collateral requirement for the long leg as a base
-        spreadRequirement += _getRequiredCollateralAtUtilization(
-            tokenType == 0 ? movedRight : movedLeft,
-            1,
-            tokenType == 0 ? int64(uint64(poolUtilization)) : int64(uint64(poolUtilization >> 64))
+        // calculate the spread requirement as max(max_loss, long_leg_col_req)
+        // narrower spreads will be very capital efficient (1/3 of non-partnered CR!), but
+        // wider spreads (an uncommon position w/ high max loss) may not benefit from risk partnering
+        spreadRequirement = Math.max(
+            spreadRequirement,
+            _getRequiredCollateralAtUtilization(
+                tokenType == 0 ? movedRight : movedLeft,
+                1,
+                tokenType == 0
+                    ? int64(uint64(poolUtilization))
+                    : int64(uint64(poolUtilization >> 64))
+            )
         );
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -21,6 +21,7 @@ import {TickStateCallContext} from "@types/TickStateCallContext.sol";
 import {LeftRight} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
+import "forge-std/Test.sol";
 
 /// @title Collateral Tracking System / Margin Accounting used in conjunction with a Panoptic Pool.
 /// @author Axicon Labs Limited
@@ -1656,6 +1657,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Calculate the required amount of collateral for the spread portion of the spread position.
+    /// @dev long leg requirement + 100% collateralized risk
+    /// @dev may be higher than the requirement of non risk-partnered legs if the spread is very wide (risky)
     /// @param tokenId the option position.
     /// @param positionSize the size of the position.
     /// @param index the leg index of the LONG leg in the spread position.
@@ -1694,12 +1697,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         uint256 tokenType = tokenId.tokenType(index);
 
-        spreadRequirement = _getRequiredCollateralAtUtilization(
-            tokenType == 0 ? movedRight : movedLeft,
-            1,
-            tokenType == 0 ? int64(uint64(poolUtilization)) : int64(uint64(poolUtilization >> 64))
-        );
-
         // if asset is NOT the same as the tokenType, the required amount is simply the difference in notional values
         // ie. asset = 1, tokenType = 0:
         if (tokenId.asset(index) != tokenType) {
@@ -1737,6 +1734,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     : ((notional - notionalP) * contracts) / notionalP;
             }
         }
+
+        // add the collateral requirement for the long leg as a base
+        spreadRequirement += _getRequiredCollateralAtUtilization(
+            tokenType == 0 ? movedRight : movedLeft,
+            1,
+            tokenType == 0 ? int64(uint64(poolUtilization)) : int64(uint64(poolUtilization >> 64))
+        );
     }
 
     /// @notice Calculate the required amount of collateral for a strangle leg.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -21,7 +21,6 @@ import {TickStateCallContext} from "@types/TickStateCallContext.sol";
 import {LeftRight} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
-import "forge-std/Test.sol";
 
 /// @title Collateral Tracking System / Margin Accounting used in conjunction with a Panoptic Pool.
 /// @author Axicon Labs Limited

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -952,15 +952,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 targetPoolUtilization = s_targetPoolUtilization;
         buyCollateralRatio = s_buyCollateralRatio;
 
-        /// if utilization is less than zero, this is the calculation for a strangle, which gets 2x the capital efficiency at low pool utilization
-        /// at 0% utilization, strangle legs do not compound efficiency
-        if (utilization < 0) {
-            unchecked {
-                buyCollateralRatio /= 2;
-                utilization = -utilization;
-            }
-        }
-
         // return the basal buy ratio if pool utilization is lower than target
         if (utilization < targetPoolUtilization) {
             return buyCollateralRatio;
@@ -1608,30 +1599,19 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // extract partner index (associated with another liquidity chunk)
         uint256 partnerIndex = tokenId.riskPartner(index);
 
-        // long/short status of associated legs
         uint256 isLong = tokenId.isLong(index);
-        uint256 isLongP = tokenId.isLong(partnerIndex);
-
-        // token type status of associate legs (call/put)
-        uint256 tokenType = tokenId.tokenType(index);
-        uint256 tokenTypeP = tokenId.tokenType(partnerIndex);
-
-        if ((isLong != isLongP) && (tokenType == tokenTypeP)) {
-            if (index < partnerIndex) {
+        if (isLong != tokenId.isLong(partnerIndex)) {
+            if (isLong == 1) {
                 // compute the total amount of funds moved for that position
-                required = _computeSpread(tokenId, positionSize, index, partnerIndex);
-
-                // Add the base, which is relevant for calendar spreads
-                // The base requirement is given by the difference in collateral requirement when price = strikePartner,
-                // this calculation is done to avoid a net-zero requirement for two positions that are slightly offset from one another.
-                // Ensuring that the pool is not "diluted" by taking a narrow option's liquidity and spreading it over a very large range at no cost.
-                unchecked {
-                    required += _computeBase(tokenId, positionSize, index, partnerIndex);
-                }
+                required = _computeSpread(
+                    tokenId,
+                    positionSize,
+                    index,
+                    partnerIndex,
+                    poolUtilization
+                );
             }
-        }
-
-        if ((isLong == isLongP) && (tokenType != tokenTypeP)) {
+        } else {
             required = _computeStrangle(tokenId, index, positionSize, atTick, poolUtilization);
         }
     }
@@ -1675,53 +1655,18 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         }
     }
 
-    /// @notice Calculate The base required amount of collateral for the spread position (both legs).
-    /// @param tokenId The option position.
-    /// @param positionSize The size of the position.
-    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for.
-    /// @param partnerIndex The associated spread leg that is apart of the spread position.
-    /// @return baseRequirement The required amount of collateral needed for the spread base portion.
-    function _computeBase(
-        uint256 tokenId,
-        uint128 positionSize,
-        uint256 index,
-        uint256 partnerIndex
-    ) internal view returns (uint256 baseRequirement) {
-        // spread base collateral requirement legs are always evaluated as short positions at 0% utilization
-        uint256 checkedTokenId = tokenId.flipToBurnToken();
-
-        uint256 requiredBase = _getRequiredCollateralSingleLegNoPartner(
-            tokenId.isLong(index) == 1 ? checkedTokenId : tokenId,
-            index,
-            positionSize,
-            tokenId.strike(partnerIndex), // calculate base collateral as currentTick = strike of riskPartner
-            0 // utilization 0%
-        );
-
-        uint256 requiredBaseP = _getRequiredCollateralSingleLegNoPartner(
-            tokenId.isLong(partnerIndex) == 1 ? checkedTokenId : tokenId,
-            partnerIndex,
-            positionSize,
-            tokenId.strike(index), // calculate base collateral as currentTick = strike of riskPartner
-            0 // utilization 0%
-        );
-
-        baseRequirement = requiredBase < requiredBaseP
-            ? requiredBaseP - requiredBase
-            : requiredBase - requiredBaseP;
-    }
-
     /// @notice Calculate the required amount of collateral for the spread portion of the spread position.
     /// @param tokenId the option position.
     /// @param positionSize the size of the position.
-    /// @param index the leg index (associated with a liquidity chunk) to consider a partner for.
-    /// @param partnerIndex the associated spread leg that is apart of the spread position.
+    /// @param index the leg index of the LONG leg in the spread position.
+    /// @param partnerIndex the index of the partnered SHORT leg in the spread position.
     /// @return spreadRequirement the required amount of collateral needed for the spread portion.
     function _computeSpread(
         uint256 tokenId,
         uint128 positionSize,
         uint256 index,
-        uint256 partnerIndex
+        uint256 partnerIndex,
+        uint128 poolUtilization
     ) internal view returns (uint256 spreadRequirement) {
         // compute the total amount of funds moved for the position's current leg
         uint256 amountsMoved = PanopticMath.getAmountsMoved(
@@ -1747,14 +1692,17 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint128 movedPartnerRight = amountsMovedPartner.rightSlot();
         uint128 movedPartnerLeft = amountsMovedPartner.leftSlot();
 
-        // extract the tokenType
         uint256 tokenType = tokenId.tokenType(index);
-        // extract the asset
-        uint256 asset = tokenId.asset(index);
+
+        spreadRequirement = _getRequiredCollateralAtUtilization(
+            tokenType == 0 ? movedRight : movedLeft,
+            1,
+            tokenType == 0 ? int64(uint64(poolUtilization)) : int64(uint64(poolUtilization >> 64))
+        );
 
         // if asset is NOT the same as the tokenType, the required amount is simply the difference in notional values
         // ie. asset = 1, tokenType = 0:
-        if (asset != tokenType) {
+        if (tokenId.asset(index) != tokenType) {
             unchecked {
                 // always take the absolute values of the difference of amounts moved
                 if (tokenType == 0) {

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -508,7 +508,8 @@ library TokenId {
 
                     // if the two token long-types and the tokenTypes are both different (one is a short call, the other a long put, e.g.), this is a synthetic position
                     // A synthetic long or short is more capital efficient than each leg separated because the long+short premia accumulate proportionally
-                    if ((isLong != isLongP) && (tokenType != tokenTypeP))
+                    // unlike short stranlges, long strangles also cannot be partnered, because there is no reduction in risk (both legs can earn premia simultaneously)
+                    if (((isLong != isLongP) || isLong == 1) && (tokenType != tokenTypeP))
                         revert Errors.InvalidTokenIdParameter(5);
                 }
             } // end for loop over legs

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -2030,11 +2030,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
                 (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
 
-            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2);
+            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
             premium0 = premium0 < 0 ? int128(10_000 * uint128(-premium0)) / 10_000 : int128(0);
             required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
+            console2.log(
+                "1prem",
+                premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0
+            );
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
@@ -2126,7 +2130,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
             _assumePositionValidity(Bob, tokenId, positionSize0);
-            _spreadTokensRequired(tokenId1, positionSize0);
+
+            (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
+                .optionPositionBalance(Alice, tokenId1);
+
+            uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
+                (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
+
+            _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
             panopticPool.mintOptions(
                 positionIdList,
@@ -2196,7 +2207,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 poolUtilizations = uint128(poolUtilization0) +
                 (uint128(poolUtilization1) << 64);
 
-            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 4);
+            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 4, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
             required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
@@ -2295,7 +2306,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             /// calculate position
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 64));
             _assumePositionValidity(Bob, tokenId, positionSize0);
-            _spreadTokensRequired(tokenId1, positionSize0);
+
+            (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
+                .optionPositionBalance(Alice, tokenId1);
+
+            uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
+                (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
+
+            _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
             panopticPool.mintOptions(
                 positionIdList,
@@ -2365,7 +2383,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 poolUtilizations = uint128(poolUtilization0) +
                 (uint128(poolUtilization1) << 64);
 
-            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2);
+            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
             premium0 = premium0 < 0 ? int128((10_000 * uint128(-premium0)) / 10_000) : int128(0);
@@ -2550,7 +2568,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 poolUtilizations = uint128(poolUtilization0) +
                 (uint128(poolUtilization1) << 64);
 
-            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2);
+            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
             // only add premium requirement if there is net premia owed
@@ -2669,7 +2687,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 )
             );
             _assumePositionValidity(Bob, tokenId, positionSize0);
-            _spreadTokensRequired(tokenId1, positionSize0);
+
+            (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
+                .optionPositionBalance(Alice, tokenId1);
+
+            uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
+                (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
+
+            _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
             panopticPool.mintOptions(
                 positionIdList,
@@ -2699,7 +2724,13 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-            required = _spreadTokensRequired(tokenId1, positionSize0 / 2);
+            (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
+                .optionPositionBalance(Alice, tokenId1);
+
+            uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
+                (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
+
+            required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
 
             panopticPool.mintOptions(
                 positionIdList1,
@@ -2835,7 +2866,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 120));
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
-            _spreadTokensRequired(tokenId1, positionSize0);
 
             panopticPool.mintOptions(
                 positionIdList,
@@ -2865,7 +2895,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0);
-            required = _spreadTokensRequired(tokenId1, positionSize0);
+
+            (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
+                .optionPositionBalance(Alice, tokenId1);
+
+            uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
+                (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
+
+            required = _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
             panopticPool.mintOptions(
                 positionIdList1,
@@ -2908,45 +2945,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
             premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
             assertEq(required, tokenData0.leftSlot(), "required token0");
             assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
-        }
-
-        {
-            (, currentTick, , , , , ) = pool.slot0();
-
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, positionIdList1);
-
-            uint256 tokenData0 = collateralToken0.getAccountMarginDetails(
-                Alice,
-                currentTick,
-                posBalanceArray,
-                premium0
-            );
-            uint256 tokenData1 = collateralToken1.getAccountMarginDetails(
-                Alice,
-                currentTick,
-                posBalanceArray,
-                premium1
-            );
-
-            (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
-                .convertCollateralData(tokenData0, tokenData1, 1, currentTick);
-
-            (tokenData0, tokenData1) = panopticHelper.checkCollateral(
-                PanopticPool(address(panopticPool)),
-                Alice,
-                currentTick,
-                1,
-                positionIdList1
-            );
-
-            // assert the collateral requirements between the pool and tracker are equivalent
-            assertEq(tokenData0, calcBalanceCross, "0");
-            assertEq(tokenData1, calcThresholdCross, "1");
-
-            // assert that the threshold cross is 0 (calendar spread of same strike/width) has 0 requirement
-            assertEq(tokenData1, 0);
-            assertEq(calcThresholdCross, 0);
         }
     }
 
@@ -3065,52 +3063,13 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 poolUtilizations = uint128(poolUtilization0) +
                 (uint128(poolUtilization1) << 64);
 
-            uint128 required = _spreadTokensRequired(tokenId1, positionSize0);
+            uint128 required = _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
             premium0 = premium0 < 0 ? int128((10_000 * uint128(-premium0)) / 10_000) : int128(0); // add only long premia (premia owed)
             required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
-        }
-
-        {
-            (, currentTick, , , , , ) = pool.slot0();
-
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, positionIdList1);
-
-            uint256 tokenData0 = collateralToken0.getAccountMarginDetails(
-                Alice,
-                currentTick,
-                posBalanceArray,
-                premium0
-            );
-            uint256 tokenData1 = collateralToken1.getAccountMarginDetails(
-                Alice,
-                currentTick,
-                posBalanceArray,
-                premium1
-            );
-
-            (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
-                .convertCollateralData(tokenData0, tokenData1, 1, currentTick);
-
-            (tokenData0, tokenData1) = panopticHelper.checkCollateral(
-                panopticPool,
-                Alice,
-                currentTick,
-                1,
-                positionIdList1
-            );
-
-            // assert the collateral requirements between the pool and tracker are equivalent
-            assertEq(tokenData0, calcBalanceCross, "0");
-            assertEq(tokenData1, calcThresholdCross, "1");
-
-            // assert that the threshold cross is 0 (calendar spread of same strike/width) has 0 requirement
-            assertEq(tokenData1, 0);
-            assertEq(calcThresholdCross, 0);
         }
     }
 
@@ -5747,7 +5706,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             if ((isLong == isLongP) || (tokenType != tokenTypeP)) continue;
 
             {
-                if (i < partnerIndex) {
+                if (isLong == 1) {
                     // spread requirement
                     {
                         amountsMoved = PanopticMath.getAmountsMoved(
@@ -5771,13 +5730,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                         // amounts moved for partner
                         movedPartnerRight = amountsMovedPartner.rightSlot();
                         movedPartnerLeft = amountsMovedPartner.leftSlot();
-                        tokensRequired += _getRequiredCollateralAtUtilization(
-                            tokenType == 0 ? movedRight : movedLeft,
-                            1,
-                            tokenType == 0
-                                ? int64(uint64(poolUtilization))
-                                : int64(uint64(poolUtilization >> 64))
-                        );
 
                         uint256 asset = tokenId.asset(i);
 
@@ -5815,30 +5767,29 @@ contract CollateralTrackerTest is Test, PositionUtils {
                         }
                     }
 
-                    // base requirement
-                    {
-                        uint256 checkedTokenId = _tokenId.flipToBurnToken();
+                    _tempTokensRequired += uint128(
+                        collateralToken0.getRequiredCollateralAtUtilization(
+                            uint128(tokenType == 0 ? movedRight : movedLeft),
+                            1,
+                            tokenType == 0
+                                ? int64(uint64(poolUtilizations))
+                                : int64(uint64(poolUtilizations >> 64))
+                        )
+                    );
 
-                        uint128 requiredBase = _tokensRequired(
-                            isLong == 1 ? checkedTokenId : _tokenId,
-                            positionSize,
-                            baseStrike, // calculate base collateral as currentTick = strike of riskPartner
-                            0,
-                            [1, i]
-                        );
+                    console2.log(
+                        "extra",
+                        uint128(
+                            collateralToken0.getRequiredCollateralAtUtilization(
+                                uint128(tokenType == 0 ? movedRight : movedLeft),
+                                1,
+                                tokenType == 0
+                                    ? int64(uint64(poolUtilizations))
+                                    : int64(uint64(poolUtilizations >> 64))
+                            )
+                        )
+                    );
 
-                        uint128 requiredBaseP = _tokensRequired(
-                            isLongP == 1 ? checkedTokenId : _tokenId,
-                            positionSize,
-                            partnerStrike, // calculate base collateral as currentTick = strike of riskPartner
-                            0,
-                            [1, partnerIndex]
-                        );
-
-                        _tempTokensRequired += requiredBase < requiredBaseP
-                            ? requiredBaseP - requiredBase
-                            : requiredBase - requiredBaseP;
-                    }
                     vm.assume(_tempTokensRequired < type(uint128).max);
                     tokensRequired = _tempTokensRequired.toUint128();
                 }

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1903,170 +1903,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
         }
     }
 
-    function test_Success_collateralCheck_longStrangle(
-        uint256 x,
-        uint128 positionSizeSeed,
-        uint256 widthSeed,
-        int256 strikeSeed,
-        uint256 widthSeed2,
-        int256 strikeSeed2,
-        int24 atTick,
-        uint64 utilizationSeed
-    ) public {
-        vm.assume(strikeSeed != strikeSeed2 || widthSeed != widthSeed2);
-
-        {
-            _initWorld(x);
-
-            // initalize a custom Panoptic pool
-            _deployCustomPanopticPool(token0, token1, pool);
-
-            // Invoke all interactions with the Collateral Tracker from user Bob
-            vm.startPrank(Bob);
-
-            // approve collateral tracker to move tokens on Bob's behalf
-            IERC20Partial(token0).approve(address(collateralToken0), type(uint128).max);
-            IERC20Partial(token1).approve(address(collateralToken1), type(uint128).max);
-
-            // award corresponding shares
-            _mockMaxDeposit(Bob);
-
-            // have Bob sell
-            (width, strike) = PositionUtils.getOTMSW(
-                widthSeed,
-                strikeSeed,
-                uint24(tickSpacing),
-                currentTick,
-                1
-            );
-
-            (width1, strike1) = PositionUtils.getOTMSW(
-                widthSeed2,
-                strikeSeed2,
-                uint24(tickSpacing),
-                currentTick,
-                0
-            );
-
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
-            tokenId = tokenId.addLeg(1, 1, 1, 0, 0, 1, strike1, width1);
-            positionIdList.push(tokenId);
-
-            /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
-
-            positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
-            _assumePositionValidity(Bob, tokenId, positionSize0);
-
-            panopticPool.mintOptions(
-                positionIdList,
-                positionSize0,
-                type(uint64).max,
-                TickMath.MIN_TICK,
-                TickMath.MAX_TICK
-            );
-        }
-
-        {
-            // Alice buys
-            changePrank(Alice);
-
-            // approve collateral tracker to move tokens on Bob's behalf
-            IERC20Partial(token0).approve(address(collateralToken0), type(uint128).max);
-            IERC20Partial(token1).approve(address(collateralToken1), type(uint128).max);
-
-            // award corresponding shares
-            _mockMaxDeposit(Alice);
-
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 1, 1, strike, width);
-            tokenId1 = tokenId1.addLeg(1, 1, 1, 1, 0, 0, strike1, width1);
-            positionIdList1.push(tokenId1);
-            _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
-
-            panopticPool.mintOptions(
-                positionIdList1,
-                positionSize0 / 4,
-                type(uint64).max,
-                TickMath.MIN_TICK,
-                TickMath.MAX_TICK
-            );
-        }
-
-        {
-            atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
-            atTick = (atTick / tickSpacing) * tickSpacing;
-
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, positionIdList1);
-
-            uint256 tokenData0 = collateralToken0.getAccountMarginDetails(
-                Alice,
-                atTick,
-                posBalanceArray,
-                premium0
-            );
-            uint256 tokenData1 = collateralToken1.getAccountMarginDetails(
-                Alice,
-                atTick,
-                posBalanceArray,
-                premium1
-            );
-
-            (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
-                .optionPositionBalance(Alice, tokenId1);
-
-            uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
-                (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
-
-            (uint128 tokensRequired0, uint128 tokensRequired1) = _strangleTokensRequired(
-                tokenId1,
-                positionSize0 / 4,
-                poolUtilizations,
-                atTick,
-                premium0,
-                premium1
-            );
-
-            // checks tokens required
-            assertEq(tokensRequired0, tokenData0.leftSlot(), "required token0");
-            assertEq(tokensRequired1, tokenData1.leftSlot(), "required token1");
-        }
-
-        {
-            (, currentTick, , , , , ) = pool.slot0();
-
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, positionIdList1);
-
-            uint256 tokenData0 = collateralToken0.getAccountMarginDetails(
-                Alice,
-                currentTick,
-                posBalanceArray,
-                premium0
-            );
-            uint256 tokenData1 = collateralToken1.getAccountMarginDetails(
-                Alice,
-                currentTick,
-                posBalanceArray,
-                premium1
-            );
-
-            (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
-                .convertCollateralData(tokenData0, tokenData1, 1, currentTick);
-
-            (tokenData0, tokenData1) = panopticHelper.checkCollateral(
-                PanopticPool(address(panopticPool)),
-                Alice,
-                currentTick,
-                1,
-                positionIdList1
-            );
-
-            assertEq(tokenData0, calcBalanceCross, "0");
-            assertEq(tokenData1, calcThresholdCross, "1");
-        }
-    }
-
     /*//////////////////////////////////////////////////////////////
                             SPREADS
     //////////////////////////////////////////////////////////////*/
@@ -2154,7 +1990,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-            _spreadTokensRequired(tokenId1, positionSize0);
 
             panopticPool.mintOptions(
                 positionIdList1,
@@ -2192,8 +2027,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
                 .optionPositionBalance(Alice, tokenId1);
 
-            uint128 poolUtilizations = uint128(poolUtilization0) +
-                (uint128(poolUtilization1) << 64);
+            uint128 poolUtilizations = uint128(poolUtilization0 == 0 ? 1 : poolUtilization0) +
+                (uint128(poolUtilization1 == 0 ? 1 : poolUtilization1) << 64);
 
             uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2);
 
@@ -5892,7 +5727,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     function _spreadTokensRequired(
         uint256 _tokenId,
-        uint128 positionSize
+        uint128 positionSize,
+        uint128 poolUtilizations
     ) internal returns (uint128 tokensRequired) {
         uint maxLoop = tokenId.countLegs();
 
@@ -5935,6 +5771,13 @@ contract CollateralTrackerTest is Test, PositionUtils {
                         // amounts moved for partner
                         movedPartnerRight = amountsMovedPartner.rightSlot();
                         movedPartnerLeft = amountsMovedPartner.leftSlot();
+                        tokensRequired += _getRequiredCollateralAtUtilization(
+                            tokenType == 0 ? movedRight : movedLeft,
+                            1,
+                            tokenType == 0
+                                ? int64(uint64(poolUtilization))
+                                : int64(uint64(poolUtilization >> 64))
+                        );
 
                         uint256 asset = tokenId.asset(i);
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -5764,14 +5764,17 @@ contract CollateralTrackerTest is Test, PositionUtils {
                         }
                     }
 
-                    _tempTokensRequired += uint128(
-                        collateralToken0.getRequiredCollateralAtUtilization(
-                            uint128(tokenType == 0 ? movedRight : movedLeft),
-                            1,
-                            tokenType == 0
-                                ? int64(uint64(poolUtilizations))
-                                : int64(uint64(poolUtilizations >> 64))
-                        )
+                    _tempTokensRequired = Math.max(
+                        uint128(
+                            collateralToken0.getRequiredCollateralAtUtilization(
+                                uint128(tokenType == 0 ? movedRight : movedLeft),
+                                1,
+                                tokenType == 0
+                                    ? int64(uint64(poolUtilizations))
+                                    : int64(uint64(poolUtilizations >> 64))
+                            )
+                        ),
+                        _tempTokensRequired
                     );
 
                     vm.assume(_tempTokensRequired < type(uint128).max);

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -2035,10 +2035,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // only add premium requirement if there is net premia owed
             premium0 = premium0 < 0 ? int128(10_000 * uint128(-premium0)) / 10_000 : int128(0);
             required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
-            console2.log(
-                "1prem",
-                premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0
-            );
+
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
@@ -5774,19 +5771,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                             tokenType == 0
                                 ? int64(uint64(poolUtilizations))
                                 : int64(uint64(poolUtilizations >> 64))
-                        )
-                    );
-
-                    console2.log(
-                        "extra",
-                        uint128(
-                            collateralToken0.getRequiredCollateralAtUtilization(
-                                uint128(tokenType == 0 ? movedRight : movedLeft),
-                                1,
-                                tokenType == 0
-                                    ? int64(uint64(poolUtilizations))
-                                    : int64(uint64(poolUtilizations >> 64))
-                            )
                         )
                     );
 

--- a/test/foundry/periphery/PanopticHelper.t.sol
+++ b/test/foundry/periphery/PanopticHelper.t.sol
@@ -912,6 +912,16 @@ contract PanopticHelperTest is PositionUtils {
             });
             inputLeg[i] = _Leg;
         }
+
+        for (uint256 i; i < numberOfLegs; ++i) {
+            // long strangles cannot be partnered; only short strangles
+            if (
+                tokenId.riskPartner(i) != i &&
+                tokenId.tokenType(i) != tokenId.tokenType(tokenId.riskPartner(i))
+            ) {
+                vm.assume(tokenId.isLong(i) != 1);
+            }
+        }
         tokenId.validate();
         PanopticHelper.Leg[] memory unwrappedLeg = ph.unwrapTokenId(tokenId);
 

--- a/test/foundry/types/TokenId.t.sol
+++ b/test/foundry/types/TokenId.t.sol
@@ -1276,6 +1276,94 @@ contract TokenIdTest is Test, PositionUtils {
         harness.validate(tokenId);
     }
 
+    function test_Fail_validate_longStrangle(
+        uint64 poolId,
+        uint256 optionRatioSeed,
+        uint256 assetSeed,
+        uint256 isLongSeed,
+        uint256 tokenTypeSeed,
+        int24 strikeSeed,
+        int256 widthSeed,
+        int24 poolStatusSeed
+    ) public {
+        uint256 tokenId;
+
+        // fuzzes a valid currentTick
+        setPoolStatus(poolStatusSeed);
+
+        //construct two leg token
+        tokenId = fuzzedPosition(
+            2, // total amount of legs
+            poolId,
+            optionRatioSeed,
+            assetSeed,
+            isLongSeed,
+            tokenTypeSeed,
+            strikeSeed,
+            widthSeed
+        );
+
+        {
+            //clear all risk partner bits
+            tokenId = tokenId & CLEAR_RISK_PARTNER_MASK;
+
+            // leg 1 will have risk partner as leg 2
+            tokenId = harness.addRiskPartner(tokenId, 1, 0);
+
+            // leg 2 will have risk partner as leg 1
+            tokenId = harness.addRiskPartner(tokenId, 0, 1);
+        }
+
+        {
+            // clear all asset bits
+            tokenId = tokenId & CLEAR_NUMERAIRE_MASK;
+
+            // leg 1 asset 0
+            tokenId = harness.addAsset(tokenId, 0, 1);
+
+            // leg 2 asset 1
+            tokenId = harness.addAsset(tokenId, 0, 1);
+        }
+
+        /// create legs with same option ratio
+        {
+            //clear all option ratio bits
+            tokenId = tokenId & CLEAR_OPTION_RATIO_MASK;
+
+            // leg 1 option pseudorandom option ratio
+            tokenId = harness.addOptionRatio(tokenId, 1, 0); // hardcode for now
+
+            // leg 2 option pseudorandom option ratio
+            tokenId = harness.addOptionRatio(tokenId, 1, 1);
+        }
+
+        {
+            //clear all is long bits
+            tokenId = tokenId & CLEAR_IS_LONG_MASK;
+
+            // leg 1 will be long
+            tokenId = harness.addIsLong(tokenId, 1, 0);
+
+            // leg 2 will be long
+            tokenId = harness.addIsLong(tokenId, 1, 1);
+        }
+
+        {
+            //clear all risk partner bits
+            tokenId = tokenId & CLEAR_TOKEN_TYPE_MASK;
+
+            // leg 1 will be asset 0
+            tokenId = harness.addTokenType(tokenId, 0, 0);
+
+            // leg 2 will be asset 1
+            tokenId = harness.addTokenType(tokenId, 1, 1);
+        }
+
+        // will fail as risk partners must have the same asset
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTokenIdParameter.selector, 5));
+        harness.validate(tokenId);
+    }
+
     function test_Fail_validate_synthPos(
         uint64 poolId,
         uint256 optionRatioSeed,


### PR DESCRIPTION
Spreads - Changed the "base" collateral requirement to be that of the long leg. The long leg caps the maximum risk of the short leg, but the long leg itself still has premium risk. The new collateral requirement is the long leg requirement + 100% collateralized spread risk (token delta between the bounds of the "risky" portion of the spread)

Strangles/straddles - removed long strangles from the set of valid positions. Unlike short strangles, long strangles do not have any meaningful difference in risk (especially straddles - premium is accumulated at twice the rate) because the risk is derived only from the premium and not the intrinsic value of the position. 

Thanks to Robert from Numoen for asking an important question. This PR makes the answer 40x instead of infinity :)
![image](https://github.com/panoptic-labs/panoptic-v1-core-private/assets/36370397/918a1a41-0ce3-48a2-b772-7c9424b81420)
