### PR TITLE
feat: Store tickSpacing in tokenId

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -155,8 +155,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @dev Amount of assets moved from the Panoptic Pool to the AMM.
     uint128 internal s_inAMM;
 
-    /// @dev The tick spacing in the Uniswap pool.
-    int24 internal s_tickSpacing;
     /// @dev The fee of the Uniswap pool.
     uint24 internal s_poolFee;
 
@@ -256,8 +254,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         s_underlyingToken = underlyingToken;
         // store the Panoptic pool for this collateral token
         s_panopticPool = panopticPool;
-        // store the tickSpacing of the underlying Uniswap pool
-        s_tickSpacing = uniswapPool.tickSpacing();
 
         // cache the pool fee in basis points
         uint24 _poolFee;
@@ -762,7 +758,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
                 int24 strike = positionId.strike(leg);
 
-                int24 range = (positionId.width(leg) * s_tickSpacing) / 2;
+                int24 range = (positionId.width(leg) * positionId.tickSpacing()) / 2;
 
                 uint256 currNumRangesFromStrike;
 
@@ -799,8 +795,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
                     positionId,
                     leg,
-                    positionBalance,
-                    s_tickSpacing
+                    positionBalance
                 );
 
                 (uint256 currentValue0, uint256 currentValue1) = Math.getAmountsForLiquidity(
@@ -1460,12 +1455,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint128 poolUtilization
     ) internal view returns (uint256 required) {
         // compute the total amount of funds moved for that position
-        uint256 amountsMoved = PanopticMath.getAmountsMoved(
-            tokenId,
-            positionSize,
-            index,
-            s_tickSpacing
-        );
+        uint256 amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, index);
 
         // extract the tokenType (token0 or token1)
         uint256 tokenType = tokenId.tokenType(index);
@@ -1494,7 +1484,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 {
                     uint256 c_tokenId = tokenId;
                     int24 width = c_tokenId.width(index);
-                    oneSidedRange = (width * s_tickSpacing) / 2;
+                    oneSidedRange = (width * c_tokenId.tickSpacing()) / 2;
                 }
                 // compute the collateral requirement as a fixed amount that doesn't depend on price
 
@@ -1671,19 +1661,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint128 poolUtilization
     ) internal view returns (uint256 spreadRequirement) {
         // compute the total amount of funds moved for the position's current leg
-        uint256 amountsMoved = PanopticMath.getAmountsMoved(
-            tokenId,
-            positionSize,
-            index,
-            s_tickSpacing
-        );
+        uint256 amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, index);
 
         // compute the total amount of funds moved for the position's partner leg
         uint256 amountsMovedPartner = PanopticMath.getAmountsMoved(
             tokenId,
             positionSize,
-            partnerIndex,
-            s_tickSpacing
+            partnerIndex
         );
 
         // amount moved is right slot if tokenType=0, left slot otherwise

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -539,13 +539,7 @@ contract PanopticFactory is ReentrancyGuard, ERC1155, Multicall {
         uint96 _nonce
     ) internal pure returns (bytes32) {
         return
-            bytes32(
-                abi.encodePacked(
-                    PanopticMath.getPoolId(_v3Pool),
-                    uint64(uint160(_deployer)),
-                    _nonce
-                )
-            );
+            bytes32(abi.encodePacked(uint80(uint160(_v3Pool)), uint80(uint160(_deployer)), _nonce));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -274,7 +274,6 @@ contract PanopticFactory is ReentrancyGuard, ERC1155, Multicall {
         s_getPanopticPool[v3Pool] = newPoolContract;
         newPoolContract.startPool(
             v3Pool,
-            tickSpacing,
             currentTick,
             token0,
             token1,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -164,9 +164,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @dev The Uniswap v3 pool that this instance of Panoptic is deployed on
     IUniswapV3Pool internal s_univ3pool;
 
-    /// @dev The tick spacing of the underlying Uniswap v3 pool
-    int24 internal s_tickSpacing;
-
     /// @notice Mini-median storage slot
     /// @dev The data for the last 8 interactions is stored as such:
     /// LAST UPDATED BLOCK TIMESTAMP (40 bits)
@@ -254,7 +251,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @notice Creates a method for creating a Panoptic Pool on top of an existing Uniswap v3 pair.
     /// @dev Must be called first before any transaction can occur. Must also deploy collateralReference first.
     /// @param univ3pool Address of the target Uniswap v3 pool.
-    /// @param tickSpacing TickSpacing of the UniswapV3Pool.
     /// @param currentTick Current tick in the UniswapV3Pool.
     /// @param token0 Address of the pool's token0.
     /// @param token1 Address of the pool's token1.
@@ -262,7 +258,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param collateralTracker1 Interface for collateral token1.
     function startPool(
         IUniswapV3Pool univ3pool,
-        int24 tickSpacing,
         int24 currentTick,
         address token0,
         address token1,
@@ -274,9 +269,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // Store the univ3Pool variable
         s_univ3pool = IUniswapV3Pool(univ3pool);
-
-        // Store the tickSpacing variable
-        s_tickSpacing = tickSpacing;
 
         // Store the median data
         unchecked {
@@ -670,8 +662,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // compute how much of tokenId is long and short positions
         (int256 longAmounts, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            positionSize,
-            s_tickSpacing
+            positionSize
         );
 
         int128 utilization0 = s_collateralToken0.takeCommissionAddData(
@@ -707,7 +698,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         for (uint256 leg = 0; leg < numLegs; ) {
             // Extract base fee (AMM swap/trading fees) for the position and add it to s_options
             // (ie. the (feeGrowth * liquidity) / 2**128 for each token)
-            (int24 tickLower, int24 tickUpper) = mintTokenId.asTicks(leg, s_tickSpacing);
+            (int24 tickLower, int24 tickUpper) = mintTokenId.asTicks(leg);
             uint256 isLong = mintTokenId.isLong(leg);
             {
                 (uint128 premiumAccumulator0, uint128 premiumAccumulator1) = sfpm.getAccountPremium(
@@ -850,7 +841,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         for (uint256 leg = 0; leg < numLegs; ) {
             if (burnTokenId.isLong(leg) == 0) {
                 // Check the liquidity spread, make sure that closing the option does not exceed the MAX_SPREAD allowed
-                (int24 tickLower, int24 tickUpper) = burnTokenId.asTicks(leg, s_tickSpacing);
+                (int24 tickLower, int24 tickUpper) = burnTokenId.asTicks(leg);
                 _checkLiquiditySpread(burnTokenId, leg, tickLower, tickUpper, MAX_SPREAD);
             }
             delete (s_options[owner][burnTokenId][leg]);
@@ -899,8 +890,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // compute option amounts if exercise was necessary
         (int256 longAmounts, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            positionSize,
-            s_tickSpacing
+            positionSize
         );
 
         // exercise the option and take the commission and addData
@@ -1074,14 +1064,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
         int24 twapTick = getUniV3TWAP();
 
         // on forced exercise, the price *must* be outside the position's range for at least 1 leg
-        touchedId[0].validateIsExercisable(twapTick, s_tickSpacing);
+        touchedId[0].validateIsExercisable(twapTick);
 
         // compute the notional value of the short legs (the maximum amount of tokens required to exercise - premia)
         // and the long legs (from which the exercise cost is computed)
         (int256 longAmounts, int256 delegatedAmounts) = PanopticMath.computeExercisedAmounts(
             touchedId[0],
-            s_positionBalance[account][touchedId[0]].rightSlot(),
-            s_tickSpacing
+            s_positionBalance[account][touchedId[0]].rightSlot()
         );
 
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
@@ -1643,12 +1632,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         for (uint256 leg = 0; leg < numLegs; ) {
             uint256 isLong = tokenId.isLong(leg);
             if ((isLong == 1) || computeAllPremia) {
-                uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
-                    tokenId,
-                    leg,
-                    positionSize,
-                    s_tickSpacing
-                );
+                uint256 liquidityChunk = PanopticMath.getLiquidityChunk(tokenId, leg, positionSize);
 
                 uint256 premiumAccumulators;
                 {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -763,7 +763,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param mintTokenId The candidate option position to validate.
     function _doMintChecks(uint256 mintTokenId) internal view {
         // make sure the tokenId is for this Panoptic pool
-        if (mintTokenId.univ3pool() != sfpm.getPoolId(address(s_univ3pool)))
+        if (mintTokenId.poolId() != sfpm.getPoolId(address(s_univ3pool)))
             revert Errors.InvalidTokenIdParameter(0);
         // disallow user to mint exact same position
         // in order to do it, user should burn it first and then mint

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -482,7 +482,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         int24 slippageTickLimitHigh
     )
         external
-        ReentrancyLock(tokenId.univ3pool())
+        ReentrancyLock(tokenId.poolId())
         returns (int256 totalCollected, int256 totalSwapped, int24 newTick)
     {
         // burn this ERC1155 token id
@@ -516,7 +516,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         int24 slippageTickLimitHigh
     )
         external
-        ReentrancyLock(tokenId.univ3pool())
+        ReentrancyLock(tokenId.poolId())
         returns (int256 totalCollected, int256 totalSwapped, int24 newTick)
     {
         // create the option position via its ID in this erc1155
@@ -554,7 +554,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     ) public override {
         // we don't need to reentrancy lock on transfers, but we can't allow transfers for a pool during mint/burn with a reentrant call
         // so just check if there is an active reentrancy lock for the relevant pool on the token we're transferring
-        if (s_poolContext[id.univ3pool()].locked) revert Errors.ReentrantCall();
+        if (s_poolContext[id.poolId()].locked) revert Errors.ReentrantCall();
 
         // update the position data
         registerTokenTransfer(from, to, id, amount);
@@ -581,7 +581,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         // we don't need to reentrancy lock on transfers, but we can't allow transfers for a pool during mint/burn with a reentrant call
         // so just check if there is an active reentrancy lock for the relevant pool on each token
         for (uint256 i = 0; i < ids.length; ) {
-            if (s_poolContext[ids[i].univ3pool()].locked) revert Errors.ReentrantCall();
+            if (s_poolContext[ids[i].poolId()].locked) revert Errors.ReentrantCall();
             registerTokenTransfer(from, to, ids[i], amounts[i]);
             unchecked {
                 ++i;

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -362,14 +362,18 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         // if poolId == 0, we have a bit on the left set if it was initialized, so this will still return properly
         if (s_AddrToPoolIdData[univ3pool] != 0) return;
 
-        // Set the base poolId as last 8 bytes of the address (the first 16 hex characters)
-        // @dev in the unlikely case that there is a collision between the first 8 bytes of two different Uni v3 pools
-        // @dev increase the poolId by a pseudo-random number
+        // The base poolId is composed as follows:
+        // [tickSpacing][pool pattern]
+        // [16 bit tickSpacing][most significant 48 bits of the pool address]
         uint64 poolId = PanopticMath.getPoolId(univ3pool);
 
+        // There are 281,474,976,710,655 possible pool patterns.
+        // A modern GPU can generate a collision such a space relatively quickly,
+        // so if a collision is detected increment the pool pattern until a unique poolId is found
         while (address(s_poolContext[poolId].pool) != address(0)) {
-            poolId = PanopticMath.getFinalPoolId(poolId, token0, token1, fee);
+            poolId = PanopticMath.incrementPoolPattern(poolId);
         }
+
         // store the poolId => UniswapV3Pool information in a mapping
         // `locked` being initialized to false is gas-efficient because the pool address makes the slot nonzero
         // note: we preserve the state of `locked` to prevent reentering a pool by initializing it during the reentrant call

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -606,12 +606,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         for (uint256 leg = 0; leg < numLegs; ) {
             // for this leg index: extract the liquidity chunk: a 256bit word containing the liquidity amount and upper/lower tick
             // @dev see `contracts/types/LiquidityChunk.sol`
-            uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
-                id,
-                leg,
-                uint128(amount),
-                univ3pool.tickSpacing()
-            );
+            uint256 liquidityChunk = PanopticMath.getLiquidityChunk(id, leg, uint128(amount));
 
             //construct the positionKey for the from and to addresses
             bytes32 positionKey_from = keccak256(
@@ -905,8 +900,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                 uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
                     _tokenId,
                     _leg,
-                    _positionSize,
-                    _univ3pool.tickSpacing()
+                    _positionSize
                 );
 
                 (_moved, _itmAmounts, _totalCollected) = _createLegInAMM(

--- a/contracts/libraries/FeesCalc.sol
+++ b/contracts/libraries/FeesCalc.sol
@@ -58,18 +58,12 @@ library FeesCalc {
         mapping(uint256 tokenId => uint256 balance) storage userBalance,
         uint256[] calldata positionIdList
     ) external view returns (int256 value0, int256 value1) {
-        int24 ts = univ3pool.tickSpacing();
         for (uint256 k = 0; k < positionIdList.length; ) {
             uint256 tokenId = positionIdList[k];
             uint128 positionSize = userBalance[tokenId].rightSlot();
             uint256 numLegs = tokenId.countLegs();
             for (uint256 leg = 0; leg < numLegs; ) {
-                uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
-                    tokenId,
-                    leg,
-                    positionSize,
-                    ts
-                );
+                uint256 liquidityChunk = PanopticMath.getLiquidityChunk(tokenId, leg, positionSize);
 
                 (uint256 amount0, uint256 amount1) = Math.getAmountsForLiquidity(
                     atTick,
@@ -116,12 +110,7 @@ library FeesCalc {
         uint128 positionSize
     ) public view returns (uint256 liquidityChunk, int256 feesPerToken) {
         // extract the liquidity chunk representing the leg `index` of the option position `tokenId`
-        liquidityChunk = PanopticMath.getLiquidityChunk(
-            tokenId,
-            index,
-            positionSize,
-            univ3pool.tickSpacing()
-        );
+        liquidityChunk = PanopticMath.getLiquidityChunk(tokenId, index, positionSize);
 
         // Extract the AMM swap/trading fees collected by this option leg (liquidity chunk)
         // packed as LeftRight with token0 fees in the right slot and token1 fees in the left slot

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -22,6 +22,9 @@ library PanopticMath {
     // represents an option position of up to four legs as a sinlge ERC1155 tokenId
     using TokenId for uint256;
 
+    uint64 internal constant POOLID_MASK = 0xFFFF00000000FFFF;
+    uint64 internal constant ANTI_POOLID_MASK = 0xFFFFFFFF0000;
+
     /*//////////////////////////////////////////////////////////////
                               MATH HELPERS
     //////////////////////////////////////////////////////////////*/
@@ -63,12 +66,12 @@ library PanopticMath {
         uint24 fee
     ) internal pure returns (uint64) {
         unchecked {
-            // add extra entropy to bits between (12, 32) of the poolId.
-            /// @dev this protects the tickSpacing and adds 20bits of entropy (1,048,576) when there's a poolId collision.
-            uint64 extraEntropy = (uint64(
-                uint256(keccak256(abi.encodePacked(token0, token1, fee)))
-            ) >> 48) << 16;
-            return basePoolId + extraEntropy;
+            // add extra entropy to bits between (16, 48) of the poolId.
+            /// @dev this protects the tickSpacing and adds 32bits of entropy (1,294,967,296) when there's a poolId collision.
+            uint64 extraEntropy = uint64(
+                uint256(keccak256(abi.encodePacked(basePoolId, token0, token1, fee)))
+            ) & ANTI_POOLID_MASK;
+            return basePoolId & (POOLID_MASK + extraEntropy);
         }
     }
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -29,17 +29,25 @@ library PanopticMath {
     /// @notice Given an address to a Uniswap v3 pool, return its 64-bit ID as used in the `TokenId` of Panoptic.
     /// @dev Example:
     ///      the 64 bits are the 64 *last* (most significant) bits - and thus corresponds to the *first* 16 hex characters (reading left to right)
-    ///      of the Uniswap v3 pool address, e.g.:
-    ///        univ3pool = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8
+    ///      of the Uniswap v3 pool address, with the tickSpacing written in the lowest 12 bits (ie. max tickSpacing is 4096)
+    ///      e.g.:
+    ///        univ3pool   = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8
+    ///        tickSpacing = 60
     ///      the returned id is then:
-    ///        0x8ad599c3A0ff1De0
-    ///      which as a uint64 is:
-    ///        10004071212772171232.
+    ///        univ3pool   = 0x8ad599c3A0ff1000
+    ///        tickSpacing = 00000000000000003c    +
+    ///        --------------------------------------------
+    ///        poolId      = 0x8ad599c3A0ff103c
     ///
-    /// @param univ3pool the Uniswap v3 pool to get the ID of
+    /// @param univ3pool the address of the Uniswap v3 pool to get the ID of
     /// @return a uint64 representing a fingerprint of the uniswap v3 pool address
-    function getPoolId(address univ3pool) internal pure returns (uint64) {
-        return uint64(uint160(univ3pool) >> 96);
+    function getPoolId(address univ3pool) internal view returns (uint64) {
+        unchecked {
+            int24 tickSpacing = IUniswapV3Pool(univ3pool).tickSpacing();
+            uint64 poolId = uint64(uint160(univ3pool) >> (96 + 12)) << 12;
+            poolId += uint24(tickSpacing);
+            return poolId;
+        }
     }
 
     /// @notice Returns the resultant pool ID for the given 64-bit base pool ID and parameters.
@@ -55,9 +63,12 @@ library PanopticMath {
         uint24 fee
     ) internal pure returns (uint64) {
         unchecked {
-            return
-                basePoolId +
-                (uint64(uint256(keccak256(abi.encodePacked(token0, token1, fee)))) >> 32);
+            // add extra entropy to bits between (12, 32) of the poolId.
+            /// @dev this protects the tickSpacing and adds 20bits of entropy (1,048,576) when there's a poolId collision.
+            uint64 extraEntropy = (uint64(
+                uint256(keccak256(abi.encodePacked(token0, token1, fee)))
+            ) >> 44) << 12;
+            return basePoolId + extraEntropy;
         }
     }
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -22,8 +22,8 @@ library PanopticMath {
     // represents an option position of up to four legs as a sinlge ERC1155 tokenId
     using TokenId for uint256;
 
-    uint64 internal constant POOLID_MASK = 0xFFFFFFFF00000000;
-    uint64 internal constant ANTI_POOLID_MASK = 0x00000000FFFFFFFF;
+    uint64 internal constant POOLID_MASK = 0x0000FFFFFFFFFFFF;
+    uint64 internal constant TICKSPACING_MASK = 0xFFFF000000000000;
 
     /*//////////////////////////////////////////////////////////////
                               MATH HELPERS
@@ -32,12 +32,12 @@ library PanopticMath {
     /// @notice Given an address to a Uniswap v3 pool, return its 64-bit ID as used in the `TokenId` of Panoptic.
     /// @dev Example:
     ///      the 64 bits are the 64 *last* (most significant) bits - and thus corresponds to the *first* 16 hex characters (reading left to right)
-    ///      of the Uniswap v3 pool address, with the tickSpacing written in the lowest 16 bits (ie. max tickSpacing is 32768)
+    ///      of the Uniswap v3 pool address, with the tickSpacing written in the highest 16 bits (ie. max tickSpacing is 32768)
     ///      e.g.:
     ///        univ3pool   = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8
     ///        tickSpacing = 60
     ///      the returned id is then:
-    ///        univ3pool   = 0x00008ad599c3A0ff
+    ///        poolPattern = 0x00008ad599c3A0ff
     ///        tickSpacing = 0x003c000000000000    +
     ///        --------------------------------------------
     ///        poolId      = 0x003c8ad599c3A0ff
@@ -53,25 +53,13 @@ library PanopticMath {
         }
     }
 
-    /// @notice Returns the resultant pool ID for the given 64-bit base pool ID and parameters.
-    /// @param basePoolId the 64-bit base pool ID
-    /// @param token0 the address of the first token in the pool
-    /// @param token1 the address of the second token in the pool
-    /// @param fee the fee of the pool in hundredths of a bi
-    /// @return finalPoolId the final 64-bit pool id as encoded in the `TokenId` type - composed of the last 64 bits of the address and a hash of the parameters
-    function getFinalPoolId(
-        uint64 basePoolId,
-        address token0,
-        address token1,
-        uint24 fee
-    ) internal pure returns (uint64) {
+    /// @notice Increments the pool pattern (first 48 bits) of a poolId by 1.
+    /// @param poolId the 64-bit pool ID
+    /// @return poolId with the pool pattern portion incremented by 1
+    function incrementPoolPattern(uint64 poolId) internal pure returns (uint64) {
         unchecked {
-            // add extra entropy to bits between (0, 32) of the poolId.
-            /// @dev this protects the tickSpacing in bits (48, 64) and adds 32bits of entropy (4,294,967,296) when there's a poolId collision.
-            uint64 extraEntropy = uint64(
-                uint256(keccak256(abi.encodePacked(basePoolId, token0, token1, fee)))
-            ) & ANTI_POOLID_MASK;
-            return (basePoolId & POOLID_MASK) + extraEntropy;
+            // increment
+            return (poolId & TICKSPACING_MASK) + (uint48(poolId) + 1);
         }
     }
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -170,16 +170,14 @@ library PanopticMath {
     /// @param tokenId the option position id
     /// @param legIndex the leg index of the option position, can be {0,1,2,3}
     /// @param positionSize the number of contracts held by this leg
-    /// @param tickSpacing the tick spacing of the underlying univ3 pool
-    /// @return liquidityChunk a uint256 bit-packed (see `LiquidityChunk.sol`) with `tickLower`, `tickUpper`, and `liquidity`
+    // @return liquidityChunk a uint256 bit-packed (see `LiquidityChunk.sol`) with `tickLower`, `tickUpper`, and `liquidity`
     function getLiquidityChunk(
         uint256 tokenId,
         uint256 legIndex,
-        uint128 positionSize,
-        int24 tickSpacing
+        uint128 positionSize
     ) internal pure returns (uint256 liquidityChunk) {
         // get the tick range for this leg
-        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(legIndex, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(legIndex);
 
         // Get the amount of liquidity owned by this leg in the univ3 pool in the above tick range
         // Background:
@@ -233,23 +231,16 @@ library PanopticMath {
     /// @notice Compute the amount of funds that are underlying this option position. This is useful when exercising a position.
     /// @param tokenId the option position id
     /// @param positionSize The number of contracts of this option
-    /// @param tickSpacing the tick spacing of the underlying Uniswap v3 pool
     /// @return longAmounts Left-right packed word where the right conains the total contract size and the left total notional
     /// @return shortAmounts Left-right packed word where the right conains the total contract size and the left total notional
     function computeExercisedAmounts(
         uint256 tokenId,
-        uint128 positionSize,
-        int24 tickSpacing
+        uint128 positionSize
     ) internal pure returns (int256 longAmounts, int256 shortAmounts) {
         uint256 numLegs = tokenId.countLegs();
         for (uint256 leg = 0; leg < numLegs; ) {
             // Compute the amount of funds that have been removed from the Panoptic Pool
-            (int256 longs, int256 shorts) = _calculateIOAmounts(
-                tokenId,
-                positionSize,
-                leg,
-                tickSpacing
-            );
+            (int256 longs, int256 shorts) = _calculateIOAmounts(tokenId, positionSize, leg);
 
             longAmounts = longAmounts.add(longs);
             shortAmounts = shortAmounts.add(shorts);
@@ -421,16 +412,14 @@ library PanopticMath {
     /// @param tokenId the option position identifier
     /// @param positionSize the number of option contracts held in this position (each contract can control multiple tokens)
     /// @param legIndex the leg index of the option contract, can be {0,1,2,3}
-    /// @param tickSpacing the tick spacing of the underlying UniV3 pool
     /// @return amountsMoved a LeftRight encoded variable containing the amount0 and the amount1 value controlled by this option position's leg
     function getAmountsMoved(
         uint256 tokenId,
         uint128 positionSize,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) internal pure returns (uint256 amountsMoved) {
         // get the tick range for this leg in order to get the strike price (the underlying price)
-        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(legIndex, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(legIndex);
 
         // positionSize: how many option contracts we have.
 
@@ -454,17 +443,15 @@ library PanopticMath {
     /// @param tokenId the option position identifier
     /// @param positionSize The number of positions minted
     /// @param legIndex the leg index minted in this position, can be {0,1,2,3}
-    /// @param tickSpacing the tick spacing of the underlying Uniswap v3 pool
     /// @return longs A LeftRight-packed word containing the total amount of long positions
     /// @return shorts A LeftRight-packed word containing the amount of short positions
     function _calculateIOAmounts(
         uint256 tokenId,
         uint128 positionSize,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) internal pure returns (int256 longs, int256 shorts) {
         // compute amounts moved
-        uint256 amountsMoved = getAmountsMoved(tokenId, positionSize, legIndex, tickSpacing);
+        uint256 amountsMoved = getAmountsMoved(tokenId, positionSize, legIndex);
 
         bool isShort = tokenId.isLong(legIndex) == 0;
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -71,7 +71,7 @@ library PanopticMath {
             uint64 extraEntropy = uint64(
                 uint256(keccak256(abi.encodePacked(basePoolId, token0, token1, fee)))
             ) & ANTI_POOLID_MASK;
-            return basePoolId & (POOLID_MASK + extraEntropy);
+            return (basePoolId & POOLID_MASK) + extraEntropy;
         }
     }
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -22,8 +22,8 @@ library PanopticMath {
     // represents an option position of up to four legs as a sinlge ERC1155 tokenId
     using TokenId for uint256;
 
-    uint64 internal constant POOLID_MASK = 0xFFFF00000000FFFF;
-    uint64 internal constant ANTI_POOLID_MASK = 0xFFFFFFFF0000;
+    uint64 internal constant POOLID_MASK = 0xFFFFFFFF00000000;
+    uint64 internal constant ANTI_POOLID_MASK = 0x00000000FFFFFFFF;
 
     /*//////////////////////////////////////////////////////////////
                               MATH HELPERS
@@ -37,18 +37,18 @@ library PanopticMath {
     ///        univ3pool   = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8
     ///        tickSpacing = 60
     ///      the returned id is then:
-    ///        univ3pool   = 0x8ad599c3A0ff1000
-    ///        tickSpacing = 00000000000000003c    +
+    ///        univ3pool   = 0x00008ad599c3A0ff
+    ///        tickSpacing = 0x003c000000000000    +
     ///        --------------------------------------------
-    ///        poolId      = 0x8ad599c3A0ff103c
+    ///        poolId      = 0x003c8ad599c3A0ff
     ///
     /// @param univ3pool the address of the Uniswap v3 pool to get the ID of
     /// @return a uint64 representing a fingerprint of the uniswap v3 pool address
     function getPoolId(address univ3pool) internal view returns (uint64) {
         unchecked {
             int24 tickSpacing = IUniswapV3Pool(univ3pool).tickSpacing();
-            uint64 poolId = uint64(uint160(univ3pool) >> (96 + 16)) << 16;
-            poolId += uint24(tickSpacing);
+            uint64 poolId = uint64(uint160(univ3pool) >> 112);
+            poolId += uint64(uint24(tickSpacing)) << 48;
             return poolId;
         }
     }
@@ -66,8 +66,8 @@ library PanopticMath {
         uint24 fee
     ) internal pure returns (uint64) {
         unchecked {
-            // add extra entropy to bits between (16, 48) of the poolId.
-            /// @dev this protects the tickSpacing and adds 32bits of entropy (4,294,967,296) when there's a poolId collision.
+            // add extra entropy to bits between (0, 32) of the poolId.
+            /// @dev this protects the tickSpacing in bits (48, 64) and adds 32bits of entropy (4,294,967,296) when there's a poolId collision.
             uint64 extraEntropy = uint64(
                 uint256(keccak256(abi.encodePacked(basePoolId, token0, token1, fee)))
             ) & ANTI_POOLID_MASK;

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -67,7 +67,7 @@ library PanopticMath {
     ) internal pure returns (uint64) {
         unchecked {
             // add extra entropy to bits between (16, 48) of the poolId.
-            /// @dev this protects the tickSpacing and adds 32bits of entropy (1,294,967,296) when there's a poolId collision.
+            /// @dev this protects the tickSpacing and adds 32bits of entropy (4,294,967,296) when there's a poolId collision.
             uint64 extraEntropy = uint64(
                 uint256(keccak256(abi.encodePacked(basePoolId, token0, token1, fee)))
             ) & ANTI_POOLID_MASK;

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -29,7 +29,7 @@ library PanopticMath {
     /// @notice Given an address to a Uniswap v3 pool, return its 64-bit ID as used in the `TokenId` of Panoptic.
     /// @dev Example:
     ///      the 64 bits are the 64 *last* (most significant) bits - and thus corresponds to the *first* 16 hex characters (reading left to right)
-    ///      of the Uniswap v3 pool address, with the tickSpacing written in the lowest 12 bits (ie. max tickSpacing is 4096)
+    ///      of the Uniswap v3 pool address, with the tickSpacing written in the lowest 16 bits (ie. max tickSpacing is 32768)
     ///      e.g.:
     ///        univ3pool   = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8
     ///        tickSpacing = 60
@@ -44,7 +44,7 @@ library PanopticMath {
     function getPoolId(address univ3pool) internal view returns (uint64) {
         unchecked {
             int24 tickSpacing = IUniswapV3Pool(univ3pool).tickSpacing();
-            uint64 poolId = uint64(uint160(univ3pool) >> (96 + 12)) << 12;
+            uint64 poolId = uint64(uint160(univ3pool) >> (96 + 16)) << 16;
             poolId += uint24(tickSpacing);
             return poolId;
         }
@@ -67,7 +67,7 @@ library PanopticMath {
             /// @dev this protects the tickSpacing and adds 20bits of entropy (1,048,576) when there's a poolId collision.
             uint64 extraEntropy = (uint64(
                 uint256(keccak256(abi.encodePacked(token0, token1, fee)))
-            ) >> 44) << 12;
+            ) >> 48) << 16;
             return basePoolId + extraEntropy;
         }
     }

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -22,7 +22,7 @@ library PanopticMath {
     // represents an option position of up to four legs as a sinlge ERC1155 tokenId
     using TokenId for uint256;
 
-    uint64 internal constant POOLID_MASK = 0x0000FFFFFFFFFFFF;
+    // masks 16-bit tickSpacing out of 64-bit [16-bit tickspacing][48-bit poolPattern] format poolId
     uint64 internal constant TICKSPACING_MASK = 0xFFFF000000000000;
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/periphery/PanopticHelper.sol
+++ b/contracts/periphery/PanopticHelper.sol
@@ -105,7 +105,7 @@ contract PanopticHelper {
         Leg[] memory legs = new Leg[](numLegs);
 
         uint64 poolId = tokenId.validate();
-        address UniswapV3Pool = address(SFPM.getUniswapV3PoolFromId(tokenId.univ3pool()));
+        address UniswapV3Pool = address(SFPM.getUniswapV3PoolFromId(tokenId.poolId()));
         for (uint256 i = 0; i < numLegs; ++i) {
             legs[i].poolId = poolId;
             legs[i].UniswapV3Pool = UniswapV3Pool;
@@ -306,7 +306,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // A strangle is composed of
         // 1. a call with a higher strike price
@@ -357,7 +357,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // A straddle is composed of
         // 1. a call with an identical strike price
@@ -390,7 +390,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // A call spread is composed of
         // 1. a long call with a lower strike price
@@ -423,7 +423,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // A put spread is composed of
         // 1. a long put with a higher strike price
@@ -458,7 +458,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // A call diagonal spread is composed of
         // 1. a long call with a (lower/higher) strike price and (lower/higher) width(expiry)
@@ -511,7 +511,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // A bearish diagonal spread is composed of
         // 1. a long put with a (higher/lower) strike price and (lower/higher) width(expiry)
@@ -810,7 +810,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // a call ratio spread is composed of
         // 1. a long call
@@ -843,7 +843,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // a put ratio spread is composed of
         // 1. a long put
@@ -876,7 +876,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // a call ZEBRA(zero extrinsic value back ratio spread) spread is composed of
         // 1. a short call
@@ -909,7 +909,7 @@ contract PanopticHelper {
         uint256 start
     ) public view returns (uint256 tokenId) {
         // Pool
-        tokenId = tokenId.addUniv3pool(SFPM.getPoolId(univ3pool));
+        tokenId = tokenId.addPoolId(SFPM.getPoolId(univ3pool));
 
         // a put ZEBRA(zero extrinsic value back ratio spread) spread is composed of
         // 1. a short put

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -371,15 +371,14 @@ library TokenId {
     /// @dev NOTE does not extract liquidity which is the third piece of information in a LiquidityChunk.
     /// @param self the option position id.
     /// @param legIndex the leg index of the position (in {0,1,2,3}).
-    /// @param tickSpacing the tick spacing of the underlying Univ3 pool.
     /// @return legLowerTick the lower tick of the leg/liquidity chunk.
     /// @return legUpperTick the upper tick of the leg/liquidity chunk.
     function asTicks(
         uint256 self,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) internal pure returns (int24 legLowerTick, int24 legUpperTick) {
         unchecked {
+            int24 tickSpacing = self.tickSpacing();
             int24 selfWidth = self.width(legIndex);
             int24 selfStrike = self.strike(legIndex);
 
@@ -555,12 +554,8 @@ library TokenId {
     /// @dev At least one long leg must be far-out-of-the-money (i.e. price is outside its range).
     /// @param self the option position Id (tokenId)
     /// @param currentTick the current tick corresponding to the current price in the Univ3 pool.
-    /// @param tickSpacing the tick spacing of the Univ3 pool used to compute the width of the chunks.
-    function validateIsExercisable(
-        uint256 self,
-        int24 currentTick,
-        int24 tickSpacing
-    ) internal pure {
+    function validateIsExercisable(uint256 self, int24 currentTick) internal pure {
+        int24 tickSpacing = self.tickSpacing();
         unchecked {
             uint256 numLegs = self.countLegs();
             for (uint256 i = 0; i < numLegs; ++i) {

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -88,7 +88,7 @@ library TokenId {
     /// @return the tickSpacing of the Uniswap v3 pool
     function tickSpacing(uint256 self) internal pure returns (int24) {
         unchecked {
-            return int24(uint24(self % 2 ** 12));
+            return int24(uint24(self % 2 ** 16));
         }
     }
 

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -83,6 +83,15 @@ library TokenId {
         }
     }
 
+    /// @notice The tickSpacing of this option position.
+    /// @param self the option position Id
+    /// @return the tickSpacing of the Uniswap v3 pool
+    function tickSpacing(uint256 self) internal pure returns (int24) {
+        unchecked {
+            return int24(uint24(self % 2 ** 12));
+        }
+    }
+
     /// @notice Get the asset basis for this position.
     /// @dev which token is the asset - can be token0 (return 0) or token1 (return 1)
     /// @param self the option position Id

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -74,10 +74,10 @@ library TokenId {
                                 DECODING
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The Uniswap v3 Pool pointed to by this option position.
+    /// @notice The poolId of this option position.
     /// @param self the option position Id
-    /// @return the poolId (Panoptic's uni v3 pool fingerprint) of the Uniswap v3 pool
-    function univ3pool(uint256 self) internal pure returns (uint64) {
+    /// @return the poolId (Panoptic's uni v3 pool fingerprint, contains the whole 64 bit sequence) of the Uniswap v3 pool
+    function poolId(uint256 self) internal pure returns (uint64) {
         unchecked {
             return uint64(self);
         }
@@ -164,7 +164,7 @@ library TokenId {
     /// @notice Add the Uniswap v3 Pool pointed to by this option position.
     /// @param self the option position Id.
     /// @return the tokenId with the Uniswap V3 pool added to it.
-    function addUniv3pool(uint256 self, uint64 _poolId) internal pure returns (uint256) {
+    function addPoolId(uint256 self, uint64 _poolId) internal pure returns (uint256) {
         unchecked {
             return self + uint256(_poolId);
         }
@@ -515,7 +515,7 @@ library TokenId {
             } // end for loop over legs
         }
 
-        return self.univ3pool();
+        return self.poolId();
     }
 
     /// @notice Make sure that an option position `self`'s all active legs are out-of-the-money (OTM). Revert if not.

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -75,7 +75,7 @@ library TokenId {
                                 DECODING
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The poolId of this option position.
+    /// @notice The full poolId (Uniswap pool identifier + pool pattern) of this option position.
     /// @param self the option position Id
     /// @return the poolId (Panoptic's uni v3 pool fingerprint, contains the whole 64 bit sequence with the tickSpacing) of the Uniswap v3 pool
     function poolId(uint256 self) internal pure returns (uint64) {
@@ -565,12 +565,11 @@ library TokenId {
     /// @param self the option position Id (tokenId)
     /// @param currentTick the current tick corresponding to the current price in the Univ3 pool.
     function validateIsExercisable(uint256 self, int24 currentTick) internal pure {
-        int24 tickSpacing = self.tickSpacing();
         unchecked {
             uint256 numLegs = self.countLegs();
             for (uint256 i = 0; i < numLegs; ++i) {
                 // compute the range of this leg/chunk
-                int24 range = (self.width(i) * tickSpacing) / 2;
+                int24 range = (self.width(i) * self.tickSpacing()) / 2;
                 // check if the price is outside this chunk
                 if (
                     (currentTick >= (self.strike(i) + range)) ||

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -18,7 +18,8 @@ import {Errors} from "@libraries/Errors.sol";
 /// @dev From the LSB to the MSB:
 /// ===== 1 time (same for all legs) ==============================================================
 ///      Property         Size      Offset      Comment
-/// (1) univ3pool        64bits     0bits      : first 8 bytes of the Uniswap v3 pool address (first 64 bits; little-endian), plus a pseudorandom number in the event of a collision
+/// (0) univ3pool        48bits     0bits      : first 6 bytes of the Uniswap v3 pool address (first 48 bits; little-endian), plus a pseudorandom number in the event of a collision
+/// (1) tickSpacing      16bits     48bits     : tickSpacing for the univ3pool. Up to 16 bits
 /// ===== 4 times (one for each leg) ==============================================================
 /// (2) asset             1bit      0bits      : Specifies the asset (0: token0, 1: token1)
 /// (3) optionRatio       7bits     1bits      : number of contracts per leg
@@ -35,11 +36,11 @@ import {Errors} from "@libraries/Errors.sol";
 ///                        (strike price tick of the 3rd leg)
 ///                            |             (width of the 2nd leg)
 ///                            |                   |
-/// (8)(7)(6)(5)(4)(3)(2)  (8)(7)(6)(5)(4)(3)(2)  (8)(7)(6)(5)(4)(3)(2)   (8)(7)(6)(5)(4)(3)(2)        (1)
-///  <---- 48 bits ---->    <---- 48 bits ---->    <---- 48 bits ---->     <---- 48 bits ---->    <- 64 bits ->
-///         Leg 4                  Leg 3                  Leg 2                   Leg 1         Univ3 Pool Address
+/// (8)(7)(6)(5)(4)(3)(2)  (8)(7)(6)(5)(4)(3)(2)  (8)(7)(6)(5)(4)(3)(2)   (8)(7)(6)(5)(4)(3)(2)        (1)           (0)
+///  <---- 48 bits ---->    <---- 48 bits ---->    <---- 48 bits ---->     <---- 48 bits ---->   <- 16 bits ->   <- 48 bits ->
+///         Leg 4                  Leg 3                  Leg 2                   Leg 1          tickSpacing    Univ3 Pool Address
 ///
-///  <--- most significant bit                                                       least significant bit --->
+///  <--- most significant bit                                                                             least significant bit --->
 ///
 /// @notice Some rules of how legs behave (we enforce these in a `validate()` function):
 ///   - a leg is inactive if it's not part of the position. Technically it means that all bits are zero.
@@ -76,7 +77,7 @@ library TokenId {
 
     /// @notice The poolId of this option position.
     /// @param self the option position Id
-    /// @return the poolId (Panoptic's uni v3 pool fingerprint, contains the whole 64 bit sequence) of the Uniswap v3 pool
+    /// @return the poolId (Panoptic's uni v3 pool fingerprint, contains the whole 64 bit sequence with the tickSpacing) of the Uniswap v3 pool
     function poolId(uint256 self) internal pure returns (uint64) {
         unchecked {
             return uint64(self);
@@ -88,7 +89,7 @@ library TokenId {
     /// @return the tickSpacing of the Uniswap v3 pool
     function tickSpacing(uint256 self) internal pure returns (int24) {
         unchecked {
-            return int24(uint24(self % 2 ** 16));
+            return int24(uint24((self >> 48) % 2 ** 16));
         }
     }
 
@@ -170,12 +171,21 @@ library TokenId {
                                 ENCODING
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Add the Uniswap v3 Pool pointed to by this option position.
+    /// @notice Add the Uniswap v3 Pool pointed to by this option position (contains the entropy and tickSpacing).
     /// @param self the option position Id.
     /// @return the tokenId with the Uniswap V3 pool added to it.
     function addPoolId(uint256 self, uint64 _poolId) internal pure returns (uint256) {
         unchecked {
             return self + uint256(_poolId);
+        }
+    }
+
+    /// @notice Add the Uniswap v3 Pool tickSpacing.
+    /// @param self the option position Id.
+    /// @return the tickSpacing of the Uniswap V3 pool.
+    function addTickSpacing(uint256 self, int24 _tickSpacing) internal pure returns (uint256) {
+        unchecked {
+            return self + (uint256(uint24(_tickSpacing)) << 48);
         }
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1019,7 +1019,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         );
 
         // sell as Bob
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+        tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
         /// calculate position size
@@ -1108,7 +1108,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // sell as Bob
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
@@ -1762,7 +1762,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 0, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
 
@@ -1794,7 +1794,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 0, 0, 0, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, 0, 0, 1, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
@@ -1955,7 +1955,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
 
@@ -1985,7 +1985,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // award corresponding shares
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 1, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 1, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 1, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
@@ -2121,7 +2121,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
 
@@ -2159,7 +2159,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // equal deposits for both collateral token pairs for testing purposes
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 0, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 0, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 0, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
@@ -2296,7 +2296,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
 
@@ -2335,7 +2335,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // award corresponding shares
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 1, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 1, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 1, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
@@ -2472,7 +2472,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
 
@@ -2520,7 +2520,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // award corresponding shares
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, isWETH, 0, 0, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
@@ -2660,7 +2660,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
 
@@ -2716,7 +2716,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // award corresponding shares
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, isWETH, 0, 0, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
@@ -2853,7 +2853,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             strike1 = strike;
             width1 = width;
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -2887,7 +2887,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // equal deposits for both collateral token pairs for testing purposes
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 0, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 0, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 0, 0, strike, width);
             positionIdList1.push(tokenId1);
 
@@ -2984,7 +2984,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             strike1 = strike;
             width1 = width;
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -3018,7 +3018,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // award corresponding shares
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 1, 1, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 1, 1, strike, width);
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 1, 0, strike, width);
             positionIdList1.push(tokenId1);
 
@@ -3117,7 +3117,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -3149,7 +3149,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // equal deposits for both collateral token pairs for testing purposes
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, width);
             positionIdList1.push(tokenId1);
 
             uint256 snapshot = vm.snapshot();
@@ -3320,7 +3320,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -3352,7 +3352,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // equal deposits for both collateral token pairs for testing purposes
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, width);
             positionIdList1.push(tokenId1);
 
             uint256 snapshot = vm.snapshot();
@@ -3510,7 +3510,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -3542,7 +3542,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // equal deposits for both collateral token pairs for testing purposes
             _mockMaxDeposit(Alice);
 
-            tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, width);
+            tokenId1 = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, width);
             positionIdList1.push(tokenId1);
 
             uint256 snapshot = vm.snapshot();
@@ -3702,7 +3702,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -3868,7 +3868,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -4042,7 +4042,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -4205,7 +4205,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size
@@ -4368,7 +4368,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 0
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             positionIdList.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
@@ -4526,7 +4526,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 0, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
@@ -4683,7 +4683,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 1
             );
 
-            tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
+            tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
 
             /// calculate position size

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -133,9 +133,6 @@ contract PanopticPoolHarness is PanopticPool {
         // Store the univ3Pool variable
         s_univ3pool = IUniswapV3Pool(uniswapPool);
 
-        // Store the tickSpacing variable
-        s_tickSpacing = uniswapPool.tickSpacing();
-
         unchecked {
             (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
             s_miniMedian =
@@ -1023,7 +1020,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionIdList.push(tokenId);
 
         /// calculate position size
-        (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+        (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
         positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
         _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -1767,7 +1764,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 18, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -2857,7 +2854,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             // must be minimum at least 2 so there is enough liquidity to buy
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 120));
@@ -2988,7 +2985,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             // must be minimum at least 2 so there is enough liquidity to buy
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 120));
@@ -3121,7 +3118,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -3324,7 +3321,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 120));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -3514,7 +3511,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -3706,7 +3703,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -3872,7 +3869,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -4046,7 +4043,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -4209,7 +4206,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -4687,7 +4684,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList.push(tokenId);
 
             /// calculate position size
-            (legLowerTick, legUpperTick) = tokenId.asTicks(0, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(0);
 
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
@@ -5416,7 +5413,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenType = tokenId.tokenType(i);
 
             // position bounds
-            (legLowerTick, legUpperTick) = tokenId.asTicks(i, tickSpacing);
+            (legLowerTick, legUpperTick) = tokenId.asTicks(i);
 
             // sqrt price of bounds
             sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(legLowerTick);
@@ -5472,12 +5469,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 );
             vm.assume(notional != 0 && notional < type(uint128).max);
 
-            uint256 amountsMoved = PanopticMath.getAmountsMoved(
-                tokenId,
-                positionSize,
-                i,
-                tickSpacing
-            );
+            uint256 amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, i);
             amountsMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
             /// simulate mint/burn
@@ -5604,15 +5596,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             int24 strike = _tokenId.strike(i);
             int24 width = _tokenId.width(i);
 
-            (legLowerTick, legUpperTick) = _tokenId.asTicks(i, tickSpacing);
+            (legLowerTick, legUpperTick) = _tokenId.asTicks(i);
 
             {
-                uint256 amountsMoved = PanopticMath.getAmountsMoved(
-                    _tokenId,
-                    positionSize,
-                    i,
-                    tickSpacing
-                );
+                uint256 amountsMoved = PanopticMath.getAmountsMoved(_tokenId, positionSize, i);
 
                 notionalMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
@@ -5706,18 +5693,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 if (isLong == 1) {
                     // spread requirement
                     {
-                        amountsMoved = PanopticMath.getAmountsMoved(
-                            _tokenId,
-                            positionSize,
-                            i,
-                            tickSpacing
-                        );
+                        amountsMoved = PanopticMath.getAmountsMoved(_tokenId, positionSize, i);
 
                         amountsMovedPartner = PanopticMath.getAmountsMoved(
                             _tokenId,
                             positionSize,
-                            partnerIndex,
-                            tickSpacing
+                            partnerIndex
                         );
 
                         // amount moved is right slot if tokenType=0, left slot otherwise
@@ -5807,12 +5788,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             if ((isLong != isLongP) || (tokenType == tokenTypeP)) continue;
 
-            amountsMoved = PanopticMath.getAmountsMoved(_tokenId, positionSize, i, tickSpacing);
+            amountsMoved = PanopticMath.getAmountsMoved(_tokenId, positionSize, i);
 
             strike = _tokenId.strike(i);
             width = _tokenId.width(i);
 
-            (legLowerTick, legUpperTick) = _tokenId.asTicks(i, tickSpacing);
+            (legLowerTick, legUpperTick) = _tokenId.asTicks(i);
             notionalMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
             {

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -223,7 +223,7 @@ contract Misctest is Test, PositionUtils {
         // L = 1
         uniPool.liquidity();
 
-        uint256 tokenId = uint256(0).addUniv3pool(PanopticMath.getPoolId(address(uniPool))).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
             0,
             1,
             1,

--- a/test/foundry/core/PanopticFactory.t.sol
+++ b/test/foundry/core/PanopticFactory.t.sol
@@ -397,10 +397,7 @@ contract PanopticFactoryTest is Test {
         address deployer,
         uint96 nonce
     ) internal pure returns (bytes32) {
-        return
-            bytes32(
-                abi.encodePacked(PanopticMath.getPoolId(v3Pool), uint64(uint160(deployer)), nonce)
-            );
+        return bytes32(abi.encodePacked(uint80(uint160(v3Pool)), uint80(uint160(deployer)), nonce));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -4311,12 +4311,7 @@ contract PanopticPoolTest is PositionUtils {
 
             medianSqrtPriceX96 = TickMath.getSqrtRatioAtTick(medianTick);
 
-            uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
-                tokenId,
-                i,
-                positionSize,
-                tickSpacing
-            );
+            uint256 liquidityChunk = PanopticMath.getLiquidityChunk(tokenId, i, positionSize);
 
             (currentValue0, currentValue1) = LiquidityAmounts.getAmountsForLiquidity(
                 TickMath.getSqrtRatioAtTick(currentTick),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1391,7 +1391,7 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.expectRevert(Errors.PoolAlreadyInitialized.selector);
 
-        pp.startPool(pool, tickSpacing, currentTick, token0, token1, ct0, ct1);
+        pp.startPool(pool, currentTick, token0, token1, ct0, ct1);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1897,8 +1897,7 @@ contract PanopticPoolTest is PositionUtils {
         {
             (int256 longAmounts, ) = PanopticMath.computeExercisedAmounts(
                 tokenId,
-                uint128(positionSize),
-                tickSpacing
+                uint128(positionSize)
             );
 
             assertApproxEqAbs(
@@ -1985,11 +1984,7 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         {
-            (int256 longAmounts, ) = PanopticMath.computeExercisedAmounts(
-                tokenId,
-                positionSize,
-                tickSpacing
-            );
+            (int256 longAmounts, ) = PanopticMath.computeExercisedAmounts(tokenId, positionSize);
 
             assertApproxEqAbs(
                 ct0.balanceOf(Alice),
@@ -2097,8 +2092,7 @@ contract PanopticPoolTest is PositionUtils {
         {
             (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
                 tokenId,
-                uint128(positionSize),
-                tickSpacing
+                uint128(positionSize)
             );
 
             assertApproxEqAbs(
@@ -2176,8 +2170,7 @@ contract PanopticPoolTest is PositionUtils {
         {
             (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
                 tokenId,
-                uint128(positionSize),
-                tickSpacing
+                uint128(positionSize)
             );
 
             assertApproxEqAbs(
@@ -2253,11 +2246,7 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         {
-            (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
-                tokenId,
-                positionSize,
-                tickSpacing
-            );
+            (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(tokenId, positionSize);
 
             assertApproxEqAbs(
                 ct1.balanceOf(Alice),
@@ -2356,11 +2345,7 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         {
-            (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
-                tokenId,
-                positionSize,
-                tickSpacing
-            );
+            (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(tokenId, positionSize);
 
             int256 amount0Moved = currentSqrtPriceX96 > sqrtUpper
                 ? int256(0)
@@ -2449,11 +2434,7 @@ contract PanopticPoolTest is PositionUtils {
 
         changePrank(Alice);
 
-        (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
-            tokenId,
-            positionSize,
-            tickSpacing
-        );
+        (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(tokenId, positionSize);
 
         {
             uint256[] memory posIdList = new uint256[](1);
@@ -2582,8 +2563,7 @@ contract PanopticPoolTest is PositionUtils {
 
         (, int256 shortAmountsSold) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            positionSizes[0],
-            tickSpacing
+            positionSizes[0]
         );
 
         changePrank(Seller);
@@ -2626,8 +2606,7 @@ contract PanopticPoolTest is PositionUtils {
 
         (int256 longAmounts, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            positionSizes[1],
-            tickSpacing
+            positionSizes[1]
         );
 
         {
@@ -2903,11 +2882,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         // deposit commission so we can reach collateral check
-        (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
-            tokenId,
-            positionSize,
-            tickSpacing
-        );
+        (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(tokenId, positionSize);
 
         changePrank(Charlie);
 
@@ -3016,11 +2991,7 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         {
-            (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
-                tokenId,
-                positionSize,
-                tickSpacing
-            );
+            (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(tokenId, positionSize);
 
             assertApproxEqAbs(
                 ct0.balanceOf(Alice),
@@ -3150,8 +3121,7 @@ contract PanopticPoolTest is PositionUtils {
 
         (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            uint128(positionSize),
-            tickSpacing
+            uint128(positionSize)
         );
 
         int256[2] memory notionalVals = [
@@ -3301,8 +3271,7 @@ contract PanopticPoolTest is PositionUtils {
 
         (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            uint128(positionSize),
-            tickSpacing
+            uint128(positionSize)
         );
 
         int256[2] memory notionalVals = [
@@ -3496,8 +3465,7 @@ contract PanopticPoolTest is PositionUtils {
 
         (, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenIds[0],
-            uint128(positionSize),
-            tickSpacing
+            uint128(positionSize)
         );
 
         int256[2] memory notionalVals = [
@@ -4076,8 +4044,7 @@ contract PanopticPoolTest is PositionUtils {
 
         (int256 longAmounts, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            positionSize,
-            tickSpacing
+            positionSize
         );
 
         uint256[2] memory commissionFeeAmounts = [
@@ -4268,8 +4235,7 @@ contract PanopticPoolTest is PositionUtils {
 
         (int256 longAmounts, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            positionSize,
-            tickSpacing
+            positionSize
         );
 
         pp.mintOptions(posIdList, positionSize, type(uint64).max, 0, 0);

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1407,25 +1407,11 @@ contract PanopticPoolTest is PositionUtils {
         // and ensure that change was applied
         assertEq(
             vm.load(address(ct0), bytes32(uint256(9))),
-            bytes32(
-                uint256(
-                    uint256(uint24(tickSpacing)) +
-                        (uint256(fee / 100) << 24) +
-                        (2230 << 48) +
-                        (10 << 72)
-                )
-            )
-        ); // tickSpacing + poolFee + tickDeviation + commission fee
+            bytes32(uint256((uint256(fee / 100)) + (2230 << 24) + (10 << 48)))
+        ); // poolFee + tickDeviation + commission fee
         assertEq(
             vm.load(address(ct1), bytes32(uint256(9))),
-            bytes32(
-                uint256(
-                    uint256(uint24(tickSpacing)) +
-                        (uint256(fee / 100) << 24) +
-                        (2230 << 48) +
-                        (10 << 72)
-                )
-            )
+            bytes32(uint256((uint256(fee / 100)) + (2230 << 24) + (10 << 48)))
         );
         assertEq(
             vm.load(address(ct0), bytes32(uint256(10))),
@@ -1494,8 +1480,7 @@ contract PanopticPoolTest is PositionUtils {
             vm.load(address(ct0), bytes32(uint256(9))),
             bytes32(
                 uint256(
-                    uint256(uint24(tickSpacing)) +
-                        (uint256(fee / 100) << 24) +
+                    (uint256(fee / 100)) +
                         (uint256(
                             uint128(
                                 int128(2230) +
@@ -1506,8 +1491,8 @@ contract PanopticPoolTest is PositionUtils {
                                     (int128(6510) * (int128(sellCollateralRatio) - 2000) ** 3) /
                                     10_000 ** 3
                             )
-                        ) << 48) +
-                        (uint256(uint128(parameters[0])) << 72)
+                        ) << 24) +
+                        (uint256(uint128(parameters[0])) << 48)
                 )
             )
         ); // tickSpacing + poolFee + tickDeviation + commission fee
@@ -1515,8 +1500,7 @@ contract PanopticPoolTest is PositionUtils {
             vm.load(address(ct1), bytes32(uint256(9))),
             bytes32(
                 uint256(
-                    uint256(uint24(tickSpacing)) +
-                        (uint256(fee / 100) << 24) +
+                    (uint256(fee / 100)) +
                         (uint256(
                             uint128(
                                 int128(2230) +
@@ -1527,8 +1511,8 @@ contract PanopticPoolTest is PositionUtils {
                                     (int128(6510) * (int128(sellCollateralRatio) - 2000) ** 3) /
                                     10_000 ** 3
                             )
-                        ) << 48) +
-                        (uint256(uint128(parameters[0])) << 72)
+                        ) << 24) +
+                        (uint256(uint128(parameters[0])) << 48)
                 )
             )
         );

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1607,19 +1607,10 @@ contract PanopticPoolTest is PositionUtils {
         populatePositionData([width, width2], [strike, strike2], positionSizeSeeds);
 
         // leg 1
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // leg 2
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -1729,16 +1720,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionDataLarge(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -1787,19 +1769,10 @@ contract PanopticPoolTest is PositionUtils {
         populatePositionData([width, width2], [strike, strike2], positionSizeSeeds);
 
         // leg 1
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // leg 2
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -1869,16 +1842,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -1888,7 +1852,7 @@ contract PanopticPoolTest is PositionUtils {
 
         changePrank(Alice);
 
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
+        tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
         posIdList[0] = tokenId;
 
         // type(uint64).max = no limit, ensure the operation works given the changed liquidity limit
@@ -1967,16 +1931,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -1985,7 +1940,7 @@ contract PanopticPoolTest is PositionUtils {
 
         changePrank(Alice);
 
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
+        tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
         posIdList[0] = tokenId;
 
         // type(uint64).max = no limit, ensure the operation works given the changed liquidity limit
@@ -2065,16 +2020,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -2083,7 +2029,7 @@ contract PanopticPoolTest is PositionUtils {
 
         changePrank(Alice);
 
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
+        tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.EffectiveLiquidityAboveThreshold.selector);
@@ -2108,16 +2054,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -2196,16 +2133,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -2280,16 +2208,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -2368,16 +2287,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256 expectedSwap0;
         {
@@ -2508,7 +2418,7 @@ contract PanopticPoolTest is PositionUtils {
         populatePositionData([width0, width1], [strike0, strike1], positionSizeSeed);
 
         // put leg
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -2659,7 +2569,7 @@ contract PanopticPoolTest is PositionUtils {
         populatePositionDataLong([width0, width1], [strike0, strike1], positionSizeSeeds);
 
         // sell short companion to long option
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -2686,7 +2596,7 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         // put leg
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike0, width0);
+        tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike0, width0);
         // call leg (long)
         tokenId = tokenId.addLeg(1, 1, isWETH, 1, 0, 1, strike1, width1);
 
@@ -2837,16 +2747,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -2873,16 +2774,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -2909,7 +2801,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId + 1).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId + 1).addLeg(
             0,
             1,
             isWETH,
@@ -2945,16 +2837,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -2987,16 +2870,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -3023,16 +2897,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -3072,7 +2937,7 @@ contract PanopticPoolTest is PositionUtils {
         uint248 positionsHash;
         for (uint256 i = 0; i < 33; i++) {
             tokenIds.push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     i + 1, // increment the options ratio as an easy way to get unique tokenIds
                     isWETH,
@@ -3118,16 +2983,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -3196,16 +3052,7 @@ contract PanopticPoolTest is PositionUtils {
         // take snapshot for swap simulation
         vm.snapshot();
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         int256[2] memory amount0Moveds;
         int256[2] memory amount1Moveds;
@@ -3355,16 +3202,7 @@ contract PanopticPoolTest is PositionUtils {
         // take snapshot for swap simulation
         vm.snapshot();
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         int256[2] memory amount0Moveds;
         int256[2] memory amount1Moveds;
@@ -3518,9 +3356,9 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        tokenIds.push(uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width));
+        tokenIds.push(uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width));
 
-        tokenIds.push(uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width));
+        tokenIds.push(uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width));
 
         // take snapshot for swap simulation
         vm.snapshot();
@@ -3731,19 +3569,10 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         // leg 1
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // leg 2
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -3837,7 +3666,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[0].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -3856,7 +3685,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[1].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -4008,16 +3837,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -4064,19 +3884,10 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         // leg 1
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // leg 2
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -4087,7 +3898,7 @@ contract PanopticPoolTest is PositionUtils {
             width2
         );
         // leg 3
-        uint256 tokenId3 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId3 = uint256(0).addPoolId(poolId).addLeg(
             0,
             2,
             isWETH,
@@ -4098,7 +3909,7 @@ contract PanopticPoolTest is PositionUtils {
             width
         );
         // leg 4
-        uint256 tokenId4 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId4 = uint256(0).addPoolId(poolId).addLeg(
             0,
             3,
             isWETH,
@@ -4223,7 +4034,7 @@ contract PanopticPoolTest is PositionUtils {
         // this is a long option; so need to sell before it can be bought (let's say 2x position size for now)
         changePrank(Seller);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId);
+        uint256 tokenId = uint256(0).addPoolId(poolId);
 
         for (uint256 i = 0; i < numLegs; ++i) {
             tokenId = tokenId.addLeg(i, 1, isWETH, 0, tokenTypes[i], i, strikes[i], widths[i]);
@@ -4246,7 +4057,7 @@ contract PanopticPoolTest is PositionUtils {
         changePrank(Alice);
 
         // reset tokenId so we can fill for what we're actually testing (the bought option)
-        tokenId = uint256(0).addUniv3pool(poolId);
+        tokenId = uint256(0).addPoolId(poolId);
 
         for (uint256 i = 0; i < numLegs; ++i) {
             tokenId = tokenId.addLeg(
@@ -4423,7 +4234,7 @@ contract PanopticPoolTest is PositionUtils {
         // this is a long option; so need to sell before it can be bought (let's say 2x position size for now)
         changePrank(Seller);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId);
+        uint256 tokenId = uint256(0).addPoolId(poolId);
 
         for (uint256 i = 0; i < numLegs; ++i) {
             tokenId = tokenId.addLeg(i, 1, isWETH, 0, tokenTypes[i], i, strikes[i], widths[i]);
@@ -4438,7 +4249,7 @@ contract PanopticPoolTest is PositionUtils {
         changePrank(Alice);
 
         // reset tokenId so we can fill for what we're actually testing (the bought option)
-        tokenId = uint256(0).addUniv3pool(poolId);
+        tokenId = uint256(0).addPoolId(poolId);
 
         for (uint256 i = 0; i < numLegs; ++i) {
             tokenId = tokenId.addLeg(
@@ -4761,7 +4572,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[0].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -4782,7 +4593,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[1].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -4955,7 +4766,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[0].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -4976,7 +4787,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[1].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -5146,7 +4957,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[0].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -5167,7 +4978,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[1].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -5229,16 +5040,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData([width, width2], [strike, strike2], positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -5248,7 +5050,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList = new uint256[](2);
         posIdList[0] = tokenId;
 
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -5290,7 +5092,7 @@ contract PanopticPoolTest is PositionUtils {
 
         uint256 tokenId;
 
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -5460,7 +5262,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[0].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -5481,7 +5283,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[1].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -5713,16 +5515,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData([width, width2], [strike, strike2], positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
         posIdList[0] = tokenId;
@@ -5732,7 +5525,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList = new uint256[](2);
         posIdList[0] = tokenId;
 
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -5774,16 +5567,7 @@ contract PanopticPoolTest is PositionUtils {
 
         populatePositionData(width, strike, positionSizeSeed);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         uint256[] memory posIdList = new uint256[](1);
 
@@ -5885,7 +5669,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[0].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,
@@ -5906,7 +5690,7 @@ contract PanopticPoolTest is PositionUtils {
 
         for (uint256 i = 0; i < numLegs; ++i) {
             $posIdLists[1].push(
-                uint256(0).addUniv3pool(poolId).addLeg(
+                uint256(0).addPoolId(poolId).addLeg(
                     0,
                     1,
                     isWETH,

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -1007,16 +1007,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         (int256 totalCollected, int256 totalSwapped, int24 newTick) = sfpm.mintTokenizedPosition(
             tokenId,
@@ -1071,16 +1062,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         (int256 totalCollected, int256 totalSwapped, int24 newTick) = sfpm.mintTokenizedPosition(
             tokenId,
@@ -1144,7 +1126,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         positionSize = positionSize / uint128(shortRatio);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             shortRatio,
             isWETH,
@@ -1267,16 +1249,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         (int256 totalCollected, int256 totalSwapped, int24 newTick) = sfpm.mintTokenizedPosition(
             tokenId,
@@ -1331,16 +1304,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         int256 amount0Required = SqrtPriceMath.getAmount0Delta(
             sqrtLower < currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtLower,
@@ -1430,16 +1394,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         int256 amount0Moved = SqrtPriceMath.getAmount0Delta(
             sqrtLower < currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtLower,
@@ -1540,7 +1495,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
         // put leg
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -1656,7 +1611,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionDataLong([width0, width1], [strike0, strike1], positionSizeSeed);
 
         // sell short companion to long option
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -1676,7 +1631,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
         // put leg
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike0, width0);
+        tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike0, width0);
 
         // call leg
         tokenId = tokenId.addLeg(1, 1, isWETH, 1, 0, 1, strike1, width1);
@@ -1781,16 +1736,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         lowerBound = bound(lowerBound, TickMath.MIN_TICK, currentTick - 1);
         upperBound = bound(upperBound, currentTick + 1, TickMath.MAX_TICK);
@@ -1822,16 +1768,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         vm.expectRevert(Errors.OptionsBalanceZero.selector);
 
@@ -1880,7 +1817,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         // make sure actual liquidity being added is nonzero
         vm.assume(expectedLiq > 0);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -1927,16 +1864,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         vm.expectRevert(Errors.UniswapPoolNotInitialized.selector);
 
@@ -1968,16 +1896,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         lowerBound = bound(lowerBound, TickMath.MIN_TICK, TickMath.MAX_TICK);
         upperBound = bound(
@@ -2023,7 +1942,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         positionSize = positionSize / uint128(shortRatio);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             shortRatio,
             isWETH,
@@ -2069,16 +1988,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed, positionSizeBurnSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -2160,16 +2070,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed, positionSizeBurnSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         // we must calculate both values at mint and burn, since different amounts with different impacts will be swapped
         // required at mint is negative because we need that exact amount hence "required"
@@ -2377,7 +2278,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             );
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             shortRatio,
             isWETH,
@@ -2528,16 +2429,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -2619,16 +2511,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -2637,7 +2520,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MAX_TICK
         );
 
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -2768,16 +2651,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -2811,7 +2685,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId1 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -2829,7 +2703,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MAX_TICK
         );
 
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -2873,7 +2747,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId1 = uint256(0).addPoolId(poolId).addLeg(
             0,
             bound(optionRatio, 1, 127),
             isWETH,
@@ -2917,16 +2791,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeeds);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -3002,16 +2867,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            1,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -3219,7 +3075,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, type(uint128).max);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -3319,7 +3175,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId1 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId1 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -3633,7 +3489,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, type(uint256).max);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenIdShort = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenIdShort = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -3651,7 +3507,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MAX_TICK
         );
 
-        uint256 tokenIdLong = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenIdLong = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -3743,16 +3599,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // replace the Uniswap pool with a mock contract that can answer some queries correctly,
         // but will attempt to callback with mintTokenizedPosition on any other call
@@ -3803,16 +3650,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // replace the Uniswap pool with a mock contract that can answer some queries correctly,
         // but will attempt to callback with mintTokenizedPosition on any other call
@@ -3863,16 +3701,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // replace the Uniswap pool with a mock contract that can answer some queries correctly,
         // but will attempt to callback with mintTokenizedPosition on any other call
@@ -3923,16 +3752,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         // allow Alice to try to initialize and then reenter when getting the onERC1155Received callback
         vm.etch(address(Alice), address(new Reenter1155Initialize()).code);
@@ -3968,16 +3788,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, positionSizeSeed, positionSizeBurnSeed);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -4087,16 +3898,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         populatePositionData(width, strike, 0, 0);
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
-            0,
-            1,
-            isWETH,
-            0,
-            0,
-            0,
-            strike,
-            width
-        );
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width);
 
         sfpm.mintTokenizedPosition(
             tokenId,
@@ -4105,7 +3907,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MAX_TICK
         );
 
-        tokenId = uint256(0).addUniv3pool(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
+        tokenId = uint256(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width);
 
         for (uint256 i = 0; i < 10; i++) {
             sfpm.mintTokenizedPosition(tokenId, uint128(922), TickMath.MIN_TICK, TickMath.MAX_TICK);

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -43,7 +43,7 @@ contract UniswapV3FactoryMock {
     uint160 nextPool;
 
     function getPool(address, address, uint24) external view returns (address) {
-        return address(nextPool);
+        return address(nextPool << 24);
     }
 
     function increment() external {
@@ -938,33 +938,44 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             IUniswapV3Factory(address(factoryMock))
         );
 
+        UniPoolPriceMock pm = new UniPoolPriceMock();
+        uint64 poolIdNew = (200 << 48);
         for (uint160 i = 0; i < 100; i++) {
-            // Increments the returned address by 1 every call
-            // Do this call first so we start with address(1) to avoid errors
             factoryMock.increment();
 
+            vm.etch(address((i + 1) << 24), address(pm).code);
+
+            pm = UniPoolPriceMock(address((i + 1) << 24));
+            pm.construct(
+                UniPoolPriceMock.Slot0({
+                    sqrtPriceX96: 0,
+                    tick: 0,
+                    observationIndex: 0,
+                    observationCardinality: 0,
+                    observationCardinalityNext: 0,
+                    feeProtocol: 0,
+                    unlocked: false
+                }),
+                address(0),
+                address(0),
+                0,
+                200
+            );
+
+            // etch tickSpacing
             // These values are zero at this point, but they are ignored by the factory mock
             sfpm_t.initializeAMMPool(token0, token1, fee);
 
+            if (i != 0) {
+                poolIdNew = PanopticMath.incrementPoolPattern(poolIdNew);
+            }
+
             // Check that the pool address is set correctly
-            // Addresses output from the factory mock start at 1 to avoid errors so we need to add that to the address
-            assertEq(
-                address(
-                    sfpm_t
-                        .poolContext(
-                            i == 0 ? 0 : PanopticMath.getFinalPoolId(0, token0, token1, fee)
-                        )
-                        .pool
-                ),
-                address(i + 1)
-            );
+            assertEq(address(sfpm_t.poolContext(poolIdNew).pool), address((i + 1) << 24));
 
             // Check that the pool ID is set correctly
             // Addresses output from the factory mock start at 1 to avoid errors so we need to add that to the address
-            assertEq(
-                sfpm_t.addrToPoolId(address(i + 1)),
-                i == 0 ? 2 ** 255 : PanopticMath.getFinalPoolId(0, token0, token1, fee) + 2 ** 255
-            );
+            assertEq(sfpm_t.addrToPoolId(address((i + 1) << 24)), 2 ** 255 + poolIdNew);
 
             token0 = address(uint160(token0) + 1);
         }

--- a/test/foundry/libraries/FeesCalc.t.sol
+++ b/test/foundry/libraries/FeesCalc.t.sol
@@ -93,8 +93,7 @@ contract FeesCalcTest is Test, PositionUtils {
         uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
             tokenId,
             0,
-            uint128(harness.userBalance(tokenId)),
-            tickSpacing
+            uint128(harness.userBalance(tokenId))
         );
 
         (uint256 amount0, uint256 amount1) = LiquidityAmounts.getAmountsForLiquidity(
@@ -172,12 +171,7 @@ contract FeesCalcTest is Test, PositionUtils {
             );
         }
 
-        uint256 expectedLiquidityChunk = PanopticMath.getLiquidityChunk(
-            tokenId,
-            0,
-            positionSize,
-            tickSpacing
-        );
+        uint256 expectedLiquidityChunk = PanopticMath.getLiquidityChunk(tokenId, 0, positionSize);
 
         int256 expectedFeesPerToken = harness.calculateAMMSwapFeesLiquidityChunk(
             selectedPool,
@@ -225,12 +219,7 @@ contract FeesCalcTest is Test, PositionUtils {
             );
         }
 
-        uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
-            tokenId,
-            0,
-            positionSize,
-            tickSpacing
-        );
+        uint256 liquidityChunk = PanopticMath.getLiquidityChunk(tokenId, 0, positionSize);
 
         (uint256 ammFeesPerLiqToken0X128, uint256 ammFeesPerLiqToken1X128) = harness
             .getAMMSwapFeesPerLiquidityCollected(

--- a/test/foundry/libraries/FeesCalc.t.sol
+++ b/test/foundry/libraries/FeesCalc.t.sol
@@ -257,7 +257,13 @@ contract FeesCalcTest is Test, PositionUtils {
         int256 strikeSeed,
         int256 widthSeed
     ) internal returns (uint256) {
-        uint256 tokenId;
+        tickSpacing = selectedPool.tickSpacing();
+        // add univ3pool to token
+        uint64 poolId = uint64(
+            ((uint64(bound(poolIdSeed, 1, type(uint64).max)) >> 16)) +
+                (uint64(uint24(tickSpacing)) << 48)
+        );
+        uint256 tokenId = uint256(poolId);
 
         for (uint256 legIndex; legIndex < totalLegs; legIndex++) {
             // We don't want the same data for each leg
@@ -286,13 +292,10 @@ contract FeesCalcTest is Test, PositionUtils {
             /// bound inputs
             int24 strike;
             int24 width;
-            uint64 poolId;
             {
                 // the following must be at least 1
-                poolId = uint64(bound(poolIdSeed, 1, type(uint64).max));
                 optionRatioSeed = bound(optionRatioSeed, 1, 127);
 
-                tickSpacing = selectedPool.tickSpacing();
                 width = int24(bound(widthSeed, 1, 4094));
                 int24 oneSidedRange = (width * tickSpacing) / 2;
 
@@ -317,9 +320,6 @@ contract FeesCalcTest is Test, PositionUtils {
             }
 
             {
-                // add univ3pool to token
-                tokenId = tokenId.addPoolId(poolId);
-
                 // add a leg
                 // no risk partner by default (will reference its own leg index)
                 tokenId = tokenId.addLeg(

--- a/test/foundry/libraries/FeesCalc.t.sol
+++ b/test/foundry/libraries/FeesCalc.t.sol
@@ -329,7 +329,7 @@ contract FeesCalcTest is Test, PositionUtils {
 
             {
                 // add univ3pool to token
-                tokenId = tokenId.addUniv3pool(poolId);
+                tokenId = tokenId.addPoolId(poolId);
 
                 // add a leg
                 // no risk partner by default (will reference its own leg index)

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -122,12 +122,7 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         uint256 expectedLiquidityChunk = uint256(0).createChunk(tickLower, tickUpper, legLiquidity);
-        uint256 returnedLiquidityChunk = harness.getLiquidityChunk(
-            tokenId,
-            0,
-            positionSize,
-            tickSpacing
-        );
+        uint256 returnedLiquidityChunk = harness.getLiquidityChunk(tokenId, 0, positionSize);
 
         assertEq(expectedLiquidityChunk, returnedLiquidityChunk);
     }
@@ -193,12 +188,7 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         uint256 expectedLiquidityChunk = uint256(0).createChunk(tickLower, tickUpper, legLiquidity);
-        uint256 returnedLiquidityChunk = harness.getLiquidityChunk(
-            tokenId,
-            0,
-            positionSize,
-            tickSpacing
-        );
+        uint256 returnedLiquidityChunk = harness.getLiquidityChunk(tokenId, 0, positionSize);
 
         assertEq(expectedLiquidityChunk, returnedLiquidityChunk);
     }

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -1387,9 +1387,8 @@ contract PanopticMathTest is Test, PositionUtils {
             tokenId = tokenId.addLeg(0, optionRatio, asset, 0, 1, 0, strike, width);
         }
 
-        console2.log("tokenId", tokenId);
-
         uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
+        vm.assume(int256(uint256(contractsNotional.leftSlot())) < type(int128).max);
 
         int256 expectedShorts = int256(0).toLeftSlot(Math.toInt128(contractsNotional.leftSlot()));
         (int256 returnedLongs, int256 returnedShorts) = harness.calculateIOAmounts(

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -105,6 +105,7 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, 0, isLong, tokenType, 0, strike, width);
         }
 
@@ -171,6 +172,7 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, 1, isLong, tokenType, 0, strike, width);
         }
 
@@ -193,9 +195,13 @@ contract PanopticMathTest is Test, PositionUtils {
         assertEq(expectedLiquidityChunk, returnedLiquidityChunk);
     }
 
-    function test_Success_getPoolId(address univ3pool) public {
-        uint64 poolId = uint64(uint160(univ3pool) >> 96);
-        assertEq(poolId, harness.getPoolId(univ3pool));
+    function test_Success_getPoolId(uint8 index) public {
+        // bound fuzzed tick
+        selectedPool = pools[bound(index, 0, 2)]; // resue position size as seed
+        tickSpacing = selectedPool.tickSpacing();
+        uint64 poolId = uint64(uint160(address(selectedPool)) >> 112) +
+            (uint64(uint24(tickSpacing)) << 48);
+        assertEq(poolId, harness.getPoolId(address(selectedPool)));
     }
 
     function test_Success_getFinalPoolId(
@@ -208,8 +214,9 @@ contract PanopticMathTest is Test, PositionUtils {
         uint24 fee = [30, 60, 100][bound(feeSeed, 0, 2)];
         unchecked {
             finalPoolId =
-                basePoolId +
-                (uint64(uint256(keccak256(abi.encodePacked(token0, token1, fee)))) >> 32);
+                ((basePoolId >> 32) << 32) +
+                (uint64(uint256(keccak256(abi.encodePacked(basePoolId, token0, token1, fee)))) %
+                    2 ** 32);
         }
 
         assertEq(finalPoolId, harness.getFinalPoolId(basePoolId, token0, token1, fee));
@@ -263,20 +270,19 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, asset, isLong, tokenType, 0, strike, width);
         }
 
         (int256 expectedLongs, int256 expectedShorts) = harness.calculateIOAmounts(
             tokenId,
             positionSize,
-            0,
-            tickSpacing
+            0
         );
 
         (int256 returnedLongs, int256 returnedShorts) = harness.computeExercisedAmounts(
             tokenId,
-            positionSize,
-            tickSpacing
+            positionSize
         );
 
         assertEq(expectedLongs, returnedLongs);
@@ -335,6 +341,7 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, asset, isLong, tokenType, 0, strike, width);
         }
 
@@ -392,6 +399,7 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, asset, isLong, tokenType, 0, strike, width);
         }
 
@@ -1116,6 +1124,7 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, 0, isLong, tokenType, 0, strike, width);
         }
 
@@ -1126,12 +1135,7 @@ contract PanopticMathTest is Test, PositionUtils {
         uint128 amount1 = harness.convertNotional(amount0, tickLower, tickUpper, tokenId.asset(0));
         uint256 expectedContractsNotional = uint256(0).toRightSlot(amount0).toLeftSlot(amount1);
 
-        uint256 returnedContractsNotional = harness.getAmountsMoved(
-            tokenId,
-            positionSize,
-            0,
-            tickSpacing
-        );
+        uint256 returnedContractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
         assertEq(expectedContractsNotional, returnedContractsNotional);
     }
 
@@ -1180,6 +1184,7 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, 1, isLong, tokenType, 0, strike, width);
         }
 
@@ -1190,12 +1195,7 @@ contract PanopticMathTest is Test, PositionUtils {
         uint128 amount0 = harness.convertNotional(amount1, tickLower, tickUpper, tokenId.asset(0));
         uint256 expectedContractsNotional = uint256(0).toRightSlot(amount0).toLeftSlot(amount1);
 
-        uint256 returnedContractsNotional = harness.getAmountsMoved(
-            tokenId,
-            positionSize,
-            0,
-            tickSpacing
-        );
+        uint256 returnedContractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
         assertEq(expectedContractsNotional, returnedContractsNotional);
     }
 
@@ -1242,18 +1242,18 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, asset, 0, 0, 0, strike, width);
         }
 
-        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0, tickSpacing);
+        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
         vm.assume(int256(uint256(contractsNotional.rightSlot())) < type(int128).max);
 
         int256 expectedShorts = int256(0).toRightSlot(Math.toInt128(contractsNotional.rightSlot()));
         (int256 returnedLongs, int256 returnedShorts) = harness.calculateIOAmounts(
             tokenId,
             positionSize,
-            0,
-            tickSpacing
+            0
         );
 
         assertEq(expectedShorts, returnedShorts);
@@ -1302,6 +1302,7 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, asset, 1, 0, 0, strike, width);
         }
 
@@ -1318,15 +1319,14 @@ contract PanopticMathTest is Test, PositionUtils {
             )
         );
 
-        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0, tickSpacing);
+        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
         vm.assume(int256(uint256(contractsNotional.rightSlot())) < type(int128).max);
 
         int256 expectedLongs = int256(0).toRightSlot(Math.toInt128(contractsNotional.rightSlot()));
         (int256 returnedLongs, int256 returnedShorts) = harness.calculateIOAmounts(
             tokenId,
             positionSize,
-            0,
-            tickSpacing
+            0
         );
 
         assertEq(0, returnedShorts);
@@ -1340,14 +1340,12 @@ contract PanopticMathTest is Test, PositionUtils {
         int24 width,
         uint64 positionSize
     ) public {
-        vm.assume(positionSize != 0);
+        positionSize = uint64(bound(positionSize, 1, type(uint64).max));
         uint256 tokenId;
 
         // contruct a tokenId
         {
             uint256 optionRatio = bound(optionRatio, 1, 127);
-
-            vm.assume(positionSize * uint128(optionRatio) < type(uint56).max);
 
             // the following are all 1 bit so mask them:
             uint8 MASK = 0x1; // takes first 1 bit of the uint16
@@ -1374,18 +1372,19 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, asset, 0, 1, 0, strike, width);
         }
 
-        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0, tickSpacing);
+        console2.log("tokenId", tokenId);
 
-        vm.assume(int256(uint256(contractsNotional.leftSlot())) < type(int128).max);
+        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
+
         int256 expectedShorts = int256(0).toLeftSlot(Math.toInt128(contractsNotional.leftSlot()));
         (int256 returnedLongs, int256 returnedShorts) = harness.calculateIOAmounts(
             tokenId,
             positionSize,
-            0,
-            tickSpacing
+            0
         );
 
         assertEq(expectedShorts, returnedShorts);
@@ -1434,10 +1433,11 @@ contract PanopticMathTest is Test, PositionUtils {
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
             strike = int24(strike * tickSpacing + strikeOffset);
 
+            tokenId = uint256(uint24(tickSpacing)) << 48;
             tokenId = tokenId.addLeg(0, optionRatio, asset, 1, 1, 0, strike, width);
         }
 
-        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0, tickSpacing);
+        uint256 contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
 
         vm.assume(int256(uint256(contractsNotional.leftSlot())) < type(int128).max);
         int256 expectedLongs = int256(0).toLeftSlot(Math.toInt128(contractsNotional.leftSlot()));
@@ -1445,8 +1445,7 @@ contract PanopticMathTest is Test, PositionUtils {
         (int256 returnedLongs, int256 returnedShorts) = harness.calculateIOAmounts(
             tokenId,
             positionSize,
-            0,
-            tickSpacing
+            0
         );
 
         assertEq(0, returnedShorts);

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -21,6 +21,7 @@ import {FixedPoint128} from "v3-core/libraries/FixedPoint128.sol";
 import {FullMath} from "v3-core/libraries/FullMath.sol";
 // Test util
 import {PositionUtils} from "../testUtils/PositionUtils.sol";
+import {UniPoolPriceMock} from "../testUtils/PriceMocks.sol";
 
 /**
  * Test the PanopticMath functionality with Foundry and Fuzzing.
@@ -195,31 +196,41 @@ contract PanopticMathTest is Test, PositionUtils {
         assertEq(expectedLiquidityChunk, returnedLiquidityChunk);
     }
 
-    function test_Success_getPoolId(uint8 index) public {
-        // bound fuzzed tick
-        selectedPool = pools[bound(index, 0, 2)]; // resue position size as seed
-        tickSpacing = selectedPool.tickSpacing();
-        uint64 poolId = uint64(uint160(address(selectedPool)) >> 112) +
-            (uint64(uint24(tickSpacing)) << 48);
-        assertEq(poolId, harness.getPoolId(address(selectedPool)));
+    function test_Success_getPoolId(address univ3pool, uint256 _tickSpacing) public {
+        _tickSpacing = bound(_tickSpacing, 0, uint16(type(int16).max));
+
+        UniPoolPriceMock pm = new UniPoolPriceMock();
+        vm.etch(univ3pool, address(pm).code);
+        pm = UniPoolPriceMock(univ3pool);
+
+        pm.construct(
+            UniPoolPriceMock.Slot0({
+                sqrtPriceX96: 0,
+                tick: 0,
+                observationIndex: 0,
+                observationCardinality: 0,
+                observationCardinalityNext: 0,
+                feeProtocol: 0,
+                unlocked: false
+            }),
+            address(0),
+            address(0),
+            0,
+            int24(uint24(_tickSpacing))
+        );
+        uint64 poolPattern = uint64(uint160(univ3pool) >> 112);
+        _tickSpacing <<= 48;
+        assertEq(_tickSpacing + poolPattern, harness.getPoolId(univ3pool));
     }
 
-    function test_Success_getFinalPoolId(
-        uint64 basePoolId,
-        address token0,
-        address token1,
-        uint8 feeSeed
-    ) public {
-        uint64 finalPoolId;
-        uint24 fee = [30, 60, 100][bound(feeSeed, 0, 2)];
+    function test_Success_incrementPoolPattern(uint64 poolId) public {
         unchecked {
-            finalPoolId =
-                ((basePoolId >> 32) << 32) +
-                (uint64(uint256(keccak256(abi.encodePacked(basePoolId, token0, token1, fee)))) %
-                    2 ** 32);
+            uint48 pattern = uint48(poolId & 0x0000FFFFFFFFFFFF);
+            pattern += 1;
+            uint64 _tickSpacing = uint24(uint256(poolId).tickSpacing());
+            _tickSpacing <<= 48;
+            assertEq(harness.incrementPoolPattern(poolId), _tickSpacing + pattern);
         }
-
-        assertEq(finalPoolId, harness.getFinalPoolId(basePoolId, token0, token1, fee));
     }
 
     function test_Success_computeExercisedAmounts_emptyOldTokenId(

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -197,6 +197,10 @@ contract PanopticMathTest is Test, PositionUtils {
     }
 
     function test_Success_getPoolId(address univ3pool, uint256 _tickSpacing) public {
+        vm.assume(
+            univ3pool > address(10) &&
+                univ3pool != address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D)
+        );
         _tickSpacing = bound(_tickSpacing, 0, uint16(type(int16).max));
 
         UniPoolPriceMock pm = new UniPoolPriceMock();

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -108,7 +108,7 @@ contract PanopticMathTest is Test, PositionUtils {
             tokenId = tokenId.addLeg(0, optionRatio, 0, isLong, tokenType, 0, strike, width);
         }
 
-        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0);
 
         uint160 sqrtPriceBottom = (tokenId.width(0) == 4095)
             ? TickMath.getSqrtRatioAtTick(tokenId.strike(0))
@@ -174,7 +174,7 @@ contract PanopticMathTest is Test, PositionUtils {
             tokenId = tokenId.addLeg(0, optionRatio, 1, isLong, tokenType, 0, strike, width);
         }
 
-        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0);
 
         uint160 sqrtPriceTop = (tokenId.width(0) == 4095)
             ? TickMath.getSqrtRatioAtTick(tokenId.strike(0))
@@ -1120,7 +1120,7 @@ contract PanopticMathTest is Test, PositionUtils {
         }
 
         // get the tick range for this leg in order to get the strike price (the underlying price)
-        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0);
 
         uint128 amount0 = positionSize * uint128(tokenId.optionRatio(0));
         uint128 amount1 = harness.convertNotional(amount0, tickLower, tickUpper, tokenId.asset(0));
@@ -1184,7 +1184,7 @@ contract PanopticMathTest is Test, PositionUtils {
         }
 
         // get the tick range for this leg in order to get the strike price (the underlying price)
-        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0);
 
         uint128 amount1 = positionSize * uint128(tokenId.optionRatio(0));
         uint128 amount0 = harness.convertNotional(amount1, tickLower, tickUpper, tokenId.asset(0));
@@ -1306,7 +1306,7 @@ contract PanopticMathTest is Test, PositionUtils {
         }
 
         // contractSize = positionSize * uint128(tokenId.optionRatio(legIndex));
-        (int24 legLowerTick, int24 legUpperTick) = tokenId.asTicks(0, tickSpacing);
+        (int24 legLowerTick, int24 legUpperTick) = tokenId.asTicks(0);
 
         positionSize = uint64(
             PositionUtils.getContractsForAmountAtTick(

--- a/test/foundry/libraries/harnesses/PanopticMathHarness.sol
+++ b/test/foundry/libraries/harnesses/PanopticMathHarness.sol
@@ -26,7 +26,7 @@ contract PanopticMathHarness is Test {
         return liquidityChunk;
     }
 
-    function getPoolId(address univ3pool) public pure returns (uint64) {
+    function getPoolId(address univ3pool) public view returns (uint64) {
         uint64 poolId = PanopticMath.getPoolId(univ3pool);
         return poolId;
     }

--- a/test/foundry/libraries/harnesses/PanopticMathHarness.sol
+++ b/test/foundry/libraries/harnesses/PanopticMathHarness.sol
@@ -37,8 +37,7 @@ contract PanopticMathHarness is Test {
 
     function computeExercisedAmounts(
         uint256 tokenId,
-        uint128 positionSize,
-        int24 tickSpacing
+        uint128 positionSize
     ) public view returns (int256, int256) {
         (int256 longAmounts, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
@@ -119,8 +118,7 @@ contract PanopticMathHarness is Test {
     function _getAmountsMoved(
         uint256 tokenId,
         uint128 positionSize,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) public view returns (uint256) {
         uint256 amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, legIndex);
         return amountsMoved;
@@ -130,10 +128,9 @@ contract PanopticMathHarness is Test {
     function getAmountsMoved(
         uint256 tokenId,
         uint128 positionSize,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) public view returns (uint256) {
-        try this._getAmountsMoved(tokenId, positionSize, legIndex, tickSpacing) returns (
+        try this._getAmountsMoved(tokenId, positionSize, legIndex) returns (
             uint256 contractsNotional
         ) {
             return contractsNotional;
@@ -145,8 +142,7 @@ contract PanopticMathHarness is Test {
     function _calculateIOAmounts(
         uint256 tokenId,
         uint128 positionSize,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) public view returns (int256, int256) {
         (int256 longs, int256 shorts) = PanopticMath._calculateIOAmounts(
             tokenId,
@@ -159,10 +155,9 @@ contract PanopticMathHarness is Test {
     function calculateIOAmounts(
         uint256 tokenId,
         uint128 positionSize,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) public view returns (int256, int256) {
-        try this._calculateIOAmounts(tokenId, positionSize, legIndex, tickSpacing) returns (
+        try this._calculateIOAmounts(tokenId, positionSize, legIndex) returns (
             int256 longs,
             int256 shorts
         ) {

--- a/test/foundry/libraries/harnesses/PanopticMathHarness.sol
+++ b/test/foundry/libraries/harnesses/PanopticMathHarness.sol
@@ -14,15 +14,9 @@ contract PanopticMathHarness is Test {
     function getLiquidityChunk(
         uint256 tokenId,
         uint256 legIndex,
-        uint128 positionSize,
-        int24 tickSpacing
+        uint128 positionSize
     ) public view returns (uint256) {
-        uint256 liquidityChunk = PanopticMath.getLiquidityChunk(
-            tokenId,
-            legIndex,
-            positionSize,
-            tickSpacing
-        );
+        uint256 liquidityChunk = PanopticMath.getLiquidityChunk(tokenId, legIndex, positionSize);
         return liquidityChunk;
     }
 
@@ -48,8 +42,7 @@ contract PanopticMathHarness is Test {
     ) public view returns (int256, int256) {
         (int256 longAmounts, int256 shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
-            positionSize,
-            tickSpacing
+            positionSize
         );
         return (longAmounts, shortAmounts);
     }
@@ -129,12 +122,7 @@ contract PanopticMathHarness is Test {
         uint256 legIndex,
         int24 tickSpacing
     ) public view returns (uint256) {
-        uint256 amountsMoved = PanopticMath.getAmountsMoved(
-            tokenId,
-            positionSize,
-            legIndex,
-            tickSpacing
-        );
+        uint256 amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, legIndex);
         return amountsMoved;
     }
 
@@ -163,8 +151,7 @@ contract PanopticMathHarness is Test {
         (int256 longs, int256 shorts) = PanopticMath._calculateIOAmounts(
             tokenId,
             positionSize,
-            legIndex,
-            tickSpacing
+            legIndex
         );
         return (longs, shorts);
     }

--- a/test/foundry/libraries/harnesses/PanopticMathHarness.sol
+++ b/test/foundry/libraries/harnesses/PanopticMathHarness.sol
@@ -25,14 +25,9 @@ contract PanopticMathHarness is Test {
         return poolId;
     }
 
-    function getFinalPoolId(
-        uint64 basePoolId,
-        address token0,
-        address token1,
-        uint24 fee
-    ) public pure returns (uint64) {
-        uint64 finalPoolId = PanopticMath.getFinalPoolId(basePoolId, token0, token1, fee);
-        return finalPoolId;
+    function incrementPoolPattern(uint64 poolId) public pure returns (uint64) {
+        uint64 poolId = PanopticMath.incrementPoolPattern(poolId);
+        return poolId;
     }
 
     function computeExercisedAmounts(

--- a/test/foundry/periphery/PanopticHelper.t.sol
+++ b/test/foundry/periphery/PanopticHelper.t.sol
@@ -469,7 +469,7 @@ contract PanopticHelperTest is PositionUtils {
 
         optionRatio = uint8(bound(optionRatio, uint8(1), uint8(2 ** 7 - 1)));
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             optionRatio,
             asset ? 1 : 0,
@@ -521,7 +521,7 @@ contract PanopticHelperTest is PositionUtils {
 
         uint256 long = isLong ? 1 : 0;
         uint256 tt = tokenType ? 1 : 0;
-        uint256 tokenId = uint256(0).addUniv3pool(poolId);
+        uint256 tokenId = uint256(0).addPoolId(poolId);
 
         {
             tokenId = tokenId.addOptionRatio(optionRatio, 0);
@@ -581,7 +581,7 @@ contract PanopticHelperTest is PositionUtils {
         uint256 numberOfLegs = uint256((seed % 4) + 1);
         PanopticHelper.Leg[] memory inputLeg = new PanopticHelper.Leg[](numberOfLegs);
 
-        uint256 tokenId = uint256(0).addUniv3pool(poolId);
+        uint256 tokenId = uint256(0).addPoolId(poolId);
 
         for (uint256 i; i < numberOfLegs; ++i) {
             // update seed
@@ -724,7 +724,7 @@ contract PanopticHelperTest is PositionUtils {
         isLongArray[9] = uint256(0).addIsLong(1, 0).addIsLong(1, 1);
 
         uint256 riskPreset = uint256(keccak256(abi.encode(seed))) % 10;
-        uint256 tokenId = riskArray[riskPreset].addUniv3pool(poolId) + isLongArray[riskPreset];
+        uint256 tokenId = riskArray[riskPreset].addPoolId(poolId) + isLongArray[riskPreset];
 
         uint256 optionRatio = uint256(seed % 2 ** 7);
         optionRatio = optionRatio == 0 ? 1 : optionRatio;
@@ -861,7 +861,7 @@ contract PanopticHelperTest is PositionUtils {
         tokenTypeArray[9] = uint256(0).addTokenType(1, 0).addTokenType(1, 1);
 
         uint256 riskPreset = uint256(keccak256(abi.encode(seed))) % 10;
-        uint256 tokenId = riskArray[riskPreset].addUniv3pool(poolId) + tokenTypeArray[riskPreset];
+        uint256 tokenId = riskArray[riskPreset].addPoolId(poolId) + tokenTypeArray[riskPreset];
 
         uint256 optionRatio = uint256(seed % 2 ** 7);
         optionRatio = optionRatio == 0 ? 1 : optionRatio;
@@ -966,7 +966,7 @@ contract PanopticHelperTest is PositionUtils {
 
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
         // leg 1
-        uint256 tokenId = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,
@@ -977,7 +977,7 @@ contract PanopticHelperTest is PositionUtils {
             $width
         );
         // leg 2
-        uint256 tokenId2 = uint256(0).addUniv3pool(poolId).addLeg(
+        uint256 tokenId2 = uint256(0).addPoolId(poolId).addLeg(
             0,
             1,
             isWETH,

--- a/test/foundry/testUtils/ReentrancyMocks.sol
+++ b/test/foundry/testUtils/ReentrancyMocks.sol
@@ -58,7 +58,7 @@ contract ReenterBurn {
         activated = true;
         if (reenter)
             SemiFungiblePositionManagerHarness(msg.sender).burnTokenizedPosition(
-                uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
+                uint256(0).addPoolId(PanopticMath.getPoolId(address(this))),
                 0,
                 0,
                 0
@@ -120,7 +120,7 @@ contract ReenterMint {
 
         if (reenter)
             SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(
-                uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
+                uint256(0).addPoolId(PanopticMath.getPoolId(address(this))),
                 0,
                 0,
                 0
@@ -184,7 +184,7 @@ contract ReenterTransferSingle {
             SemiFungiblePositionManagerHarness(msg.sender).safeTransferFrom(
                 address(0),
                 address(0),
-                uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this))),
+                uint256(0).addPoolId(PanopticMath.getPoolId(address(this))),
                 0,
                 ""
             );
@@ -244,7 +244,7 @@ contract ReenterTransferBatch {
         activated = true;
 
         uint256[] memory ids = new uint256[](1);
-        ids[0] = uint256(0).addUniv3pool(PanopticMath.getPoolId(address(this)));
+        ids[0] = uint256(0).addPoolId(PanopticMath.getPoolId(address(this)));
         if (reenter)
             SemiFungiblePositionManagerHarness(msg.sender).safeBatchTransferFrom(
                 address(0),

--- a/test/foundry/types/TokenId.t.sol
+++ b/test/foundry/types/TokenId.t.sol
@@ -659,7 +659,7 @@ contract TokenIdTest is Test, PositionUtils {
         vm.assume(strike - (((width * tickSpacing) / 2) % tickSpacing) == 0);
 
         // We now construct the tokenId with properly bounded fuzz values
-        uint256 tokenId = harness.addWidth(0, width, 0);
+        uint256 tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0);
         tokenId = harness.addStrike(tokenId, strike, 0);
 
         // Test the asTicks function
@@ -693,7 +693,7 @@ contract TokenIdTest is Test, PositionUtils {
 
         // We now construct the tokenId with properly bounded fuzz values
         uint256 tokenId;
-        tokenId = harness.addWidth(0, width, 0); // width
+        tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0); // width
         tokenId = harness.addStrike(tokenId, strike, 0); // strike
 
         vm.expectRevert(Errors.TicksNotInitializable.selector);
@@ -726,7 +726,7 @@ contract TokenIdTest is Test, PositionUtils {
 
         // We now construct the tokenId with properly bounded fuzz values
         uint256 tokenId;
-        tokenId = harness.addWidth(0, width, 0); // width
+        tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0); // width
         tokenId = harness.addStrike(tokenId, strike, 0); // strike
 
         // Test the asTicks function
@@ -759,7 +759,7 @@ contract TokenIdTest is Test, PositionUtils {
 
         // We now construct the tokenId with properly bounded fuzz values
         uint256 tokenId;
-        tokenId = harness.addWidth(0, width, 0); // width
+        tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0); // width
         tokenId = harness.addStrike(tokenId, strike, 0); // strike
 
         // Test the asTicks function
@@ -1863,11 +1863,16 @@ contract TokenIdTest is Test, PositionUtils {
                 bound(strikeSeed, currentTick - range + 1, currentTick + range - 1)
             );
 
+            console2.log("strike", strike);
+            console2.log("width", width);
+            console2.log("strikeSee", strikeSeed);
             tokenId = harness.addStrike(tokenId, strike, i);
             tokenId = harness.addIsLong(tokenId, 1, i);
         }
 
         vm.expectRevert(Errors.NoLegsExercisable.selector);
+        console2.log("tokenId", tokenId);
+        console2.log("currentTick", currentTick);
         harness.validateIsExercisable(tokenId, currentTick);
     }
 
@@ -2052,7 +2057,7 @@ contract TokenIdTest is Test, PositionUtils {
     // uses a seed to fuzz data so that there is different data for each leg
     function fuzzedPosition(
         uint256 totalLegs,
-        uint64 poolId,
+        uint64 poolIdSeed,
         uint256 optionRatioSeed,
         uint256 assetSeed,
         uint256 isLongSeed,
@@ -2093,7 +2098,8 @@ contract TokenIdTest is Test, PositionUtils {
 
             {
                 // the following must be at least 1
-                poolId = uint64(bound(poolId, 1, type(uint64).max));
+                poolId = (uint64(bound(poolIdSeed, 1, type(uint64).max)) >> 16) << 16;
+                poolId += uint64(uint24(tickSpacing));
                 optionRatioSeed = bound(optionRatioSeed, 1, 127);
 
                 width = int24(bound(widthSeed, 1, 4094));

--- a/test/foundry/types/TokenId.t.sol
+++ b/test/foundry/types/TokenId.t.sol
@@ -60,9 +60,9 @@ contract TokenIdTest is Test, PositionUtils {
     function test_Success_AddUniv3Pool(address y) public {
         uint256 tokenId;
 
-        tokenId = harness.addUniv3pool(tokenId, uint64(uint160(y)));
+        tokenId = harness.addPoolId(tokenId, uint64(uint160(y)));
 
-        assertEq(harness.univ3pool(tokenId), uint64(uint160(y)));
+        assertEq(harness.poolId(tokenId), uint64(uint160(y)));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -956,7 +956,7 @@ contract TokenIdTest is Test, PositionUtils {
             widthSeed
         );
 
-        uint64 expectedData = harness.univ3pool(tokenId);
+        uint64 expectedData = harness.poolId(tokenId);
         uint64 returnedData = harness.validate(tokenId);
 
         assertEq(expectedData, returnedData);
@@ -977,7 +977,7 @@ contract TokenIdTest is Test, PositionUtils {
         setPoolStatus(strikeSeed);
 
         // add uni pool to tokenId
-        tokenId = harness.addUniv3pool(tokenId, uint64(poolId));
+        tokenId = harness.addPoolId(tokenId, uint64(poolId));
 
         // will fail as there are no valid legs
         vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTokenIdParameter.selector, 1));
@@ -2113,8 +2113,8 @@ contract TokenIdTest is Test, PositionUtils {
             }
 
             {
-                // add univ3pool to token
-                tokenId = harness.addUniv3pool(tokenId, poolId);
+                // add poolId to token
+                tokenId = harness.addPoolId(tokenId, poolId);
 
                 // add a leg
                 // no risk partner by default (will reference its own leg index)

--- a/test/foundry/types/TokenId.t.sol
+++ b/test/foundry/types/TokenId.t.sol
@@ -663,7 +663,7 @@ contract TokenIdTest is Test, PositionUtils {
         tokenId = harness.addStrike(tokenId, strike, 0);
 
         // Test the asTicks function
-        (int24 tickLower, int24 tickUpper) = harness.asTicks(tokenId, 0, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = harness.asTicks(tokenId, 0);
 
         // Ensure tick values returned are correct
         assertEq(tickLower, strike - (width * tickSpacing) / 2);
@@ -698,7 +698,7 @@ contract TokenIdTest is Test, PositionUtils {
 
         vm.expectRevert(Errors.TicksNotInitializable.selector);
         // Test the asTicks function
-        (int24 tickLower, int24 tickUpper) = harness.asTicks(tokenId, 0, tickSpacing);
+        (int24 tickLower, int24 tickUpper) = harness.asTicks(tokenId, 0);
     }
 
     function test_Fail_asTicks_belowMinTick(
@@ -731,7 +731,7 @@ contract TokenIdTest is Test, PositionUtils {
 
         // Test the asTicks function
         vm.expectRevert(Errors.TicksNotInitializable.selector);
-        harness.asTicks(tokenId, 0, tickSpacing);
+        harness.asTicks(tokenId, 0);
     }
 
     function test_Fail_asTicks_aboveMinTick(
@@ -764,7 +764,7 @@ contract TokenIdTest is Test, PositionUtils {
 
         // Test the asTicks function
         vm.expectRevert(Errors.TicksNotInitializable.selector);
-        harness.asTicks(tokenId, 0, tickSpacing);
+        harness.asTicks(tokenId, 0);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1735,7 +1735,7 @@ contract TokenIdTest is Test, PositionUtils {
             tokenId = harness.addIsLong(tokenId, 1, i);
         }
 
-        harness.validateIsExercisable(tokenId, currentTick, tickSpacing);
+        harness.validateIsExercisable(tokenId, currentTick);
     }
 
     function test_Success_validateIsExercisable_aboveTick(
@@ -1784,7 +1784,7 @@ contract TokenIdTest is Test, PositionUtils {
             tokenId = harness.addIsLong(tokenId, 1, i);
         }
 
-        harness.validateIsExercisable(tokenId, currentTick, tickSpacing);
+        harness.validateIsExercisable(tokenId, currentTick);
     }
 
     function test_Fail_validateIsExercisable_shortPos(
@@ -1818,7 +1818,7 @@ contract TokenIdTest is Test, PositionUtils {
         tokenId = tokenId & CLEAR_IS_LONG_MASK;
 
         vm.expectRevert(Errors.NoLegsExercisable.selector);
-        harness.validateIsExercisable(tokenId, currentTick, tickSpacing);
+        harness.validateIsExercisable(tokenId, currentTick);
     }
 
     function test_Fail_validateIsExercisable_inRange(
@@ -1868,7 +1868,7 @@ contract TokenIdTest is Test, PositionUtils {
         }
 
         vm.expectRevert(Errors.NoLegsExercisable.selector);
-        harness.validateIsExercisable(tokenId, currentTick, tickSpacing);
+        harness.validateIsExercisable(tokenId, currentTick);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/types/TokenId.t.sol
+++ b/test/foundry/types/TokenId.t.sol
@@ -1863,16 +1863,11 @@ contract TokenIdTest is Test, PositionUtils {
                 bound(strikeSeed, currentTick - range + 1, currentTick + range - 1)
             );
 
-            console2.log("strike", strike);
-            console2.log("width", width);
-            console2.log("strikeSee", strikeSeed);
             tokenId = harness.addStrike(tokenId, strike, i);
             tokenId = harness.addIsLong(tokenId, 1, i);
         }
 
         vm.expectRevert(Errors.NoLegsExercisable.selector);
-        console2.log("tokenId", tokenId);
-        console2.log("currentTick", currentTick);
         harness.validateIsExercisable(tokenId, currentTick);
     }
 
@@ -2065,7 +2060,12 @@ contract TokenIdTest is Test, PositionUtils {
         int24 strikeSeed,
         int256 widthSeed
     ) internal returns (uint256) {
-        uint256 tokenId;
+        uint64 poolId = uint64(
+            ((uint64(bound(poolIdSeed, 1, type(uint64).max)) >> 16) << 16) +
+                uint64(uint24(tickSpacing))
+        );
+        // add poolId to token
+        uint256 tokenId = harness.addPoolId(0, poolId);
 
         for (uint256 legIndex; legIndex < totalLegs; legIndex++) {
             // We don't want the same data for each leg
@@ -2094,12 +2094,9 @@ contract TokenIdTest is Test, PositionUtils {
             /// bound inputs
             int24 strike;
             int24 width;
-            uint64 poolId;
 
             {
                 // the following must be at least 1
-                poolId = (uint64(bound(poolIdSeed, 1, type(uint64).max)) >> 16) << 16;
-                poolId += uint64(uint24(tickSpacing));
                 optionRatioSeed = bound(optionRatioSeed, 1, 127);
 
                 width = int24(bound(widthSeed, 1, 4094));
@@ -2119,9 +2116,6 @@ contract TokenIdTest is Test, PositionUtils {
             }
 
             {
-                // add poolId to token
-                tokenId = harness.addPoolId(tokenId, poolId);
-
                 // add a leg
                 // no risk partner by default (will reference its own leg index)
                 tokenId = harness.addLeg(

--- a/test/foundry/types/TokenId.t.sol
+++ b/test/foundry/types/TokenId.t.sol
@@ -65,6 +65,15 @@ contract TokenIdTest is Test, PositionUtils {
         assertEq(harness.poolId(tokenId), uint64(uint160(y)));
     }
 
+    function test_Success_AddTickSpacing(int24 y) public {
+        uint256 tokenId;
+
+        y = int24(bound(y, int24(0), int24(2 ** 16 - 1)));
+        tokenId = harness.addTickSpacing(tokenId, y);
+
+        assertEq(harness.tickSpacing(tokenId), y);
+    }
+
     /*//////////////////////////////////////////////////////////////
                             ADD WIDTH
     //////////////////////////////////////////////////////////////*/
@@ -659,7 +668,8 @@ contract TokenIdTest is Test, PositionUtils {
         vm.assume(strike - (((width * tickSpacing) / 2) % tickSpacing) == 0);
 
         // We now construct the tokenId with properly bounded fuzz values
-        uint256 tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0);
+        uint256 tokenId = harness.addTickSpacing(0, tickSpacing);
+        tokenId = harness.addWidth(tokenId, width, 0);
         tokenId = harness.addStrike(tokenId, strike, 0);
 
         // Test the asTicks function
@@ -692,8 +702,8 @@ contract TokenIdTest is Test, PositionUtils {
         );
 
         // We now construct the tokenId with properly bounded fuzz values
-        uint256 tokenId;
-        tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0); // width
+        uint256 tokenId = harness.addTickSpacing(0, tickSpacing);
+        tokenId = harness.addWidth(tokenId, width, 0); // width
         tokenId = harness.addStrike(tokenId, strike, 0); // strike
 
         vm.expectRevert(Errors.TicksNotInitializable.selector);
@@ -725,8 +735,8 @@ contract TokenIdTest is Test, PositionUtils {
         );
 
         // We now construct the tokenId with properly bounded fuzz values
-        uint256 tokenId;
-        tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0); // width
+        uint256 tokenId = harness.addTickSpacing(0, tickSpacing);
+        tokenId = harness.addWidth(tokenId, width, 0); // width
         tokenId = harness.addStrike(tokenId, strike, 0); // strike
 
         // Test the asTicks function
@@ -758,8 +768,8 @@ contract TokenIdTest is Test, PositionUtils {
         );
 
         // We now construct the tokenId with properly bounded fuzz values
-        uint256 tokenId;
-        tokenId = harness.addWidth(uint256(int256(tickSpacing)), width, 0); // width
+        uint256 tokenId = harness.addTickSpacing(0, tickSpacing);
+        tokenId = harness.addWidth(tokenId, width, 0); // width
         tokenId = harness.addStrike(tokenId, strike, 0); // strike
 
         // Test the asTicks function
@@ -2061,8 +2071,8 @@ contract TokenIdTest is Test, PositionUtils {
         int256 widthSeed
     ) internal returns (uint256) {
         uint64 poolId = uint64(
-            ((uint64(bound(poolIdSeed, 1, type(uint64).max)) >> 16) << 16) +
-                uint64(uint24(tickSpacing))
+            ((uint64(bound(poolIdSeed, 1, type(uint64).max)) >> 16)) +
+                (uint64(uint24(tickSpacing)) << 48)
         );
         // add poolId to token
         uint256 tokenId = harness.addPoolId(0, poolId);

--- a/test/foundry/types/harnesses/TokenIdHarness.sol
+++ b/test/foundry/types/harnesses/TokenIdHarness.sol
@@ -34,8 +34,8 @@ contract TokenIdHarness {
      * @param self the option position Id.
      * @return the poolId (Panoptic's uni v3 pool fingerprint) of the Uniswap v3 pool
      */
-    function univ3pool(uint256 self) public view returns (uint64) {
-        uint64 r = TokenId.univ3pool(self);
+    function poolId(uint256 self) public view returns (uint64) {
+        uint64 r = TokenId.poolId(self);
         return r;
     }
 
@@ -142,8 +142,8 @@ contract TokenIdHarness {
      * @param self the option position Id.
      * @return the tokenId with the Uniswap V3 pool added to it.
      */
-    function addUniv3pool(uint256 self, uint64 _poolId) public view returns (uint256) {
-        uint256 r = TokenId.addUniv3pool(self, _poolId);
+    function addPoolId(uint256 self, uint64 _poolId) public view returns (uint256) {
+        uint256 r = TokenId.addPoolId(self, _poolId);
         return r;
     }
 

--- a/test/foundry/types/harnesses/TokenIdHarness.sol
+++ b/test/foundry/types/harnesses/TokenIdHarness.sol
@@ -39,6 +39,16 @@ contract TokenIdHarness {
         return r;
     }
 
+    /**
+     * @notice The tickSpacing of the Uniswap v3 Pool for this position
+     * @param self the option position Id.
+     * @return the tickSpacing of the Uniswap v3 pool
+     */
+    function tickSpacing(uint256 self) public view returns (int24) {
+        int24 r = TokenId.tickSpacing(self);
+        return r;
+    }
+
     /// NOW WE MOVE THROUGH THE BIT PATTERN BEYOND THE FIRST 96 BITS INTO EACH LEG (EACH OF SIZE 48)
     /// @notice our terminology: "leg n" or "nth leg" (in {1,2,3,4}) corresponds to "leg index n-1" or `legIndex` (in {0,1,2,3})
 
@@ -144,6 +154,16 @@ contract TokenIdHarness {
      */
     function addPoolId(uint256 self, uint64 _poolId) public view returns (uint256) {
         uint256 r = TokenId.addPoolId(self, _poolId);
+        return r;
+    }
+
+    /**
+     * @notice Add the Uniswap v3 Pool pointed to by this option position.
+     * @param self the option position Id.
+     * @return the tokenId with the Uniswap V3 pool added to it.
+     */
+    function addTickSpacing(uint256 self, int24 _tickSpacing) public view returns (uint256) {
+        uint256 r = TokenId.addTickSpacing(self, _tickSpacing);
         return r;
     }
 

--- a/test/foundry/types/harnesses/TokenIdHarness.sol
+++ b/test/foundry/types/harnesses/TokenIdHarness.sol
@@ -331,16 +331,14 @@ contract TokenIdHarness {
      * @dev NOTE does not extract liquidity which is the third piece of information in a LiquidityChunk.
      * @param self the option position id.
      * @param legIndex the leg index of the position (in {0,1,2,3}).
-     * @param tickSpacing the tick spacing of the underlying Univ3 pool.
      * @return legLowerTick the lower tick of the leg/liquidity chunk.
      * @return legUpperTick the upper tick of the leg/liquidity chunk.
      */
     function asTicks(
         uint256 self,
-        uint256 legIndex,
-        int24 tickSpacing
+        uint256 legIndex
     ) public view returns (int24 legLowerTick, int24 legUpperTick) {
-        (legLowerTick, legUpperTick) = TokenId.asTicks(self, legIndex, tickSpacing);
+        (legLowerTick, legUpperTick) = TokenId.asTicks(self, legIndex);
     }
 
     /**
@@ -402,9 +400,8 @@ contract TokenIdHarness {
      * @dev At least one long leg must be far-out-of-the-money (i.e. price is outside its range).
      * @param self the option position Id (tokenId)
      * @param currentTick the current tick corresponding to the current price in the Univ3 pool.
-     * @param tickSpacing the tick spacing of the Univ3 pool used to compute the width of the chunks.
      */
-    function validateIsExercisable(uint256 self, int24 currentTick, int24 tickSpacing) public view {
-        TokenId.validateIsExercisable(self, currentTick, tickSpacing);
+    function validateIsExercisable(uint256 self, int24 currentTick) public view {
+        TokenId.validateIsExercisable(self, currentTick);
     }
 }


### PR DESCRIPTION
It turns out that the only place where `tickSpacing` is needed is when calling `tokenId.asTicks` and in `CollateralTracker.exerciseCost`

Storing it in `PanopticPool` and `CollateralTracker` can be made unnecessary if the `tickSpacing` value is stored in the tokenId's `poolId`

I decided to store the tickSpacing in the lower 12 bits of the poolId. tickSpacing is int24, meaning that the max `tickSpacing` allowed in tokenId is `<4096`

I also had to refactor the getFinalPoolId a bit, but that's all very manageable.

This saves several `SLOAD` and bytecode+gas because tickSpacing doesn't need to be transmitted around anymore. 