### PR TITLE
fix: short strangle validation order at burn

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -686,7 +686,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     ) internal returns (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalMoved) {
         // Reverts if positionSize is 0 and user did not own the position before minting/burning
         if (positionSize == 0) revert Errors.OptionsBalanceZero();
-        
+
         // Validate tokenId
         tokenId.validate();
 

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -686,14 +686,14 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     ) internal returns (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalMoved) {
         // Reverts if positionSize is 0 and user did not own the position before minting/burning
         if (positionSize == 0) revert Errors.OptionsBalanceZero();
+        
+        // Validate tokenId
+        tokenId.validate();
 
         /// @dev the flipToBurnToken() function flips the isLong bits
         if (isBurn) {
             tokenId = tokenId.flipToBurnToken();
         }
-
-        // Validate tokenId
-        tokenId.validate();
 
         // Extract univ3pool from the poolId map to Uniswap Pool
         IUniswapV3Pool univ3pool = s_poolContext[tokenId.poolId()].pool;

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1299,9 +1299,8 @@ contract Misctest is Test, PositionUtils {
         // L = 1
         uniPool.liquidity();
 
-
-        /// @dev single leg, liquidation through price move making options ITM
         uint256 snapshot = vm.snapshot(); 
+        /// @dev single leg, liquidation through price move making options ITM, no-cross collateral
    
         for (uint256 i; i < 4; ++i) {
             uint256 asset = i % 2; 
@@ -1363,7 +1362,73 @@ contract Misctest is Test, PositionUtils {
             vm.revertTo(snapshot);    
         }
 
-        /// @dev single leg, liquidation through price move making options ITM
+        /// @dev single leg, liquidation through price move making options ITM, with cross collateral
+        for (uint256 i; i < 4; ++i) {
+            uint256 asset = i % 2; 
+            uint256 tokenType = i / 2;
+            TokenId tokenId = TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(0, 1, asset, 0, tokenType, 0, 0, 2);
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , )  = uniPool.slot0();
+            
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+           
+            if (tokenType == 0) {
+                token0.approve(address(ct0), 7);
+                ct0.deposit(7, Bob);
+                token1.approve(address(ct1), 1000);
+                ct1.deposit(1000, Bob);
+            } else {
+                token0.approve(address(ct0), 1000);
+                ct0.deposit(1000, Bob);
+                token1.approve(address(ct1), 7);
+                ct1.deposit(7, Bob);
+            }
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            
+            (, currentTick, , , , , )  = uniPool.slot0();
+
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+            assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
+            
+            vm.startPrank(Swapper);
+          
+            // swap to 1.21 or 0.82, depending on tokenType
+            swapperc.swapTo(uniPool, tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976);
+            
+            (, currentTick, , , , , )  = uniPool.slot0();
+            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+            
+            assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+         
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+                
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(new TokenId[](0), Bob,LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),posIdList); 
+
+            vm.revertTo(snapshot);    
+        }
+
+
+        /// @dev strangles, liquidation through price move making on leg of the option ITM
    
         for (uint256 i; i < 8; ++i) {
             uint256 asset = i % 2; 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1289,7 +1289,7 @@ contract Misctest is Test, PositionUtils {
         );
     }
 
-    function test_success_liquidation_scenarios() public {
+    function test_success_liquidation_ITM_scenarios() public {
         vm.startPrank(Swapper);
         // JIT a bunch of liquidity so swaps at mint can happen normally
         swapperc.mint(uniPool, -1000, 1000, 10 ** 18);
@@ -1298,6 +1298,7 @@ contract Misctest is Test, PositionUtils {
         uniPool.liquidity();
 
         uint256 snapshot = vm.snapshot();
+        
         /// @dev single leg, liquidation through price move making options ITM, no-cross collateral
 
         for (uint256 i; i < 4; ++i) {
@@ -1545,5 +1546,634 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
+        
+        /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token0)
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    tokenType == 0 ? int24(100) : int24(-100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    0,
+                    1 - tokenType,
+                    0,
+                    tokenType == 1 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 1000);
+            ct0.deposit(1000, Bob);
+            token1.approve(address(ct1), 5);
+            ct1.deposit(5, Bob);
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            // swap to 1.41 or 0.62, depending on tokenType
+            swapperc.swapTo(
+                uniPool,
+                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+ 
+        /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token1)
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    tokenType == 0 ? int24(100) : int24(-100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    0,
+                    1 - tokenType,
+                    0,
+                    tokenType == 1 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 5);
+            ct0.deposit(5, Bob);
+            token1.approve(address(ct1), 1000);
+            ct1.deposit(1000, Bob);
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            // swap to 1.41 or 0.62, depending on tokenType
+            swapperc.swapTo(
+                uniPool,
+                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+ 
+    }
+    
+    function test_success_liquidation_LowCollateral_scenarios() public {
+        vm.startPrank(Swapper);
+        // JIT a bunch of liquidity so swaps at mint can happen normally
+        swapperc.mint(uniPool, -1000, 1000, 10 ** 18);
+
+        // L = 1
+        uniPool.liquidity();
+
+        uint256 snapshot = vm.snapshot();
+        
+        /// @dev single leg, liquidation through decrease in collateral, no-cross collateral
+
+        for (uint256 i; i < 4; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = i / 2;
+            TokenId tokenId = TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(0, 1, asset, 0, tokenType, 0, 0, 2);
+            //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            if (tokenType == 0) {
+                token0.approve(address(ct0), 1000);
+                ct0.deposit(1000, Bob);
+            } else {
+                token1.approve(address(ct1), 1000);
+                ct1.deposit(1000, Bob);
+            }
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+            assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
+
+            vm.startPrank(Swapper);
+
+            // swap to 1.21 or 0.82, depending on tokenType
+            swapperc.swapTo(
+                uniPool,
+                tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
+                pp,
+                Bob,
+                currentTick,
+                0,
+                posIdList
+            );
+
+            assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+
+        /// @dev single leg, liquidation through price move making options ITM, with cross collateral
+        for (uint256 i; i < 4; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = i / 2;
+            TokenId tokenId = TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(0, 1, asset, 0, tokenType, 0, 0, 2);
+            //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            if (tokenType == 0) {
+                token0.approve(address(ct0), 7);
+                ct0.deposit(7, Bob);
+                token1.approve(address(ct1), 1000);
+                ct1.deposit(1000, Bob);
+            } else {
+                token0.approve(address(ct0), 1000);
+                ct0.deposit(1000, Bob);
+                token1.approve(address(ct1), 7);
+                ct1.deposit(7, Bob);
+            }
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+            assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
+
+            vm.startPrank(Swapper);
+
+            // swap to 1.21 or 0.82, depending on tokenType
+            swapperc.swapTo(
+                uniPool,
+                tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
+                pp,
+                Bob,
+                currentTick,
+                0,
+                posIdList
+            );
+
+            assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+
+        /// @dev strangles, liquidation through price move making on leg of the option ITM
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    tokenType == 0 ? int24(100) : int24(-100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    0,
+                    1 - tokenType,
+                    0,
+                    tokenType == 1 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 1000);
+            ct0.deposit(1000, Bob);
+            token1.approve(address(ct1), 1000);
+            ct1.deposit(1000, Bob);
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            // swap to 1.41 or 0.62, depending on tokenType
+            swapperc.swapTo(
+                uniPool,
+                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+        
+        /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token0)
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    tokenType == 0 ? int24(100) : int24(-100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    0,
+                    1 - tokenType,
+                    0,
+                    tokenType == 1 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 1000);
+            ct0.deposit(1000, Bob);
+            token1.approve(address(ct1), 5);
+            ct1.deposit(5, Bob);
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            // swap to 1.41 or 0.62, depending on tokenType
+            swapperc.swapTo(
+                uniPool,
+                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+ 
+        /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token1)
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    tokenType == 0 ? int24(100) : int24(-100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    0,
+                    1 - tokenType,
+                    0,
+                    tokenType == 1 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 5);
+            ct0.deposit(5, Bob);
+            token1.approve(address(ct1), 1000);
+            ct1.deposit(1000, Bob);
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            // swap to 1.41 or 0.62, depending on tokenType
+            swapperc.swapTo(
+                uniPool,
+                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+ 
     }
 }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -8,6 +8,7 @@ import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {PanopticFactory} from "@contracts/PanopticFactory.sol";
 import {IDonorNFT} from "@tokens/interfaces/IDonorNFT.sol";
 import {DonorNFT} from "@periphery/DonorNFT.sol";
+import {IERC20Partial} from "@tokens/interfaces/IERC20Partial.sol";
 import {PanopticHelper} from "@periphery/PanopticHelper.sol";
 import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {ERC20S} from "@scripts/tokens/ERC20S.sol";
@@ -340,6 +341,38 @@ contract Misctest is Test, PositionUtils {
             $posIdLists.push(new TokenId[](0));
         }
     }
+
+    // convert signed int to assets
+    function convertToAssets(CollateralTracker ct, int256 amount) internal view returns (int256) {
+        return (amount > 0 ? int8(1) : -1) * int256(ct.convertToAssets(uint256(Math.abs(amount))));
+    }
+
+ // "virtual" deposit or withdrawal from an account without changing the share price
+    function editCollateral(CollateralTracker ct, address owner, uint256 newShares) internal {
+        int256 shareDelta = int256(newShares) - int256(ct.balanceOf(owner));
+        int256 assetDelta = convertToAssets(ct, shareDelta);
+        vm.store(
+            address(ct),
+            bytes32(uint256(7)),
+            bytes32(
+                uint256(
+                    LeftRightSigned.unwrap(
+                        LeftRightSigned
+                            .wrap(int256(uint256(vm.load(address(ct), bytes32(uint256(7))))))
+                            .add(LeftRightSigned.wrap(assetDelta))
+                    )
+                )
+            )
+        );
+        deal(
+            ct.asset(),
+            address(ct),
+            uint256(int256(IERC20Partial(ct.asset()).balanceOf(address(ct))) + assetDelta)
+        );
+
+        deal(address(ct), owner, newShares, true);
+    }
+
 
     // these tests are PoCs for rounding issues in the premium distribution
     // to demonstrate the issue log the settled, gross, and owed premia at burn
@@ -1783,13 +1816,11 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Swapper);
 
-            // swap to 1.21 or 0.82, depending on tokenType
-            swapperc.swapTo(
-                uniPool,
-                tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976
-            );
-
-            (, currentTick, , , , , ) = uniPool.slot0();
+            if (tokenType == 0) {
+                editCollateral(ct0, Bob, ct0.convertToShares(550));
+            } else {
+                editCollateral(ct1, Bob, ct1.convertToShares(550));
+            }
             (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
                 pp,
                 Bob,
@@ -1819,7 +1850,8 @@ contract Misctest is Test, PositionUtils {
             vm.revertTo(snapshot);
         }
 
-        /// @dev single leg, liquidation through price move making options ITM, with cross collateral
+        /// @dev single leg, liquidation through decrease in collateral, with cross collateral
+
         for (uint256 i; i < 4; ++i) {
             uint256 asset = i % 2;
             uint256 tokenType = i / 2;
@@ -1862,11 +1894,11 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Swapper);
 
-            // swap to 1.21 or 0.82, depending on tokenType
-            swapperc.swapTo(
-                uniPool,
-                tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976
-            );
+            if (tokenType == 0) {
+                editCollateral(ct1, Bob, ct1.convertToShares(550));
+            } else {
+                editCollateral(ct0, Bob, ct0.convertToShares(550));
+            }
 
             (, currentTick, , , , , ) = uniPool.slot0();
             (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
@@ -1898,11 +1930,11 @@ contract Misctest is Test, PositionUtils {
             vm.revertTo(snapshot);
         }
 
-        /// @dev strangles, liquidation through price move making on leg of the option ITM
+        /// @dev strangles, liquidation through decrease in collateral, no-cross collateral
 
-        for (uint256 i; i < 8; ++i) {
+        for (uint256 i; i < 4; ++i) {
             uint256 asset = i % 2;
-            uint256 tokenType = ((i % 4) / 2);
+            uint256 tokenType = (i / 2);
             TokenId tokenId;
             {
                 tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
@@ -1959,11 +1991,8 @@ contract Misctest is Test, PositionUtils {
             }
             vm.startPrank(Swapper);
 
-            // swap to 1.41 or 0.62, depending on tokenType
-            swapperc.swapTo(
-                uniPool,
-                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
-            );
+            editCollateral(ct0, Bob, ct0.convertToShares(250));
+            editCollateral(ct1, Bob, ct1.convertToShares(250));
 
             (, currentTick, , , , , ) = uniPool.slot0();
             {
@@ -1991,11 +2020,11 @@ contract Misctest is Test, PositionUtils {
             vm.revertTo(snapshot);
         }
         
-        /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token0)
+        /// @dev strangles, liquidation through decrease in collateral, with cross collateral (token0)
 
-        for (uint256 i; i < 8; ++i) {
+        for (uint256 i; i < 4; ++i) {
             uint256 asset = i % 2;
-            uint256 tokenType = ((i % 4) / 2);
+            uint256 tokenType = (i/ 2);
             TokenId tokenId;
             {
                 tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
@@ -2033,8 +2062,8 @@ contract Misctest is Test, PositionUtils {
 
             token0.approve(address(ct0), 1000);
             ct0.deposit(1000, Bob);
-            token1.approve(address(ct1), 5);
-            ct1.deposit(5, Bob);
+            token1.approve(address(ct1), 15);
+            ct1.deposit(15, Bob);
 
             pp.mintOptions(posIdList, 3000, 0, 0, 0);
 
@@ -2050,12 +2079,8 @@ contract Misctest is Test, PositionUtils {
                 );
             }
             vm.startPrank(Swapper);
-
-            // swap to 1.41 or 0.62, depending on tokenType
-            swapperc.swapTo(
-                uniPool,
-                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
-            );
+            
+            editCollateral(ct0, Bob, ct0.convertToShares(250));
 
             (, currentTick, , , , , ) = uniPool.slot0();
             {
@@ -2083,11 +2108,11 @@ contract Misctest is Test, PositionUtils {
             vm.revertTo(snapshot);
         }
  
-        /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token1)
+        /// @dev strangles, liquidation through decrease in collateral, with cross collateral (token1)
 
-        for (uint256 i; i < 8; ++i) {
+        for (uint256 i; i < 4; ++i) {
             uint256 asset = i % 2;
-            uint256 tokenType = ((i % 4) / 2);
+            uint256 tokenType = (i / 2);
             TokenId tokenId;
             {
                 tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
@@ -2123,8 +2148,8 @@ contract Misctest is Test, PositionUtils {
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
             ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
 
-            token0.approve(address(ct0), 5);
-            ct0.deposit(5, Bob);
+            token0.approve(address(ct0), 15);
+            ct0.deposit(15, Bob);
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
 
@@ -2143,11 +2168,119 @@ contract Misctest is Test, PositionUtils {
             }
             vm.startPrank(Swapper);
 
-            // swap to 1.41 or 0.62, depending on tokenType
-            swapperc.swapTo(
-                uniPool,
-                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
+            editCollateral(ct1, Bob, ct1.convertToShares(250));
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
             );
+            vm.revertTo(snapshot);
+        }
+
+
+
+        /// @dev spreads, liquidation through decrease in collateral, no-cross collateral
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                // sell long leg
+                vm.startPrank(Charlie);
+
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    0,
+                    i < 3 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+                TokenId[] memory posIdList = new TokenId[](1);
+                posIdList[0] = tokenId;
+                
+                pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
+
+                // create spread tokenId
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    i < 3 ? int24(-100) : int24(100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    1,
+                    tokenType,
+                    0,
+                    i < 3 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 1000);
+            ct0.deposit(1000, Bob);
+            token1.approve(address(ct1), 1000);
+            ct1.deposit(1000, Bob);
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 10_000, 2**30, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            editCollateral(ct0, Bob, ct0.convertToShares(250));
+            editCollateral(ct1, Bob, ct1.convertToShares(250));
 
             (, currentTick, , , , , ) = uniPool.slot0();
             {
@@ -2174,6 +2307,228 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
+        
+        /// @dev spreads, liquidation through decrease in collateral, with cross collateral (token0)
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                // sell long leg
+                vm.startPrank(Charlie);
+
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    0,
+                    i < 3 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+                TokenId[] memory posIdList = new TokenId[](1);
+                posIdList[0] = tokenId;
+                
+                pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
+
+                // create spread tokenId
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    i < 3 ? int24(-100) : int24(100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    1,
+                    tokenType,
+                    0,
+                    i < 3 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 2500);
+            ct0.deposit(2500, Bob);
+            token1.approve(address(ct1), 150);
+            ct1.deposit(150, Bob);
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 10_000, 2**30, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            editCollateral(ct0, Bob, ct0.convertToShares(250));
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+        
+ 
+        /// @dev spreads, liquidation through decrease in collateral, with cross collateral (token1)
+
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+                // sell long leg
+                vm.startPrank(Charlie);
+
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    0,
+                    i < 3 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+                TokenId[] memory posIdList = new TokenId[](1);
+                posIdList[0] = tokenId;
+                
+                pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
+
+                // create spread tokenId
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    i < 3 ? int24(-100) : int24(100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    1,
+                    tokenType,
+                    0,
+                    i < 3 ? int24(100) : int24(-100),
+                    2
+                );
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            token0.approve(address(ct0), 150);
+            ct0.deposit(150, Bob);
+            token1.approve(address(ct1), 2500);
+            ct1.deposit(2500, Bob);
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 10_000, 2**30, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
+            }
+            vm.startPrank(Swapper);
+
+            editCollateral(ct1, Bob, ct1.convertToShares(250));
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            {
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+        
  
     }
 }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -347,7 +347,7 @@ contract Misctest is Test, PositionUtils {
         return (amount > 0 ? int8(1) : -1) * int256(ct.convertToAssets(uint256(Math.abs(amount))));
     }
 
- // "virtual" deposit or withdrawal from an account without changing the share price
+    // "virtual" deposit or withdrawal from an account without changing the share price
     function editCollateral(CollateralTracker ct, address owner, uint256 newShares) internal {
         int256 shareDelta = int256(newShares) - int256(ct.balanceOf(owner));
         int256 assetDelta = convertToAssets(ct, shareDelta);
@@ -2144,12 +2144,12 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
-        
+
         /// @dev strangles, liquidation through decrease in collateral, with cross collateral (token0)
 
         for (uint256 i; i < 4; ++i) {
             uint256 asset = i % 2;
-            uint256 tokenType = (i/ 2);
+            uint256 tokenType = (i / 2);
             TokenId tokenId;
             {
                 tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
@@ -2204,7 +2204,7 @@ contract Misctest is Test, PositionUtils {
                 );
             }
             vm.startPrank(Swapper);
-            
+
             editCollateral(ct0, Bob, ct0.convertToShares(250));
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -2232,7 +2232,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
- 
+
         /// @dev strangles, liquidation through decrease in collateral, with cross collateral (token1)
 
         for (uint256 i; i < 4; ++i) {
@@ -2320,8 +2320,6 @@ contract Misctest is Test, PositionUtils {
             vm.revertTo(snapshot);
         }
 
-
-
         /// @dev spreads, liquidation through decrease in collateral, no-cross collateral
 
         for (uint256 i; i < 8; ++i) {
@@ -2346,7 +2344,7 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
-                
+
                 pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
 
                 // create spread tokenId
@@ -2389,7 +2387,7 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 10_000, 2**30, 0, 0);
+            pp.mintOptions(posIdList, 10_000, 2 ** 30, 0, 0);
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2432,7 +2430,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
-        
+
         /// @dev spreads, liquidation through decrease in collateral, with cross collateral (token0)
 
         for (uint256 i; i < 8; ++i) {
@@ -2457,7 +2455,7 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
-                
+
                 pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
 
                 // create spread tokenId
@@ -2500,7 +2498,7 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(150, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 10_000, 2**30, 0, 0);
+            pp.mintOptions(posIdList, 10_000, 2 ** 30, 0, 0);
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2542,8 +2540,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
-        
- 
+
         /// @dev spreads, liquidation through decrease in collateral, with cross collateral (token1)
 
         for (uint256 i; i < 8; ++i) {
@@ -2568,7 +2565,7 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
-                
+
                 pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
 
                 // create spread tokenId
@@ -2611,7 +2608,7 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(2500, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 10_000, 2**30, 0, 0);
+            pp.mintOptions(posIdList, 10_000, 2 ** 30, 0, 0);
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2653,7 +2650,5 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
-        
- 
     }
 }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -205,6 +205,7 @@ contract Misctest is Test, PositionUtils {
             vm.roll(block.number + 1);
             swapperc.mint(uniPool, -10, 10, 10 ** 18);
             swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            
         }
         swapperc.mint(uniPool, -887270, 887270, 10 ** 18);
 
@@ -246,6 +247,28 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Swapper);
         swapperc.swapTo(uniPool, 2 ** 96);
 
+        // Update median
+        pp.pokeMedian();
+        vm.warp(block.timestamp + 120);
+        vm.roll(block.number + 10);
+
+        pp.pokeMedian();
+        vm.warp(block.timestamp + 120);
+        vm.roll(block.number + 10);
+
+        pp.pokeMedian();
+        vm.warp(block.timestamp + 120);
+        vm.roll(block.number + 10);
+
+        pp.pokeMedian();
+        vm.warp(block.timestamp + 120);
+        vm.roll(block.number + 10);
+
+        pp.pokeMedian();
+        vm.warp(block.timestamp + 120);
+        vm.roll(block.number + 10);
+
+ 
         vm.startPrank(Alice);
 
         token0.mint(Alice, type(uint104).max);
@@ -1266,5 +1289,145 @@ contract Misctest is Test, PositionUtils {
             int256(ct1.convertToAssets(ct1.balanceOf(Alice))) - int256(balanceBefore1),
             999_999_999_998
         );
+    }
+
+    function test_success_liquidation_scenarios() public {
+        vm.startPrank(Swapper);
+        // JIT a bunch of liquidity so swaps at mint can happen normally
+        swapperc.mint(uniPool, -1000, 1000, 10 ** 18);
+
+        // L = 1
+        uniPool.liquidity();
+
+
+        /// @dev single leg, liquidation through price move making options ITM
+        uint256 snapshot = vm.snapshot(); 
+   
+        for (uint256 i; i < 4; ++i) {
+            uint256 asset = i % 2; 
+            uint256 tokenType = i / 2;
+            TokenId tokenId = TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(0, 1, asset, 0, tokenType, 0, 0, 2);
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , )  = uniPool.slot0();
+            
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+           
+            if (tokenType == 0) {
+                token0.approve(address(ct0), 1000);
+                ct0.deposit(1000, Bob);
+            } else {
+                token1.approve(address(ct1), 1000);
+                ct1.deposit(1000, Bob);
+            }
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            
+            (, currentTick, , , , , )  = uniPool.slot0();
+
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+            assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
+            
+            vm.startPrank(Swapper);
+          
+            // swap to 1.21 or 0.82, depending on tokenType
+            swapperc.swapTo(uniPool, tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976);
+            
+            (, currentTick, , , , , )  = uniPool.slot0();
+            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+            
+            assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+         
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+                
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(new TokenId[](0), Bob,LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),posIdList); 
+
+            vm.revertTo(snapshot);    
+        }
+
+        /// @dev single leg, liquidation through price move making options ITM
+   
+        for (uint256 i; i < 8; ++i) {
+            uint256 asset = i % 2; 
+            uint256 tokenType = ((i % 4) / 2);
+            TokenId tokenId;
+            {
+              tokenId = TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)));
+              tokenId = tokenId.addLeg(0, 1, asset, 0, tokenType, 1, tokenType == 0 ? int24(100) : int24(-100), 2);
+              tokenId = tokenId.addLeg(1, 1, asset, 0, 1 - tokenType, 0, tokenType == 1 ? int24(100) : int24(-100), 2);
+                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            }
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , )  = uniPool.slot0();
+            
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+           
+            token0.approve(address(ct0), 1000);
+            ct0.deposit(1000, Bob);
+            token1.approve(address(ct1), 1000);
+            ct1.deposit(1000, Bob);
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            
+            (, currentTick, , , , , )  = uniPool.slot0();
+
+            {
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+            assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
+            }
+            vm.startPrank(Swapper);
+          
+            // swap to 1.41 or 0.62, depending on tokenType
+            swapperc.swapTo(uniPool, i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984);
+            
+            (, currentTick, , , , , )  = uniPool.slot0();
+            {
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+            
+            assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+            }
+            // update twaps
+            for (uint256 i = 0; i < 100; ++i) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+                
+            }
+
+            vm.startPrank(Alice);
+            pp.liquidate(new TokenId[](0), Bob,LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),posIdList); 
+
+            vm.revertTo(snapshot);    
+        }
+
+
     }
 }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -14,6 +14,7 @@ import {ISwapRouter} from "v3-periphery/interfaces/ISwapRouter.sol";
 import {ERC20S} from "@scripts/tokens/ERC20S.sol";
 import {IUniswapV3Factory} from "v3-core/interfaces/IUniswapV3Factory.sol";
 import {IUniswapV3Pool} from "v3-core/interfaces/IUniswapV3Pool.sol";
+import {TickMath} from "v3-core/libraries/TickMath.sol";
 import {TokenId} from "@types/TokenId.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {PanopticMath} from "@libraries/PanopticMath.sol";
@@ -22,6 +23,8 @@ import {SafeTransferLib} from "@libraries/SafeTransferLib.sol";
 import {PositionUtils} from "../testUtils/PositionUtils.sol";
 import {Math} from "@libraries/Math.sol";
 import {Errors} from "@libraries/Errors.sol";
+import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
+import {Constants} from "@libraries/Constants.sol";
 
 contract SwapperC {
     function uniswapV3SwapCallback(
@@ -145,6 +148,14 @@ contract Misctest is Test, PositionUtils {
 
     uint256[] assetsBefore0Arr;
     uint256[] assetsBefore1Arr;
+
+    uint256 basalCR;
+    uint256 amountBorrowed;
+    uint256 amountITM;
+    int256 util;
+    LeftRightUnsigned amountsMoved;
+    uint256 remainingCR;
+    uint160 sqrtPriceTargetX96;
 
     IUniswapV3Pool uniPool;
     ERC20S token0;
@@ -1448,6 +1459,129 @@ contract Misctest is Test, PositionUtils {
         );
     }
 
+    function test_success_liquidation_fuzzedSwapITM(uint256[4] memory prices) public {
+        vm.startPrank(Swapper);
+        // JIT a bunch of liquidity so swaps at mint can happen normally
+        swapperc.mint(uniPool, -1000, 1000, 10 ** 18);
+
+        // L = 1
+        uniPool.liquidity();
+
+        uint256 snapshot = vm.snapshot();
+
+        /// @dev single leg, liquidation through price move making options ITM, no-cross collateral
+        for (uint256 i; i < 4; ++i) {
+            uint256 asset = i % 2;
+            uint256 tokenType = i / 2;
+            TokenId tokenId = TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(0, 1, asset, 0, tokenType, 0, 0, 2);
+
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+            vm.startPrank(Bob);
+            ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+            ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+            if (tokenType == 0) {
+                token0.approve(address(ct0), 1000);
+                ct0.deposit(1000, Bob);
+            } else {
+                token1.approve(address(ct1), 1000);
+                ct1.deposit(1000, Bob);
+            }
+            // mint 1 liquidity unit of wideish centered position
+
+            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            // get base (OTM) collateral requirement for the position we just minted
+            // uint256 basalCR;
+
+            // amount of tokens borrowed to create position -- also amount of tokenType when OTM
+            // uint256 amountBorrowed;
+
+            // amount of other token when deep ITM
+            // uint256 amountITM;
+            (, , util) = tokenType == 0 ? ct0.getPoolData() : ct1.getPoolData();
+
+            amountsMoved = PanopticMath.getAmountsMoved(tokenId, 3000, 0);
+            (amountBorrowed, amountITM) = tokenType == 0
+                ? (amountsMoved.rightSlot(), amountsMoved.leftSlot())
+                : (amountsMoved.leftSlot(), amountsMoved.rightSlot());
+            basalCR = (getSCR(util) * amountBorrowed) / 10_000;
+
+            // compute ITM collateral requirement we would need for the position to be liquidatable
+            remainingCR =
+                (
+                    tokenType == 0
+                        ? ct0.convertToAssets(ct0.balanceOf(Bob))
+                        : ct1.convertToAssets(ct1.balanceOf(Bob))
+                ) -
+                basalCR;
+
+            // find price where the difference between the borrowed tokens and the value of the LP position is equal to the remaining collateral requirement (the "liquidation price")
+            // unless this is an extremely wide/full-range position, this will be deep ITM
+            sqrtPriceTargetX96 = uint160(
+                tokenType == 0
+                    ? FixedPointMathLib.sqrt(
+                        Math.mulDiv(amountITM, 2 ** 192, amountBorrowed - remainingCR - 1)
+                    )
+                    : FixedPointMathLib.sqrt(
+                        Math.mulDiv(amountBorrowed - remainingCR - 1, 2 ** 192, amountITM)
+                    )
+            );
+
+            vm.startPrank(Swapper);
+
+            // swap to somewhere between the liquidation price and maximum/minimum prices
+            // limiting "max/min prices" to reasonable levels for now because protocol breaks at tail ends of AMM curve (can't handle >2**128 tokens)
+            swapperc.swapTo(
+                uniPool,
+                uint160(
+                    bound(
+                        prices[i],
+                        tokenType == 0 ? sqrtPriceTargetX96 : TickMath.getSqrtRatioAtTick(-750_000),
+                        tokenType == 0 ? TickMath.getSqrtRatioAtTick(750_000) : sqrtPriceTargetX96
+                    )
+                )
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+            assertTrue(totalCollateralBalance0 <= totalCollateralRequired0, "Is liquidatable!");
+
+            // update twaps
+            for (uint256 j = 0; j < 100; ++j) {
+                vm.warp(block.timestamp + 120);
+                vm.roll(block.number + 10);
+                swapperc.mint(uniPool, -10, 10, 10 ** 18);
+                swapperc.burn(uniPool, -10, 10, 10 ** 18);
+            }
+
+            // deal alice a bunch of collateral tokens without touching the supply
+            editCollateral(ct0, Alice, ct0.convertToShares(type(uint120).max));
+            editCollateral(ct1, Alice, ct1.convertToShares(type(uint120).max));
+
+            vm.startPrank(Alice);
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint120).max - 1).toLeftSlot(type(uint120).max - 1),
+                posIdList
+            );
+
+            vm.revertTo(snapshot);
+        }
+    }
+
     function test_success_liquidation_ITM_scenarios() public {
         vm.startPrank(Swapper);
         // JIT a bunch of liquidity so swaps at mint can happen normally
@@ -1516,7 +1650,7 @@ contract Misctest is Test, PositionUtils {
             assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
 
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -1595,7 +1729,7 @@ contract Misctest is Test, PositionUtils {
             assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
 
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -1688,7 +1822,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -1780,7 +1914,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -1872,7 +2006,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -1957,7 +2091,7 @@ contract Misctest is Test, PositionUtils {
             assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
 
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -2037,7 +2171,7 @@ contract Misctest is Test, PositionUtils {
             assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
 
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -2127,7 +2261,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -2215,7 +2349,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -2633,7 +2767,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1298,7 +1298,7 @@ contract Misctest is Test, PositionUtils {
         uniPool.liquidity();
 
         uint256 snapshot = vm.snapshot();
-        
+
         /// @dev single leg, liquidation through price move making options ITM, no-cross collateral
 
         for (uint256 i; i < 4; ++i) {
@@ -1546,7 +1546,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
-        
+
         /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token0)
 
         for (uint256 i; i < 8; ++i) {
@@ -1638,7 +1638,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
- 
+
         /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token1)
 
         for (uint256 i; i < 8; ++i) {
@@ -1730,9 +1730,8 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
- 
     }
-    
+
     function test_success_liquidation_LowCollateral_scenarios() public {
         vm.startPrank(Swapper);
         // JIT a bunch of liquidity so swaps at mint can happen normally
@@ -1742,7 +1741,7 @@ contract Misctest is Test, PositionUtils {
         uniPool.liquidity();
 
         uint256 snapshot = vm.snapshot();
-        
+
         /// @dev single leg, liquidation through decrease in collateral, no-cross collateral
 
         for (uint256 i; i < 4; ++i) {
@@ -1990,7 +1989,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
-        
+
         /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token0)
 
         for (uint256 i; i < 8; ++i) {
@@ -2082,7 +2081,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
- 
+
         /// @dev strangles, liquidation through price move making on leg of the option ITM, with cross-collateral (token1)
 
         for (uint256 i; i < 8; ++i) {
@@ -2174,6 +2173,5 @@ contract Misctest is Test, PositionUtils {
 
             vm.revertTo(snapshot);
         }
- 
     }
 }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -353,37 +353,6 @@ contract Misctest is Test, PositionUtils {
         }
     }
 
-    // convert signed int to assets
-    function convertToAssets(CollateralTracker ct, int256 amount) internal view returns (int256) {
-        return (amount > 0 ? int8(1) : -1) * int256(ct.convertToAssets(uint256(Math.abs(amount))));
-    }
-
-    // "virtual" deposit or withdrawal from an account without changing the share price
-    function editCollateral(CollateralTracker ct, address owner, uint256 newShares) internal {
-        int256 shareDelta = int256(newShares) - int256(ct.balanceOf(owner));
-        int256 assetDelta = convertToAssets(ct, shareDelta);
-        vm.store(
-            address(ct),
-            bytes32(uint256(7)),
-            bytes32(
-                uint256(
-                    LeftRightSigned.unwrap(
-                        LeftRightSigned
-                            .wrap(int256(uint256(vm.load(address(ct), bytes32(uint256(7))))))
-                            .add(LeftRightSigned.wrap(assetDelta))
-                    )
-                )
-            )
-        );
-        deal(
-            ct.asset(),
-            address(ct),
-            uint256(int256(IERC20Partial(ct.asset()).balanceOf(address(ct))) + assetDelta)
-        );
-
-        deal(address(ct), owner, newShares, true);
-    }
-
     // Test that risk-partnered positions can be minted/burned succesfully
     function test_success_MintBurnStraddle() public {
         swapperc = new SwapperC();
@@ -2437,7 +2406,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -2460,6 +2429,8 @@ contract Misctest is Test, PositionUtils {
             uint256 asset = i % 2;
             uint256 tokenType = ((i % 4) / 2);
             TokenId tokenId;
+            TokenId[] memory posIdList = new TokenId[](1);
+
             {
                 // sell long leg
                 vm.startPrank(Charlie);
@@ -2476,7 +2447,6 @@ contract Misctest is Test, PositionUtils {
                     2
                 );
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
-                TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
 
                 pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
@@ -2506,7 +2476,6 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
             }
 
-            TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
             (, int24 currentTick, , , , , ) = uniPool.slot0();
@@ -2547,7 +2516,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -2571,6 +2540,8 @@ contract Misctest is Test, PositionUtils {
             uint256 asset = i % 2;
             uint256 tokenType = ((i % 4) / 2);
             TokenId tokenId;
+            TokenId[] memory posIdList = new TokenId[](1);
+
             {
                 // sell long leg
                 vm.startPrank(Charlie);
@@ -2587,7 +2558,6 @@ contract Misctest is Test, PositionUtils {
                     2
                 );
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
-                TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
 
                 pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
@@ -2617,7 +2587,6 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
             }
 
-            TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
             (, int24 currentTick, , , , , ) = uniPool.slot0();
@@ -2657,7 +2626,7 @@ contract Misctest is Test, PositionUtils {
                 assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
-            for (uint256 i = 0; i < 100; ++i) {
+            for (uint256 j = 0; j < 100; ++j) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
@@ -2681,6 +2650,8 @@ contract Misctest is Test, PositionUtils {
             uint256 asset = i % 2;
             uint256 tokenType = ((i % 4) / 2);
             TokenId tokenId;
+            TokenId[] memory posIdList = new TokenId[](1);
+
             {
                 // sell long leg
                 vm.startPrank(Charlie);
@@ -2697,7 +2668,6 @@ contract Misctest is Test, PositionUtils {
                     2
                 );
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
-                TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
 
                 pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
@@ -2727,7 +2697,6 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
             }
 
-            TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
             (, int24 currentTick, , , , , ) = uniPool.slot0();

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1297,9 +1297,9 @@ contract Misctest is Test, PositionUtils {
         // L = 1
         uniPool.liquidity();
 
-        uint256 snapshot = vm.snapshot(); 
+        uint256 snapshot = vm.snapshot();
         /// @dev single leg, liquidation through price move making options ITM, no-cross collateral
-   
+
         for (uint256 i; i < 4; ++i) {
             uint256 asset = i % 2;
             uint256 tokenType = i / 2;
@@ -1376,23 +1376,23 @@ contract Misctest is Test, PositionUtils {
 
         /// @dev single leg, liquidation through price move making options ITM, with cross collateral
         for (uint256 i; i < 4; ++i) {
-            uint256 asset = i % 2; 
+            uint256 asset = i % 2;
             uint256 tokenType = i / 2;
             TokenId tokenId = TokenId
                 .wrap(0)
                 .addPoolId(PanopticMath.getPoolId(address(uniPool)))
                 .addLeg(0, 1, asset, 0, tokenType, 0, 0, 2);
-                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
 
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , )  = uniPool.slot0();
-            
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
             ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
-           
+
             if (tokenType == 0) {
                 token0.approve(address(ct0), 7);
                 ct0.deposit(7, Bob);
@@ -1407,38 +1407,51 @@ contract Misctest is Test, PositionUtils {
             // mint 1 liquidity unit of wideish centered position
 
             pp.mintOptions(posIdList, 3000, 0, 0, 0);
-            
-            (, currentTick, , , , , )  = uniPool.slot0();
 
-            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                .checkCollateral(pp, Bob, currentTick, 0, posIdList);
 
             assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
-            
+
             vm.startPrank(Swapper);
-          
+
             // swap to 1.21 or 0.82, depending on tokenType
-            swapperc.swapTo(uniPool, tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976);
-            
-            (, currentTick, , , , , )  = uniPool.slot0();
-            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
-            
+            swapperc.swapTo(
+                uniPool,
+                tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
+                pp,
+                Bob,
+                currentTick,
+                0,
+                posIdList
+            );
+
             assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
-         
+
             // update twaps
             for (uint256 i = 0; i < 100; ++i) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
                 swapperc.burn(uniPool, -10, 10, 10 ** 18);
-                
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob,LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),posIdList); 
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
 
-            vm.revertTo(snapshot);    
+            vm.revertTo(snapshot);
         }
-
 
         /// @dev strangles, liquidation through price move making on leg of the option ITM
 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -341,6 +341,133 @@ contract Misctest is Test, PositionUtils {
         }
     }
 
+    // Test that risk-partnered positions can be minted/burned succesfully
+    function test_success_MintBurnStraddle() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // mint OTM position
+        $posIdList.push(
+            TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(0, 1, 1, 0, 0, 1, 15, 1)
+                .addLeg(1, 1, 1, 0, 1, 0, 15, 1)
+        );
+
+        vm.startPrank(Bob);
+
+        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+
+        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+    }
+
+    function test_success_MintBurnStrangle() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // mint OTM position
+        $posIdList.push(
+            TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(0, 1, 1, 0, 0, 1, 15, 1)
+                .addLeg(1, 1, 1, 0, 1, 0, -15, 1)
+        );
+
+        vm.startPrank(Bob);
+
+        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+
+        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+    }
+
+    function test_success_MintBurnCallSpread() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        vm.startPrank(Seller);
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                35,
+                1
+            )
+        );
+
+        pp.mintOptions($posIdList, 2_000_000, 0, 0, 0);
+
+        // mint OTM position
+        $posIdList[0] = TokenId
+            .wrap(0)
+            .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+            .addLeg(0, 1, 1, 0, 0, 1, 15, 1)
+            .addLeg(1, 1, 1, 1, 0, 0, 35, 1);
+
+        vm.startPrank(Bob);
+
+        pp.mintOptions($posIdList, 1_000_000, type(uint64).max, 0, 0);
+
+        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+    }
+
+    function test_success_MintBurnPutSpread() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        vm.startPrank(Seller);
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                1,
+                0,
+                -35,
+                1
+            )
+        );
+
+        pp.mintOptions($posIdList, 2_000_000, 0, 0, 0);
+
+        // mint OTM position
+        $posIdList[0] = TokenId
+            .wrap(0)
+            .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+            .addLeg(0, 1, 1, 0, 1, 1, -15, 1)
+            .addLeg(1, 1, 1, 1, 1, 0, -35, 1);
+
+        vm.startPrank(Bob);
+
+        pp.mintOptions($posIdList, 1_000_000, type(uint64).max, 0, 0);
+
+        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+    }
+
     // these tests are PoCs for rounding issues in the premium distribution
     // to demonstrate the issue log the settled, gross, and owed premia at burn
     function test_settledPremiumDistribution_demoInflatedGross() public {

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -205,7 +205,6 @@ contract Misctest is Test, PositionUtils {
             vm.roll(block.number + 1);
             swapperc.mint(uniPool, -10, 10, 10 ** 18);
             swapperc.burn(uniPool, -10, 10, 10 ** 18);
-            
         }
         swapperc.mint(uniPool, -887270, 887270, 10 ** 18);
 
@@ -268,7 +267,6 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 120);
         vm.roll(block.number + 10);
 
- 
         vm.startPrank(Alice);
 
         token0.mint(Alice, type(uint104).max);
@@ -1299,28 +1297,27 @@ contract Misctest is Test, PositionUtils {
         // L = 1
         uniPool.liquidity();
 
-
         /// @dev single leg, liquidation through price move making options ITM
-        uint256 snapshot = vm.snapshot(); 
-   
+        uint256 snapshot = vm.snapshot();
+
         for (uint256 i; i < 4; ++i) {
-            uint256 asset = i % 2; 
+            uint256 asset = i % 2;
             uint256 tokenType = i / 2;
             TokenId tokenId = TokenId
                 .wrap(0)
                 .addPoolId(PanopticMath.getPoolId(address(uniPool)))
                 .addLeg(0, 1, asset, 0, tokenType, 0, 0, 2);
-                //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
+            //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
 
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , )  = uniPool.slot0();
-            
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
             ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
-           
+
             if (tokenType == 0) {
                 token0.approve(address(ct0), 1000);
                 ct0.deposit(1000, Bob);
@@ -1331,62 +1328,92 @@ contract Misctest is Test, PositionUtils {
             // mint 1 liquidity unit of wideish centered position
 
             pp.mintOptions(posIdList, 3000, 0, 0, 0);
-            
-            (, currentTick, , , , , )  = uniPool.slot0();
 
-            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+            (, currentTick, , , , , ) = uniPool.slot0();
+
+            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                .checkCollateral(pp, Bob, currentTick, 0, posIdList);
 
             assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
-            
+
             vm.startPrank(Swapper);
-          
+
             // swap to 1.21 or 0.82, depending on tokenType
-            swapperc.swapTo(uniPool, tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976);
-            
-            (, currentTick, , , , , )  = uniPool.slot0();
-            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
-            
+            swapperc.swapTo(
+                uniPool,
+                tokenType == 0 ? 87150978765690778389772763136 : 72025602285694849958832766976
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
+            (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
+                pp,
+                Bob,
+                currentTick,
+                0,
+                posIdList
+            );
+
             assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
-         
+
             // update twaps
             for (uint256 i = 0; i < 100; ++i) {
                 vm.warp(block.timestamp + 120);
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
                 swapperc.burn(uniPool, -10, 10, 10 ** 18);
-                
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob,LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),posIdList); 
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
 
-            vm.revertTo(snapshot);    
+            vm.revertTo(snapshot);
         }
 
         /// @dev single leg, liquidation through price move making options ITM
-   
+
         for (uint256 i; i < 8; ++i) {
-            uint256 asset = i % 2; 
+            uint256 asset = i % 2;
             uint256 tokenType = ((i % 4) / 2);
             TokenId tokenId;
             {
-              tokenId = TokenId
-                .wrap(0)
-                .addPoolId(PanopticMath.getPoolId(address(uniPool)));
-              tokenId = tokenId.addLeg(0, 1, asset, 0, tokenType, 1, tokenType == 0 ? int24(100) : int24(-100), 2);
-              tokenId = tokenId.addLeg(1, 1, asset, 0, 1 - tokenType, 0, tokenType == 1 ? int24(100) : int24(-100), 2);
+                tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
+                tokenId = tokenId.addLeg(
+                    0,
+                    1,
+                    asset,
+                    0,
+                    tokenType,
+                    1,
+                    tokenType == 0 ? int24(100) : int24(-100),
+                    2
+                );
+                tokenId = tokenId.addLeg(
+                    1,
+                    1,
+                    asset,
+                    0,
+                    1 - tokenType,
+                    0,
+                    tokenType == 1 ? int24(100) : int24(-100),
+                    2
+                );
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
             }
 
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , )  = uniPool.slot0();
-            
+            (, int24 currentTick, , , , , ) = uniPool.slot0();
+
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
             ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
-           
+
             token0.approve(address(ct0), 1000);
             ct0.deposit(1000, Bob);
             token1.approve(address(ct1), 1000);
@@ -1394,24 +1421,32 @@ contract Misctest is Test, PositionUtils {
             // mint 1 liquidity unit of wideish centered position
 
             pp.mintOptions(posIdList, 3000, 0, 0, 0);
-            
-            (, currentTick, , , , , )  = uniPool.slot0();
+
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             {
-            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
 
-            assertTrue(totalCollateralBalance0 >= totalCollateralRequired0, "Is not liquidatable");
+                assertTrue(
+                    totalCollateralBalance0 >= totalCollateralRequired0,
+                    "Is not liquidatable"
+                );
             }
             vm.startPrank(Swapper);
-          
+
             // swap to 1.41 or 0.62, depending on tokenType
-            swapperc.swapTo(uniPool, i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984);
-            
-            (, currentTick, , , , , )  = uniPool.slot0();
+            swapperc.swapTo(
+                uniPool,
+                i > 3 ? 110919427519970065594087112704 : 56591544653045956680544681984
+            );
+
+            (, currentTick, , , , , ) = uniPool.slot0();
             {
-            (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(pp, Bob, currentTick, 0, posIdList);
-            
-            assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
+                (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph
+                    .checkCollateral(pp, Bob, currentTick, 0, posIdList);
+
+                assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable!");
             }
             // update twaps
             for (uint256 i = 0; i < 100; ++i) {
@@ -1419,15 +1454,17 @@ contract Misctest is Test, PositionUtils {
                 vm.roll(block.number + 10);
                 swapperc.mint(uniPool, -10, 10, 10 ** 18);
                 swapperc.burn(uniPool, -10, 10, 10 ** 18);
-                
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob,LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),posIdList); 
+            pp.liquidate(
+                new TokenId[](0),
+                Bob,
+                LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+                posIdList
+            );
 
-            vm.revertTo(snapshot);    
+            vm.revertTo(snapshot);
         }
-
-
     }
 }

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5762,9 +5762,6 @@ contract PanopticPoolTest is PositionUtils {
             "incorrect amount of premium was haircut"
         );
 
-        console2.log("longPremium0", longPremium0);
-        console2.log("$protocolLoss0Actual", $protocolLoss0Actual);
-        console2.log("$protocolLoss0BaseExpected", $protocolLoss0BaseExpected);
         assertApproxEqAbs(
             $protocolLoss0Actual,
             $protocolLoss0BaseExpected - Math.min(longPremium0, $protocolLoss0BaseExpected),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1473,37 +1473,6 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
-    // convert signed int to assets
-    function convertToAssets(CollateralTracker ct, int256 amount) internal view returns (int256) {
-        return (amount > 0 ? int8(1) : -1) * int256(ct.convertToAssets(uint256(Math.abs(amount))));
-    }
-
-    // "virtual" deposit or withdrawal from an account without changing the share price
-    function editCollateral(CollateralTracker ct, address owner, uint256 newShares) internal {
-        int256 shareDelta = int256(newShares) - int256(ct.balanceOf(owner));
-        int256 assetDelta = convertToAssets(ct, shareDelta);
-        vm.store(
-            address(ct),
-            bytes32(uint256(7)),
-            bytes32(
-                uint256(
-                    LeftRightSigned.unwrap(
-                        LeftRightSigned
-                            .wrap(int256(uint256(vm.load(address(ct), bytes32(uint256(7))))))
-                            .add(LeftRightSigned.wrap(assetDelta))
-                    )
-                )
-            )
-        );
-        deal(
-            ct.asset(),
-            address(ct),
-            uint256(int256(IERC20Partial(ct.asset()).balanceOf(address(ct))) + assetDelta)
-        );
-
-        deal(address(ct), owner, newShares, true);
-    }
-
     /*//////////////////////////////////////////////////////////////
                          POOL INITIALIZATION: -
     //////////////////////////////////////////////////////////////*/
@@ -5793,6 +5762,9 @@ contract PanopticPoolTest is PositionUtils {
             "incorrect amount of premium was haircut"
         );
 
+        console2.log("longPremium0", longPremium0);
+        console2.log("$protocolLoss0Actual", $protocolLoss0Actual);
+        console2.log("$protocolLoss0BaseExpected", $protocolLoss0BaseExpected);
         assertApproxEqAbs(
             $protocolLoss0Actual,
             $protocolLoss0BaseExpected - Math.min(longPremium0, $protocolLoss0BaseExpected),

--- a/test/foundry/testUtils/PositionUtils.sol
+++ b/test/foundry/testUtils/PositionUtils.sol
@@ -11,6 +11,9 @@ import {PoolAddress} from "v3-periphery/libraries/PoolAddress.sol";
 import {LiquidityAmounts} from "@uniswap/v3-periphery/contracts/libraries/LiquidityAmounts.sol";
 import {TransferHelper} from "v3-periphery/libraries/TransferHelper.sol";
 import {PanopticMath} from "@libraries/PanopticMath.sol";
+import {CollateralTracker} from "@contracts/CollateralTracker.sol";
+import {Math} from "@libraries/Math.sol";
+import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 
 contract MiniPositionManager {
     struct CallbackData {
@@ -1367,5 +1370,90 @@ contract PositionUtils is Test {
         }
 
         return calldataWithoutSelector;
+    }
+
+    function getSCR(int256 utilization) internal pure returns (uint256 sellCollateralRatio) {
+        // the sell ratio is on a straight line defined between two points (x0,y0) and (x1,y1):
+        //   (x0,y0) = (targetPoolUtilization,min_sell_ratio) and
+        //   (x1,y1) = (saturatedPoolUtilization,max_sell_ratio)
+        // the line's formula: y = a * (x - x0) + y0, where a = (y1 - y0) / (x1 - x0)
+        /**
+            SELL
+            COLLATERAL
+            RATIO
+                          ^
+                          |                  max ratio = 100%
+                   100% - |                _------
+                          |             _-¯
+                          |          _-¯
+                    20% - |---------¯
+                          |         .       . .
+                          +---------+-------+-+--->   POOL_
+                                   50%    90% 100%     UTILIZATION
+        */
+
+        uint256 min_sell_ratio = 2000;
+        /// if utilization is less than zero, this is the calculation for a strangle, which gets 2x the capital efficiency at low pool utilization
+        /// at 0% utilization, strangle legs do not compound efficiency
+        if (utilization < 0) {
+            unchecked {
+                min_sell_ratio /= 2;
+                utilization = -utilization;
+            }
+        }
+
+        // return the basal sell ratio if pool utilization is lower than target
+        if (uint256(utilization) < 5000) {
+            return min_sell_ratio;
+        }
+
+        // return 100% collateral ratio if utilization is above saturated pool utilization
+        // this means all new positions are fully collateralized, which reduces risks of insolvency at high pool utilization
+        if (uint256(utilization) > 9000) {
+            return 10000;
+        }
+
+        unchecked {
+            return
+                min_sell_ratio +
+                ((10000 - min_sell_ratio) * (uint256(utilization) - 5000)) /
+                (9000 - 5000);
+        }
+    }
+
+    // convert signed int to assets
+    function convertToAssets(CollateralTracker ct, int256 amount) internal view returns (int256) {
+        return (amount > 0 ? int8(1) : -1) * int256(ct.convertToAssets(uint256(Math.abs(amount))));
+    }
+
+    // "virtual" deposit or withdrawal from an account without changing the share price
+    function editCollateral(CollateralTracker ct, address owner, uint256 newShares) internal {
+        int256 shareDelta = int256(newShares) - int256(ct.balanceOf(owner));
+        int256 assetDelta = convertToAssets(ct, shareDelta);
+        console2.log("assetDelta", assetDelta);
+        console2.log("assetsBefore", ct.totalAssets());
+        vm.store(
+            address(ct),
+            bytes32(uint256(7)),
+            bytes32(
+                uint256(
+                    LeftRightSigned.unwrap(
+                        LeftRightSigned
+                            .wrap(int256(uint256(vm.load(address(ct), bytes32(uint256(7))))))
+                            .add(LeftRightSigned.wrap(assetDelta))
+                    )
+                )
+            )
+        );
+        console2.log("assetAfter", ct.totalAssets());
+
+        deal(
+            ct.asset(),
+            address(ct),
+            uint256(int256(IERC20Partial(ct.asset()).balanceOf(address(ct))) + assetDelta)
+        );
+        console2.log("balBefore", ct.balanceOf(owner));
+        deal(address(ct), owner, newShares, true);
+        console2.log("balAfter", ct.balanceOf(owner));
     }
 }

--- a/test/foundry/testUtils/PositionUtils.sol
+++ b/test/foundry/testUtils/PositionUtils.sol
@@ -1430,8 +1430,6 @@ contract PositionUtils is Test {
     function editCollateral(CollateralTracker ct, address owner, uint256 newShares) internal {
         int256 shareDelta = int256(newShares) - int256(ct.balanceOf(owner));
         int256 assetDelta = convertToAssets(ct, shareDelta);
-        console2.log("assetDelta", assetDelta);
-        console2.log("assetsBefore", ct.totalAssets());
         vm.store(
             address(ct),
             bytes32(uint256(7)),
@@ -1445,15 +1443,13 @@ contract PositionUtils is Test {
                 )
             )
         );
-        console2.log("assetAfter", ct.totalAssets());
 
         deal(
             ct.asset(),
             address(ct),
             uint256(int256(IERC20Partial(ct.asset()).balanceOf(address(ct))) + assetDelta)
         );
-        console2.log("balBefore", ct.balanceOf(owner));
+
         deal(address(ct), owner, newShares, true);
-        console2.log("balAfter", ct.balanceOf(owner));
     }
 }


### PR DESCRIPTION
The tokenId validation in the SFPM has always been done on the post-flip tokenId when a position is being burned, but we recently added a rule prohibiting long strangles. If a user minted a short strangle and attempted to burn it, their tokenId would be flipped and validated as a long strangle, resulting in the check for that rule failing and DoSing their account. The solution for this is to just move the validation before the tokenId is flipped.