### PR TITLE
fix: sign flip in `settleLongPremium` causes payments to flow the wrong way

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1634,8 +1634,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 .toLeftSlot(int128(int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64)));
 
             // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-            s_collateralToken0.exercise(owner, 0, 0, 0, realizedPremia.rightSlot());
-            s_collateralToken1.exercise(owner, 0, 0, 0, realizedPremia.leftSlot());
+            s_collateralToken0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
+            s_collateralToken1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
 
             bytes32 chunkKey = keccak256(
                 abi.encodePacked(

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -900,13 +900,13 @@ contract Misctest is Test, PositionUtils {
         }
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[0])) - assetsBefore0,
+            assetsBefore0 - ct0.convertToAssets(ct0.balanceOf(Buyers[0])),
             33_342,
             "Incorrect Buyer 1 1st Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[0])) - assetsBefore1,
+            assetsBefore1 - ct1.convertToAssets(ct1.balanceOf(Buyers[0])),
             33_343_452,
             "Incorrect Buyer 1 1st Collect 1"
         );
@@ -964,37 +964,37 @@ contract Misctest is Test, PositionUtils {
         }
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[0])) - assetsBefore0Arr[0],
+            assetsBefore0Arr[0] - ct0.convertToAssets(ct0.balanceOf(Buyers[0])),
             333,
             "Incorrect Buyer 1 2nd Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[0])) - assetsBefore1Arr[0],
+            assetsBefore1Arr[0] - ct1.convertToAssets(ct1.balanceOf(Buyers[0])),
             3_333,
             "Incorrect Buyer 1 2nd Collect 1"
         );
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[1])) - assetsBefore0Arr[1],
+            assetsBefore0Arr[1] - ct0.convertToAssets(ct0.balanceOf(Buyers[1])),
             333,
             "Incorrect Buyer 2 2nd Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[1])) - assetsBefore1Arr[1],
+            assetsBefore1Arr[1] - ct1.convertToAssets(ct1.balanceOf(Buyers[1])),
             3_333,
             "Incorrect Buyer 2 2nd Collect 1"
         );
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[2])) - assetsBefore0Arr[2],
+            assetsBefore0Arr[2] - ct0.convertToAssets(ct0.balanceOf(Buyers[2])),
             333,
             "Incorrect Buyer 3 2nd Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[2])) - assetsBefore1Arr[2],
+            assetsBefore1Arr[2] - ct1.convertToAssets(ct1.balanceOf(Buyers[2])),
             3_333,
             "Incorrect Buyer 3 2nd Collect 1"
         );
@@ -1033,37 +1033,37 @@ contract Misctest is Test, PositionUtils {
         }
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[0])) - assetsBefore0Arr[0],
+            assetsBefore0Arr[0] - ct0.convertToAssets(ct0.balanceOf(Buyers[0])),
             0,
             "Incorrect Buyer 1 3rd Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[0])) - assetsBefore1Arr[0],
+            assetsBefore1Arr[0] - ct1.convertToAssets(ct1.balanceOf(Buyers[0])),
             0,
             "Incorrect Buyer 1 3rd Collect 1"
         );
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[1])) - assetsBefore0Arr[1],
+            assetsBefore0Arr[1] - ct0.convertToAssets(ct0.balanceOf(Buyers[1])),
             0,
             "Incorrect Buyer 2 3rd Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[1])) - assetsBefore1Arr[1],
+            assetsBefore1Arr[1] - ct1.convertToAssets(ct1.balanceOf(Buyers[1])),
             0,
             "Incorrect Buyer 2 3rd Collect 1"
         );
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[2])) - assetsBefore0Arr[2],
+            assetsBefore0Arr[2] - ct0.convertToAssets(ct0.balanceOf(Buyers[2])),
             0,
             "Incorrect Buyer 3 3rd Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[2])) - assetsBefore1Arr[2],
+            assetsBefore1Arr[2] - ct1.convertToAssets(ct1.balanceOf(Buyers[2])),
             0,
             "Incorrect Buyer 3 3rd Collect 1"
         );
@@ -1085,37 +1085,37 @@ contract Misctest is Test, PositionUtils {
         }
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[0])) - assetsBefore0Arr[0],
+            assetsBefore0Arr[0] - ct0.convertToAssets(ct0.balanceOf(Buyers[0])),
             0,
             "Incorrect Buyer 1 4th Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[0])) - assetsBefore1Arr[0],
+            assetsBefore1Arr[0] - ct1.convertToAssets(ct1.balanceOf(Buyers[0])),
             0,
             "Incorrect Buyer 1 4th Collect 1"
         );
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[1])) - assetsBefore0Arr[1],
+            assetsBefore0Arr[1] - ct0.convertToAssets(ct0.balanceOf(Buyers[1])),
             33_342,
             "Incorrect Buyer 2 4th Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[1])) - assetsBefore1Arr[1],
+            assetsBefore1Arr[1] - ct1.convertToAssets(ct1.balanceOf(Buyers[1])),
             33_343_452,
             "Incorrect Buyer 2 4th Collect 1"
         );
 
         assertEq(
-            ct0.convertToAssets(ct0.balanceOf(Buyers[2])) - assetsBefore0Arr[2],
+            assetsBefore0Arr[2] - ct0.convertToAssets(ct0.balanceOf(Buyers[2])),
             33_342,
             "Incorrect Buyer 3 4th Collect 0"
         );
 
         assertEq(
-            ct1.convertToAssets(ct1.balanceOf(Buyers[2])) - assetsBefore1Arr[2],
+            assetsBefore1Arr[2] - ct1.convertToAssets(ct1.balanceOf(Buyers[2])),
             33_343_452,
             "Incorrect Buyer 3 4th Collect 1"
         );


### PR DESCRIPTION
The wrong convention was used for the `realizedPremia`  values passed into `exercise` during `settleLongPremium` -- they are never flipped negative (as they are for long positions during the `burnOptions` flow), causing premium payments to be credited instead of debited from buyers.

We have an extensive test covering this logic, but a separate issue prevented it from catching this. Token delta calculations for both buyer *and* seller accounts used the same format: `ctN.convertToAssets(ctN.balanceOf(account)) - assetsBeforeN`, but those terms need to be reversed for buyers because their deltas have the opposite sign.

So, effectively, this issue was caused by sign flips present in both the actual logic and the tests. In the future, we need to conduct more careful review of the assertions we make in tests. The code here is not visibly incorrect (that convention could have been easily been the reverse), so in situations like these we have to rely on the test assertions being accurate.