### PR TITLE
fix: update settlement at burn when legPremia = 0

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1857,117 +1857,112 @@ contract PanopticPool is ERC1155Holder, Multicall {
             // collected from Uniswap
             LeftRightUnsigned settledTokens = s_settledTokens[chunkKey].add(collectedByLeg[leg]);
 
-            if (LeftRightSigned.unwrap(legPremia) != 0) {
-                // (will be) paid by long legs
-                if (tokenId.isLong(leg) == 1) {
-                    if (commitLongSettled)
-                        settledTokens = LeftRightUnsigned.wrap(
-                            uint256(
-                                LeftRightSigned.unwrap(
-                                    LeftRightSigned
-                                        .wrap(int256(LeftRightUnsigned.unwrap(settledTokens)))
-                                        .sub(legPremia)
+            // (will be) paid by long legs
+            if (tokenId.isLong(leg) == 1) {
+                if (commitLongSettled)
+                    settledTokens = LeftRightUnsigned.wrap(
+                        uint256(
+                            LeftRightSigned.unwrap(
+                                LeftRightSigned
+                                    .wrap(int256(LeftRightUnsigned.unwrap(settledTokens)))
+                                    .sub(legPremia)
+                            )
+                        )
+                    );
+                realizedPremia = realizedPremia.add(legPremia);
+            } else {
+                uint256 positionLiquidity = PanopticMath
+                    .getLiquidityChunk(tokenId, leg, positionSize)
+                    .liquidity();
+
+                // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (T - R)
+                uint256 totalLiquidity = _getTotalLiquidity(tokenId, leg);
+                // T (totalLiquidity is (T - R) after burning)
+                uint256 totalLiquidityBefore = totalLiquidity + positionLiquidity;
+
+                LeftRightUnsigned grossPremiumLast = s_grossPremiumLast[chunkKey];
+
+                LeftRightUnsigned availablePremium = _getAvailablePremium(
+                    totalLiquidity + positionLiquidity,
+                    settledTokens,
+                    grossPremiumLast,
+                    LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(legPremia))),
+                    premiumAccumulatorsByLeg[leg]
+                );
+
+                // subtract settled tokens sent to seller
+                settledTokens = settledTokens.sub(availablePremium);
+
+                // add available premium to amount that should be settled
+                realizedPremia = realizedPremia.add(
+                    LeftRightSigned.wrap(int256(LeftRightUnsigned.unwrap(availablePremium)))
+                );
+
+                // We need to adjust the grossPremiumLast value such that the result of
+                // (grossPremium - adjustedGrossPremiumLast)*updatedTotalLiquidityPostBurn/2**64 is equal to
+                // (grossPremium - grossPremiumLast)*totalLiquidityBeforeBurn/2**64 - premiumOwedToPosition
+                // G: total gross premium (- premiumOwedToPosition)
+                // T: totalLiquidityBeforeMint
+                // R: positionLiquidity
+                // C: current grossPremium value
+                // L: current grossPremiumLast value
+                // Ln: updated grossPremiumLast value
+                // T * (C - L) = G
+                // (T - R) * (C - Ln) = G - P
+                //
+                // T * (C - L) = (T - R) * (C - Ln) + P
+                // (TC - TL - P) / (T - R) = C - Ln
+                // Ln = C - (TC - TL - P) / (T - R)
+                // Ln = (TC - CR - TC + LT + P) / (T-R)
+                // Ln = (LT - CR + P) / (T-R)
+
+                unchecked {
+                    uint256[2][4] memory _premiumAccumulatorsByLeg = premiumAccumulatorsByLeg;
+                    uint256 _leg = leg;
+
+                    // if there's still liquidity, compute the new grossPremiumLast
+                    // otherwise, we just reset grossPremiumLast to the current grossPremium
+                    s_grossPremiumLast[chunkKey] = totalLiquidity != 0
+                        ? LeftRightUnsigned
+                            .wrap(0)
+                            .toRightSlot(
+                                uint128(
+                                    uint256(
+                                        Math.max(
+                                            (int256(
+                                                grossPremiumLast.rightSlot() * totalLiquidityBefore
+                                            ) -
+                                                int256(
+                                                    _premiumAccumulatorsByLeg[_leg][0] *
+                                                        positionLiquidity
+                                                )) + int256(legPremia.rightSlot() * 2 ** 64),
+                                            0
+                                        )
+                                    ) / totalLiquidity
                                 )
                             )
-                        );
-                    realizedPremia = realizedPremia.add(legPremia);
-                } else {
-                    uint256 positionLiquidity = PanopticMath
-                        .getLiquidityChunk(tokenId, leg, positionSize)
-                        .liquidity();
-
-                    // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (T - R)
-                    uint256 totalLiquidity = _getTotalLiquidity(tokenId, leg);
-                    // T (totalLiquidity is (T - R) after burning)
-                    uint256 totalLiquidityBefore = totalLiquidity + positionLiquidity;
-
-                    LeftRightUnsigned grossPremiumLast = s_grossPremiumLast[chunkKey];
-
-                    LeftRightUnsigned availablePremium = _getAvailablePremium(
-                        totalLiquidity + positionLiquidity,
-                        settledTokens,
-                        grossPremiumLast,
-                        LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(legPremia))),
-                        premiumAccumulatorsByLeg[leg]
-                    );
-
-                    // subtract settled tokens sent to seller
-                    settledTokens = settledTokens.sub(availablePremium);
-
-                    // add available premium to amount that should be settled
-                    realizedPremia = realizedPremia.add(
-                        LeftRightSigned.wrap(int256(LeftRightUnsigned.unwrap(availablePremium)))
-                    );
-
-                    // We need to adjust the grossPremiumLast value such that the result of
-                    // (grossPremium - adjustedGrossPremiumLast)*updatedTotalLiquidityPostBurn/2**64 is equal to
-                    // (grossPremium - grossPremiumLast)*totalLiquidityBeforeBurn/2**64 - premiumOwedToPosition
-                    // G: total gross premium (- premiumOwedToPosition)
-                    // T: totalLiquidityBeforeMint
-                    // R: positionLiquidity
-                    // C: current grossPremium value
-                    // L: current grossPremiumLast value
-                    // Ln: updated grossPremiumLast value
-                    // T * (C - L) = G
-                    // (T - R) * (C - Ln) = G - P
-                    //
-                    // T * (C - L) = (T - R) * (C - Ln) + P
-                    // (TC - TL - P) / (T - R) = C - Ln
-                    // Ln = C - (TC - TL - P) / (T - R)
-                    // Ln = (TC - CR - TC + LT + P) / (T-R)
-                    // Ln = (LT - CR + P) / (T-R)
-
-                    unchecked {
-                        uint256[2][4] memory _premiumAccumulatorsByLeg = premiumAccumulatorsByLeg;
-                        uint256 _leg = leg;
-
-                        // if there's still liquidity, compute the new grossPremiumLast
-                        // otherwise, we just reset grossPremiumLast to the current grossPremium
-                        s_grossPremiumLast[chunkKey] = totalLiquidity != 0
-                            ? LeftRightUnsigned
-                                .wrap(0)
-                                .toRightSlot(
-                                    uint128(
-                                        uint256(
-                                            Math.max(
-                                                (int256(
-                                                    grossPremiumLast.rightSlot() *
-                                                        totalLiquidityBefore
-                                                ) -
-                                                    int256(
-                                                        _premiumAccumulatorsByLeg[_leg][0] *
-                                                            positionLiquidity
-                                                    )) + int256(legPremia.rightSlot() * 2 ** 64),
-                                                0
-                                            )
-                                        ) / totalLiquidity
-                                    )
+                            .toLeftSlot(
+                                uint128(
+                                    uint256(
+                                        Math.max(
+                                            (int256(
+                                                grossPremiumLast.leftSlot() * totalLiquidityBefore
+                                            ) -
+                                                int256(
+                                                    _premiumAccumulatorsByLeg[_leg][1] *
+                                                        positionLiquidity
+                                                )) + int256(legPremia.leftSlot()) * 2 ** 64,
+                                            0
+                                        )
+                                    ) / totalLiquidity
                                 )
-                                .toLeftSlot(
-                                    uint128(
-                                        uint256(
-                                            Math.max(
-                                                (int256(
-                                                    grossPremiumLast.leftSlot() *
-                                                        totalLiquidityBefore
-                                                ) -
-                                                    int256(
-                                                        _premiumAccumulatorsByLeg[_leg][1] *
-                                                            positionLiquidity
-                                                    )) + int256(legPremia.leftSlot()) * 2 ** 64,
-                                                0
-                                            )
-                                        ) / totalLiquidity
-                                    )
-                                )
-                            : LeftRightUnsigned
-                                .wrap(0)
-                                .toRightSlot(uint128(premiumAccumulatorsByLeg[_leg][0]))
-                                .toLeftSlot(uint128(premiumAccumulatorsByLeg[_leg][1]));
-                    }
+                            )
+                        : LeftRightUnsigned
+                            .wrap(0)
+                            .toRightSlot(uint128(premiumAccumulatorsByLeg[_leg][0]))
+                            .toLeftSlot(uint128(premiumAccumulatorsByLeg[_leg][1]));
                 }
             }
-
             // update settled tokens in storage with all local deltas
             s_settledTokens[chunkKey] = settledTokens;
 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -480,6 +480,105 @@ contract Misctest is Test, PositionUtils {
         pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
     }
 
+    // total owed/grossPremiumLast should not change when positions with 0 premia are minted/burnt
+    function test_settledtracking_premia0() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // mint OTM position
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        $tempIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        $tempIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                1,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
+        assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
+
+        vm.startPrank(Alice);
+        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+
+        vm.startPrank(Bob);
+        pp.mintOptions($posIdList, 1_000_000_000, 0, 0, 0);
+
+        pp.mintOptions($tempIdList, 900_000_000, type(uint64).max, 0, 0);
+
+        vm.startPrank(Swapper);
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
+
+        accruePoolFeesInRange(
+            address(uniPool),
+            uniPool.liquidity() - 1,
+            1_000_000_000_000_000_000_000,
+            1_000_000_000_000
+        );
+        swapperc.swapTo(uniPool, 2 ** 96);
+
+        uint256 snap = vm.snapshot();
+        vm.startPrank(Charlie);
+
+        for (uint256 i = 0; i < 10; i++) {
+            pp.mintOptions($posIdList, 250_000_000, type(uint64).max, 0, 0);
+
+            pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        }
+
+        vm.startPrank(Alice);
+        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+
+        uint256 delta0 = ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0;
+        uint256 delta1 = ct1.convertToAssets(ct1.balanceOf(Alice)) - assetsBefore1;
+        vm.revertTo(snap);
+
+        vm.startPrank(Alice);
+        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+
+        // there is a small amount of error in token0 -- this is the commissions from Charlie
+        assertApproxEqAbs(
+            delta0,
+            ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0,
+            3_000_000
+        );
+        assertEq(delta1, ct1.convertToAssets(ct1.balanceOf(Alice)) - assetsBefore1);
+    }
+
     // these tests are PoCs for rounding issues in the premium distribution
     // to demonstrate the issue log the settled, gross, and owed premia at burn
     function test_settledPremiumDistribution_demoInflatedGross() public {
@@ -755,7 +854,6 @@ contract Misctest is Test, PositionUtils {
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
 
         // There are some precision issues with this (1B is not exactly 1B) but close enough to see the effects
-        accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1_000_000, 1_000_000_000);
         console2.log("liquidity", uniPool.liquidity());
 
         // accumulate lower order of fees on dummy chunk

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -854,6 +854,7 @@ contract Misctest is Test, PositionUtils {
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
 
         // There are some precision issues with this (1B is not exactly 1B) but close enough to see the effects
+        accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1_000_000, 1_000_000_000);
         console2.log("liquidity", uniPool.liquidity());
 
         // accumulate lower order of fees on dummy chunk


### PR DESCRIPTION
The`s_grossPremiumLast` update in `_updateSettlementPostBurn` is gated by a `legPremia != 0` check.  While this may appear logical because that check necessarily implies there is no change in the overall amount of premium owed to sellers for a given chunk, `s_grossPremiumLast` needs to be updated regardless because it is a *per-liquidity* accumulator. When sellers close their positions, the total premium owed according to the previous `s_grossPremiumLast` decreases by `currentGross - grossPremiumLast * closedLiq`. This occurs regardless of the the amount of premium owed to the seller, because the total amount of liquidity sold decreases. In the `_updateSettlementPostBurn` calculation, the premium owed to a seller is subtracted from the total premium, and `s_grossPremiumLast` is adjusted to reflect the remaining amounts of premium and liquidity in that chunk. In the case where a seller is not owed any premium, that calculation will still result in a lower `s_grossPremiumLast` to account for the liquidity removed by that seller at burn (which mirrors the increase in `s_grossPremiumLast` at mint). Thus, we cannot skip that calculation --  if positions are minted and burned in a loop and earn no premium, the calculated premium total will gradually decrease (`s_grossPremiumLast` increases at mint with no corresponding increase when the position is burned), breaking the invariant that sellers can only withdraw `max(owedSeller, owedSeller*settledTotal/owedTotal)` tokens of premium.

To rectify this, we simply remove that `legPremia != 0` check. There are no significant gas consequences/side effects to doing this.

This was not caught by our existing test suite because the only way to observe the effects of that internal state change is by minting and burning multiple positions with no premium, then attempting to withdraw from that chunk while a long position owes a significant portion of the premium. Our Echidna tests should be able to catch this soon -- the required sequence of transactions can be generated rather easily and we can check the invariants directly on the internal settlement state.