### PR TITLE
fix: use correct formula for commission fee in `maxMint`

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -423,7 +423,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return maxShares The maximum amount of shares that can be minted.
     function maxMint(address) external view returns (uint256 maxShares) {
         unchecked {
-            return (convertToShares(type(uint104).max) * DECIMALS) / (DECIMALS + COMMISSION_FEE);
+            return (convertToShares(type(uint104).max) * (DECIMALS - COMMISSION_FEE)) / DECIMALS;
         }
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -5367,7 +5367,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         _initWorld(x);
 
         // use a fixed amount for single test
-        uint256 expectedValue = (collateralToken0.convertToShares(type(uint104).max) * 1000) / 1001;
+        uint256 expectedValue = (collateralToken0.convertToShares(type(uint104).max) * 999) / 1000;
 
         // real value
         uint256 actualValue = collateralToken0.maxMint(Bob);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -480,6 +480,10 @@ contract Misctest is Test, PositionUtils {
         pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
     }
 
+    function test_parity_maxmint_previewmint() public {
+        assertEq(ct0.previewMint(ct0.maxMint(Alice)), type(uint104).max);
+    }
+
     // these tests are PoCs for rounding issues in the premium distribution
     // to demonstrate the issue log the settled, gross, and owed premia at burn
     function test_settledPremiumDistribution_demoInflatedGross() public {


### PR DESCRIPTION
At one point, the MEV tax was (inaccurately) calculated as `deposit / (1 + fee)` instead of `deposit * (1 - fee)`. This was later corrrected everywhere except for the `maxMint` function, which currently returns a value slightly than the actual maximum amount of shares that can be minted.  We don't use this function internally, but this could be a niche issue for integrators (in the unlikely case they are trying to deposit the maximum amount possible of a token for which `2**104 wei` is a reasonable quantity).