### PR TITLE
fix: prevent users from purchasing all liquidity in a chunk

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1478,7 +1478,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         uint128 netLiquidity = accountLiquidities.rightSlot();
         uint128 removedLiquidity = accountLiquidities.leftSlot();
         // compute and return effective liquidity. Return if short=net=0, which is closing short position
-        if (netLiquidity == 0) return;
+        if (netLiquidity == 0 && removedLiquidity == 0) return;
 
         uint256 effectiveLiquidityFactorX32;
         unchecked {

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -480,6 +480,50 @@ contract Misctest is Test, PositionUtils {
         pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
     }
 
+    function test_fail_buyAllLiquidity() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // mint OTM position
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        $tempIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                1,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        vm.startPrank(Alice);
+        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+
+        vm.startPrank(Bob);
+
+        vm.expectRevert(stdError.divisionError);
+        pp.mintOptions($tempIdList, 1_000_000, 0, 0, 0);
+    }
+
     // these tests are PoCs for rounding issues in the premium distribution
     // to demonstrate the issue log the settled, gross, and owed premia at burn
     function test_settledPremiumDistribution_demoInflatedGross() public {


### PR DESCRIPTION
Buyers in Panoptic are limited to purchasing 90% of the liquidity in a chunk. This is in part because the limit of the premium multiplier as utilization approaches 100% is infinity. This invariant is checked in `_checkLiquiditySpread` after every minted long option and burned short option (burning short options increases the utilization), however, we have an early return for the last short position burned (since the resulting numerator and denominator used to compute the utilization are both 0 in that case). The issue here is that we only checked if the denominator (`netLiquidity`) is zero, which can *also* occur if a buyer purchased 100% of the liquidity in a chunk. If a buyer were to do this, premium accumulation would cease (because premium is computed off the amount of tokens collected for the remaining liquidity in the pool) and our invariant would be broken.

The solution to this is to confirm that *both* `netLiquidity` and `removedLiquidity` are zero before skipping the check. If a buyer attempts to purchase all of the liquidity in a chunk, the function will revert with a division panic while attempting to compute the utilization (which prevents that buyer from breaking the utilization invariant). 