### PR TITLE
fix: add support for <1bps pools

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -115,7 +115,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     uint128 internal s_inAMM;
 
     /// @notice additional risk premium charged on intrinsic value of ITM positions,
-    /// defined in basis points as a multiple of the pool fee / 10_000.
+    /// defined in hundredths of basis points.
     /// @dev The result of the calculation is stored instead of the multiple to save gas during usage.
     /// When the fee is set, the multiple is calculated and stored
     uint128 internal s_ITMSpreadFee;

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -223,12 +223,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // store the Panoptic pool for this collateral token
         s_panopticPool = panopticPool;
 
-        // cache the pool fee in basis points
-        uint24 _poolFee;
-        unchecked {
-            _poolFee = fee / 100;
-        }
-        s_poolFee = _poolFee;
+        // cache the pool fee in hundredths of basis points
+        s_poolFee = fee;
 
         // Stores the addresses of the underlying tracked tokens.
         s_univ3token0 = token0;
@@ -239,7 +235,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         // Additional risk premium charged on intrinsic value of ITM positions
         unchecked {
-            s_ITMSpreadFee = uint128((ITM_SPREAD_MULTIPLIER * _poolFee) / DECIMALS);
+            s_ITMSpreadFee = uint128((ITM_SPREAD_MULTIPLIER * fee) / DECIMALS);
         }
     }
 
@@ -1088,7 +1084,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 // the swap commission is paid on the intrinsic value, and it is always positive
                 uint256 swapCommission = Math.unsafeDivRoundingUp(
                     s_ITMSpreadFee * uint256(Math.abs(intrinsicValue)),
-                    DECIMALS
+                    DECIMALS * 100
                 );
 
                 // set the exchanged amount to the sum of the intrinsic value and swapCommission

--- a/contracts/libraries/InteractionHelper.sol
+++ b/contracts/libraries/InteractionHelper.sol
@@ -42,7 +42,7 @@ library InteractionHelper {
     /// @param token0 The token0 in the Uniswap Pool
     /// @param token1 The token1 in the Uniswap Pool
     /// @param isToken0 Whether the collateral token computing the name is for token0 or token1
-    /// @param fee The fee of the Uniswap pool in basis points
+    /// @param fee The fee of the Uniswap pool in hundredths of basis points
     /// @param prefix A constant string appended to the start of the token name
     /// @return The complete name of the collateral token calling this function
     function computeName(

--- a/contracts/libraries/InteractionHelper.sol
+++ b/contracts/libraries/InteractionHelper.sol
@@ -78,7 +78,14 @@ library InteractionHelper {
                     "/",
                     symbol1,
                     " ",
-                    Strings.toString(fee),
+                    Strings.toString(fee / 100),
+                    fee % 100 == 0
+                        ? ""
+                        : string.concat(
+                            ".",
+                            Strings.toString((fee / 10) % 10),
+                            Strings.toString(fee % 10)
+                        ),
                     "bps"
                 );
         }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -480,6 +480,40 @@ contract Misctest is Test, PositionUtils {
         pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
     }
 
+    function test_success_ITMspreadfee_0_01bp() public {
+        CollateralTracker(collateralReference).startToken(
+            true,
+            address(token0),
+            address(token1),
+            1,
+            pp
+        );
+
+        vm.startPrank(Bob);
+        token0.mint(Bob, type(uint104).max);
+        token0.approve(collateralReference, type(uint104).max);
+        CollateralTracker(collateralReference).deposit(type(uint104).max, Bob);
+
+        vm.startPrank(Alice);
+        token0.mint(Alice, (uint256(1_000_000_000_000_000) * 10_000) / 9_990);
+        token0.approve(collateralReference, (uint256(1_000_000_000_000_000) * 10_000) / 9_990);
+        CollateralTracker(collateralReference).deposit(
+            (uint256(1_000_000_000_000_000) * 10_000) / 9_990,
+            Alice
+        );
+
+        vm.startPrank(address(pp));
+        CollateralTracker(collateralReference).takeCommissionAddData(Alice, 0, 0, 1_000_000_000);
+        assertEq(
+            1_000_000_000_000_000 -
+                1 -
+                CollateralTracker(collateralReference).convertToAssets(
+                    CollateralTracker(collateralReference).balanceOf(Alice)
+                ),
+            1_000_000_000 + 2000
+        );
+    }
+
     // these tests are PoCs for rounding issues in the premium distribution
     // to demonstrate the issue log the settled, gross, and owed premia at burn
     function test_settledPremiumDistribution_demoInflatedGross() public {

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1551,12 +1551,12 @@ contract PanopticPoolTest is PositionUtils {
 
         assertEq(
             vm.load(address(ct0), bytes32(uint256(8))),
-            bytes32(uint256((2 * uint256(fee)) / 100 + (uint256(fee / 100) << 128)))
+            bytes32(uint256((2 * uint256(fee)) + (uint256(fee) << 128)))
         ); // ITMSpreadFee + poolFee
 
         assertEq(
             vm.load(address(ct1), bytes32(uint256(8))),
-            bytes32(uint256((2 * uint256(fee)) / 100 + (uint256(fee / 100) << 128)))
+            bytes32(uint256((2 * uint256(fee)) + (uint256(fee) << 128)))
         ); // ITMSpreadFee + poolFee
 
         assertEq(vm.load(address(ct0), bytes32(uint256(9))), bytes32(uint256(0))); // 0


### PR DESCRIPTION
The available Uniswap V3 fee tiers are limited to 1bps, 5bps, 30bps, and 100bps. However, there are proposals for even lower fee tiers -- 0.1bps or 0.01bps. Also, in Uniswap V4, users will be able to select from the full set of possible fee tiers when creating a pool.

Fee tiers in Uniswap are stored in hundredths of basis points (e.g. 5bps would be represented as `500`), but we convert the fee to basis points internally. This means that any fee tier below 1bps would be stored as `0`, which results in a token name with a fee tier of `"0bps"` and an ITM spread fee of 0. 

To rectify this, we need to store the fee tiers in hundredths of basis points, adjust the ITM spread fee denominator accordingly, and add decimal support to the token name calculation. This allows the ITM spread fee to be computed accurately on pools with <1bps and ensure token names on different fee tiers are differentiated (i.e. "0.03bps" or "0.49bps" instead of both "0bps").