### PR TITLE
fix: prevent removed liquidity from overflowing

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1027,10 +1027,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                 /// @dev If the isLong flag is 1=long and the position is minted, then this is opening a long position
                 /// @dev so the amount of removed liquidity should increase.
                 if (!isBurn) {
-                    // we can't remove more liquidity than we add in the first place, so this can't overflow
-                    unchecked {
-                        removedLiquidity += chunkLiquidity;
-                    }
+                    removedLiquidity += chunkLiquidity;
                 }
             }
 


### PR DESCRIPTION
We do an unchecked addition to `removedLiquidity` when creating a long position because of the assumption that we cannot remove more liquidity than we add to the pool (which is theoretically limited to `2**128-1` liquidity units. However, this assumption is false. As long as all the liquidity is not in the pool concurrently, we can add and remove a total amount of liquidity greater than `2**128-1` by looping large long and short positions. There's no total liquidity tracker on our end, so it's actually possible to get to a point where `removedLiquidity + netLiquidity` is greater than `2**128 - 1`, creating a potential overflow.

The impact of this is that theoretically, with enough transactions and funds to waste on fees and gas (this is financially unrealistic on most strikes users actually trade), an actor could prevent long positions from being closed. That situation can be reversed, but it would require new long positions to be opened permanently to allow the others to be closed. 

The solution to this is just to check that addition. This prevents long positions from being *opened* past that point, which is a significantly more desirable/reversible situation than the current behavior.