### PR TITLE
fix: settle premium on correct chunks in `haircutPremia`

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -19,7 +19,6 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
-import "forge-std/Test.sol";
 
 /// @title The Panoptic Pool: Create permissionless options on top of a concentrated liquidity AMM like Uniswap v3.
 /// @author Axicon Labs Limited
@@ -1861,8 +1860,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
             if (LeftRightSigned.unwrap(legPremia) != 0) {
                 // (will be) paid by long legs
                 if (tokenId.isLong(leg) == 1) {
-                    console2.log("settled0 (Theoryburn)", legPremia.rightSlot());
-                    console2.log("settled1 (Theoryburn)", legPremia.leftSlot());
                     if (commitLongSettled)
                         settledTokens = LeftRightUnsigned.wrap(
                             uint256(
@@ -1973,7 +1970,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
             // update settled tokens in storage with all local deltas
             s_settledTokens[chunkKey] = settledTokens;
-            console2.log("finalsettle", LeftRightUnsigned.unwrap(settledTokens));
 
             unchecked {
                 ++leg;

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -19,6 +19,7 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
+import "forge-std/Test.sol";
 
 /// @title The Panoptic Pool: Create permissionless options on top of a concentrated liquidity AMM like Uniswap v3.
 /// @author Axicon Labs Limited
@@ -1860,6 +1861,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
             if (LeftRightSigned.unwrap(legPremia) != 0) {
                 // (will be) paid by long legs
                 if (tokenId.isLong(leg) == 1) {
+                    console2.log("settled0 (Theoryburn)", legPremia.rightSlot());
+                    console2.log("settled1 (Theoryburn)", legPremia.leftSlot());
                     if (commitLongSettled)
                         settledTokens = LeftRightUnsigned.wrap(
                             uint256(
@@ -1970,6 +1973,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
             // update settled tokens in storage with all local deltas
             s_settledTokens[chunkKey] = settledTokens;
+            console2.log("finalsettle", LeftRightUnsigned.unwrap(settledTokens));
 
             unchecked {
                 ++leg;

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -12,7 +12,6 @@ import {Math} from "@libraries/Math.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
-import "forge-std/Test.sol";
 
 /// @title Compute general math quantities relevant to Panoptic and AMM pool management.
 /// @author Axicon Labs Limited
@@ -896,9 +895,6 @@ library PanopticMath {
                             0,
                             uint128(-_premiasByLeg[i][leg].leftSlot()) - settled1
                         );
-
-                        console2.log("settled0", settled0);
-                        console2.log("settled1", settled1);
 
                         _settledTokens[chunkKey] = _settledTokens[chunkKey].add(
                             LeftRightUnsigned.wrap(0).toRightSlot(uint128(settled0)).toLeftSlot(

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -12,6 +12,7 @@ import {Math} from "@libraries/Math.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
+import "forge-std/Test.sol";
 
 /// @title Compute general math quantities relevant to Panoptic and AMM pool management.
 /// @author Axicon Labs Limited
@@ -879,9 +880,9 @@ library PanopticMath {
 
                         bytes32 chunkKey = keccak256(
                             abi.encodePacked(
-                                tokenId.strike(0),
-                                tokenId.width(0),
-                                tokenId.tokenType(0)
+                                tokenId.strike(leg),
+                                tokenId.width(leg),
+                                tokenId.tokenType(leg)
                             )
                         );
 
@@ -895,6 +896,9 @@ library PanopticMath {
                             0,
                             uint128(-_premiasByLeg[i][leg].leftSlot()) - settled1
                         );
+
+                        console2.log("settled0", settled0);
+                        console2.log("settled1", settled1);
 
                         _settledTokens[chunkKey] = _settledTokens[chunkKey].add(
                             LeftRightUnsigned.wrap(0).toRightSlot(uint128(settled0)).toLeftSlot(

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5827,7 +5827,6 @@ contract PanopticPoolTest is PositionUtils {
                 );
             }
         }
-        // vm.assume(medianValue0 > 1);
         if (numLegs == 1) populatePositionData(widths[0], strikes[0], positionSizeSeed);
         if (numLegs == 2)
             populatePositionData(
@@ -6152,11 +6151,6 @@ contract PanopticPoolTest is PositionUtils {
         // this happens on *both* liquidations and burns, but during liquidations 1-n shares can be clawed back from PLPs
         // this is because the assets refunded to the liquidator are only rounded down once,
         // so they could correspond to a higher amount of overall shares than the liquidatee had]
-        // vm.assume(numLegs > 1);
-        // vm.assume(
-        //     (ct0.totalSupply() - $totalSupply0 <= numLegs) &&
-        //     (ct1.totalSupply() - $totalSupply1 <= numLegs)
-        // );
         if (
             (ct0.totalSupply() - $totalSupply0 <= numLegs) &&
             (ct1.totalSupply() - $totalSupply1 <= numLegs)
@@ -6191,9 +6185,6 @@ contract PanopticPoolTest is PositionUtils {
                         )
                     );
 
-                    // vm.assume(LeftRightUnsigned.unwrap($settledTokens[chunk]) > 0);
-                    console2.log("settledpp", LeftRightUnsigned.unwrap(pp.settledTokens(chunk)));
-                    console2.log("setteldactual", LeftRightUnsigned.unwrap($settledTokens[chunk]));
                     assertEq(
                         LeftRightUnsigned.unwrap(pp.settledTokens(chunk)),
                         LeftRightUnsigned.unwrap($settledTokens[chunk]),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -314,6 +314,7 @@ contract PanopticPoolTest is PositionUtils {
 
     mapping(bytes32 chunk => LeftRightUnsigned settledTokens) $settledTokens;
     uint256[] settledTokens0;
+
     int256 longPremium0;
     LeftRightSigned $premia;
     LeftRightSigned $netExchanged;
@@ -5270,7 +5271,7 @@ contract PanopticPoolTest is PositionUtils {
     }
 
     /*//////////////////////////////////////////////////////////////
-                           LIQUIDAuinTION TESTS
+                           LIQUIDATION TESTS
     //////////////////////////////////////////////////////////////*/
 
     function test_success_liquidate(
@@ -5670,6 +5671,529 @@ contract PanopticPoolTest is PositionUtils {
                             $posIdLists[1][i].tokenType(j)
                         )
                     );
+                    assertEq(
+                        LeftRightUnsigned.unwrap(pp.settledTokens(chunk)),
+                        LeftRightUnsigned.unwrap($settledTokens[chunk]),
+                        "settled tokens were modified when a haircut was not needed"
+                    );
+                }
+            }
+        } else {
+            assertLe(
+                convertToAssets(ct0, $shareDelta0) +
+                    PanopticMath.convert1to0(
+                        convertToAssets(ct1, $shareDelta1),
+                        TickMath.getSqrtRatioAtTick(currentTickFinal)
+                    ),
+                Math.min(
+                    $combinedBalance0Premium / 2,
+                    int256(
+                        $tokenData0.leftSlot() +
+                            PanopticMath.convert1to0(
+                                $tokenData1.leftSlot(),
+                                TickMath.getSqrtRatioAtTick(TWAPtick)
+                            )
+                    ) - $combinedBalance0Premium
+                ),
+                "liquidatee was debited incorrectly high bonus value (no funds leftover)"
+            );
+        }
+
+        settledTokens0.push(0);
+        settledTokens0.push(0);
+
+        for (uint256 i = 0; i < $posIdLists[1].length; ++i) {
+            for (uint256 j = 0; j < $posIdLists[1][i].countLegs(); ++j) {
+                bytes32 chunk = keccak256(
+                    abi.encodePacked(
+                        $posIdLists[1][i].strike(j),
+                        $posIdLists[1][i].width(j),
+                        $posIdLists[1][i].tokenType(j)
+                    )
+                );
+                settledTokens0[0] += $settledTokens[chunk].rightSlot();
+                settledTokens0[1] += pp.settledTokens(chunk).rightSlot();
+                settledTokens0[0] += PanopticMath.convert1to0(
+                    $settledTokens[chunk].leftSlot(),
+                    TickMath.getSqrtRatioAtTick(currentTickFinal)
+                );
+                settledTokens0[1] += PanopticMath.convert1to0(
+                    pp.settledTokens(chunk).leftSlot(),
+                    TickMath.getSqrtRatioAtTick(currentTickFinal)
+                );
+            }
+        }
+
+        int256 balanceCombined0CT = int256(
+            $tokenData0.rightSlot() +
+                PanopticMath.convert1to0(
+                    $tokenData1.rightSlot(),
+                    TickMath.getSqrtRatioAtTick(TWAPtick)
+                )
+        );
+
+        $balance0CombinedPostBurn =
+            int256(uint256($tokenData0.rightSlot())) -
+            Math.max($premia.rightSlot(), 0) +
+            $burnDelta0 +
+            int256(
+                PanopticMath.convert1to0(
+                    int256(uint256($tokenData1.rightSlot())) -
+                        Math.max($premia.leftSlot(), 0) +
+                        $burnDelta1,
+                    TickMath.getSqrtRatioAtTick(currentTickFinal)
+                )
+            );
+
+        $protocolLoss0BaseExpected = Math.max(
+            -($balance0CombinedPostBurn -
+                Math.min(
+                    balanceCombined0CT / 2,
+                    int256(
+                        $tokenData0.leftSlot() +
+                            PanopticMath.convert1to0(
+                                $tokenData1.leftSlot(),
+                                TickMath.getSqrtRatioAtTick(TWAPtick)
+                            )
+                    ) - balanceCombined0CT
+                )),
+            0
+        );
+        assertApproxEqAbs(
+            int256(settledTokens0[0]) - int256(settledTokens0[1]),
+            Math.min(longPremium0, $protocolLoss0BaseExpected),
+            10,
+            "incorrect amount of premium was haircut"
+        );
+
+        assertApproxEqAbs(
+            $protocolLoss0Actual,
+            $protocolLoss0BaseExpected - Math.min(longPremium0, $protocolLoss0BaseExpected),
+            10,
+            "not all premium was haircut during protocol loss"
+        );
+
+        assertApproxEqAbs(
+            int256(
+                ct0.convertToAssets(ct0.balanceOf(Bob)) +
+                    PanopticMath.convert1to0(
+                        ct1.convertToAssets(ct1.balanceOf(Bob)),
+                        TickMath.getSqrtRatioAtTick(currentTickFinal)
+                    )
+            ) - int256($accValueBefore0),
+            $bonusCombined0,
+            10,
+            "liquidator did not receive correct bonus"
+        );
+    }
+
+    function test_success_liquidateMultiLeg(
+        uint256 x,
+        uint256 numLegs,
+        uint256[4] memory isLongs,
+        uint256[4] memory tokenTypes,
+        uint256[4] memory widthSeeds,
+        int256[4] memory strikeSeeds,
+        uint256 positionSizeSeed,
+        uint256 swapSizeSeed,
+        uint256 collateralBalanceSeed,
+        uint256 collateralRatioSeed
+    ) public {
+        _initPool(x);
+
+        numLegs = bound(numLegs, 1, 4);
+
+        int24[4] memory widths;
+        int24[4] memory strikes;
+
+        for (uint256 i = 0; i < numLegs; ++i) {
+            tokenTypes[i] = bound(tokenTypes[i], 0, 1);
+            isLongs[i] = bound(isLongs[i], 0, 1);
+            medianValue0 += isLongs[i];
+            (widths[i], strikes[i]) = getValidSW(
+                widthSeeds[i],
+                strikeSeeds[i],
+                uint24(tickSpacing),
+                // distancing tickSpacing ensures this position stays OTM throughout this test case. ITM is tested elsewhere.
+                currentTick
+            );
+
+            // make sure there are no conflicts
+            for (uint256 j = 0; j < i; ++j) {
+                vm.assume(
+                    widths[i] != widths[j] ||
+                        strikes[i] != strikes[j] ||
+                        tokenTypes[i] != tokenTypes[j]
+                );
+            }
+        }
+        // vm.assume(medianValue0 > 1);
+        if (numLegs == 1) populatePositionData(widths[0], strikes[0], positionSizeSeed);
+        if (numLegs == 2)
+            populatePositionData(
+                [widths[0], widths[1]],
+                [strikes[0], strikes[1]],
+                positionSizeSeed
+            );
+        if (numLegs == 3)
+            populatePositionData(
+                [widths[0], widths[1], widths[2]],
+                [strikes[0], strikes[1], strikes[2]],
+                positionSizeSeed
+            );
+        if (numLegs == 4) populatePositionData(widths, strikes, positionSizeSeed);
+
+        // this is a long option; so need to sell before it can be bought (let's say 2x position size for now)
+        vm.startPrank(Seller);
+
+        $posIdLists[0].push(TokenId.wrap(0).addPoolId(poolId));
+        for (uint256 i = 0; i < numLegs; ++i) {
+            $posIdLists[0][0] = $posIdLists[0][0].addLeg(
+                i,
+                1,
+                isWETH,
+                0,
+                tokenTypes[i],
+                i,
+                strikes[i],
+                widths[i]
+            );
+        }
+        pp.mintOptions($posIdLists[0], positionSize * 2, 0, 0, 0);
+
+        twoWaySwap(swapSizeSeed);
+
+        // now we can mint the options being liquidated
+        vm.startPrank(Alice);
+
+        $posIdLists[1].push(TokenId.wrap(0).addPoolId(poolId));
+        for (uint256 i = 0; i < numLegs; ++i) {
+            $posIdLists[1][0] = $posIdLists[1][0].addLeg(
+                i,
+                1,
+                isWETH,
+                isLongs[i],
+                tokenTypes[i],
+                i,
+                strikes[i],
+                widths[i]
+            );
+        }
+
+        pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+
+        twoWaySwap(swapSizeSeed);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        vm.assume(Math.abs(int256(currentTick) - pp.getUniV3TWAP_()) <= 513);
+
+        (, uint256 totalCollateralRequired0) = ph.checkCollateral(
+            pp,
+            Alice,
+            pp.getUniV3TWAP_(),
+            0,
+            $posIdLists[1]
+        );
+
+        uint256 totalCollateralB0 = bound(
+            collateralBalanceSeed,
+            1,
+            (totalCollateralRequired0 * 9_999) / 10_000
+        );
+
+        editCollateral(
+            ct0,
+            Alice,
+            ct0.convertToShares(
+                (totalCollateralB0 * bound(collateralRatioSeed, 0, 10_000)) / 10_000
+            )
+        );
+        editCollateral(
+            ct1,
+            Alice,
+            ct1.convertToShares(
+                PanopticMath.convert0to1(
+                    (totalCollateralB0 * (10_000 - bound(collateralRatioSeed, 0, 10_000))) / 10_000,
+                    Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                )
+            )
+        );
+
+        TWAPtick = pp.getUniV3TWAP_();
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        ($expectedPremia0, $expectedPremia1, $positionBalanceArray) = pp
+            .calculateAccumulatedFeesBatch(Alice, false, $posIdLists[1]);
+
+        $tokenData0 = ct0.getAccountMarginDetails(
+            Alice,
+            TWAPtick,
+            $positionBalanceArray,
+            $expectedPremia0
+        );
+
+        $tokenData1 = ct1.getAccountMarginDetails(
+            Alice,
+            TWAPtick,
+            $positionBalanceArray,
+            $expectedPremia1
+        );
+
+        // initialize collateral share deltas - we measure the flow of value out of Alice account to find the bonus
+        $shareDelta0 = int256(ct0.balanceOf(Alice));
+        $shareDelta1 = int256(ct1.balanceOf(Alice));
+
+        // delegate bobs entire balance so we don't have the protocol loss in his unutilized collateral as a source of error
+        deal(address(ct0), Bob, ct0.convertToShares(type(uint96).max));
+        deal(address(ct1), Bob, ct1.convertToShares(type(uint96).max));
+
+        // simulate burning all options to compare against the liquidation
+        uint256 snapshot = vm.snapshot();
+
+        vm.startPrank(address(pp));
+
+        ct0.delegate(Bob, Alice, type(uint96).max);
+        ct1.delegate(Bob, Alice, type(uint96).max);
+
+        int256[2] memory shareDeltasLiquidatee = [
+            int256(ct0.balanceOf(Alice)),
+            int256(ct1.balanceOf(Alice))
+        ];
+
+        vm.startPrank(Alice);
+        uint256 numLegs = numLegs;
+
+        int24 currentTickFinal;
+        {
+            (LeftRightSigned[4][] memory premiasByLeg, LeftRightSigned netExchanged) = pp
+                .burnAllOptionsFrom($posIdLists[1], 0, 0);
+
+            shareDeltasLiquidatee = [
+                int256(ct0.balanceOf(Alice)) - shareDeltasLiquidatee[0],
+                int256(ct1.balanceOf(Alice)) - shareDeltasLiquidatee[1]
+            ];
+
+            (, currentTickFinal, , , , , ) = pool.slot0();
+
+            uint256[2][4][] memory settledTokensTemp = new uint256[2][4][]($posIdLists[1].length);
+            for (uint256 i = 0; i < $posIdLists[1].length; ++i) {
+                for (uint256 j = 0; j < $posIdLists[1][i].countLegs(); ++j) {
+                    bytes32 chunk = keccak256(
+                        abi.encodePacked(
+                            $posIdLists[1][i].strike(j),
+                            $posIdLists[1][i].width(j),
+                            $posIdLists[1][i].tokenType(j)
+                        )
+                    );
+                    settledTokensTemp[i][j] = [
+                        uint256(chunk),
+                        LeftRightUnsigned.unwrap(pp.settledTokens(chunk))
+                    ];
+                }
+            }
+            {
+                uint256 totalSupply0 = ct0.totalSupply();
+                uint256 totalSupply1 = ct1.totalSupply();
+                uint256 totalAssets0 = ct0.totalAssets();
+                uint256 totalAssets1 = ct1.totalAssets();
+
+                int256 burnDelta0C = convertToAssets(ct0, shareDeltasLiquidatee[0]) +
+                    PanopticMath.convert1to0(
+                        convertToAssets(ct1, shareDeltasLiquidatee[1]),
+                        TickMath.getSqrtRatioAtTick(currentTickFinal)
+                    );
+                int256 burnDelta0 = convertToAssets(ct0, shareDeltasLiquidatee[0]);
+                int256 burnDelta1 = convertToAssets(ct1, shareDeltasLiquidatee[1]);
+
+                uint256 _snapshot = snapshot;
+
+                uint256 bal0postl = ct0.balanceOf(Alice);
+                uint256 bal1postl = ct1.balanceOf(Alice);
+
+                vm.revertTo(_snapshot);
+
+                $totalSupply0 = totalSupply0;
+                $totalSupply1 = totalSupply1;
+                $totalAssets0 = totalAssets0;
+                $totalAssets1 = totalAssets1;
+
+                $burnDelta0Combined = burnDelta0C;
+                $burnDelta0 = burnDelta0;
+                $burnDelta1 = burnDelta1;
+
+                $liquidateeBalancePost0 = bal0postl;
+                $liquidateeBalancePost1 = bal1postl;
+
+                $netExchanged = netExchanged;
+            }
+
+            for (uint256 i = 0; i < $posIdLists[1].length; ++i) {
+                for (uint256 j = 0; j < $posIdLists[1][i].countLegs(); ++j) {
+                    longPremium0 += premiasByLeg[i][j].rightSlot() < 0
+                        ? -premiasByLeg[i][j].rightSlot()
+                        : int128(0);
+                    longPremium0 += PanopticMath.convert1to0(
+                        premiasByLeg[i][j].leftSlot() < 0
+                            ? -premiasByLeg[i][j].leftSlot()
+                            : int128(0),
+                        TickMath.getSqrtRatioAtTick(currentTickFinal)
+                    );
+                    $settledTokens[bytes32(settledTokensTemp[i][j][0])] = LeftRightUnsigned.wrap(
+                        settledTokensTemp[i][j][1]
+                    );
+                }
+            }
+        }
+
+        vm.startPrank(Bob);
+
+        $accValueBefore0 =
+            ct0.convertToAssets(ct0.balanceOf(Bob)) +
+            PanopticMath.convert1to0(
+                ct1.convertToAssets(ct1.balanceOf(Bob)),
+                TickMath.getSqrtRatioAtTick(currentTickFinal)
+            );
+
+        {
+            (int128 premium0, int128 premium1, ) = pp.calculateAccumulatedFeesBatch(
+                Alice,
+                false,
+                $posIdLists[1]
+            );
+            $premia = LeftRightSigned.wrap(0).toRightSlot(premium0).toLeftSlot(premium1);
+        }
+
+        ($bonus0, $bonus1, ) = PanopticMath.getLiquidationBonus(
+            $tokenData0,
+            $tokenData1,
+            Math.getSqrtRatioAtTick(TWAPtick),
+            Math.getSqrtRatioAtTick(currentTickFinal),
+            $netExchanged,
+            $premia
+        );
+
+        $delegated0 = uint256(
+            int256(ct0.convertToShares(uint256(int256(uint256(type(uint96).max)) + $bonus0)))
+        );
+        $delegated1 = uint256(
+            int256(ct1.convertToShares(uint256(int256(uint256(type(uint96).max)) + $bonus1)))
+        );
+
+        pp.liquidate(
+            new TokenId[](0),
+            Alice,
+            LeftRightUnsigned.wrap(type(uint96).max).toLeftSlot(type(uint96).max),
+            $posIdLists[1]
+        );
+
+        // take the difference between the share deltas after burn and after mint - that should be the bonus
+        $shareDelta0 = shareDeltasLiquidatee[0] - (int256(ct0.balanceOf(Alice)) - $shareDelta0);
+        $shareDelta1 = shareDeltasLiquidatee[1] - (int256(ct1.balanceOf(Alice)) - $shareDelta1);
+
+        // bonus can be very small on the threshold leading to a loss (of 1-2 tokens) due to precision, which is fine
+        assertGe(
+            ct0.convertToAssets(ct0.balanceOf(Bob)) +
+                PanopticMath.convert1to0(
+                    ct1.convertToAssets(ct1.balanceOf(Bob)),
+                    TickMath.getSqrtRatioAtTick(currentTickFinal)
+                ) +
+                1,
+            $accValueBefore0,
+            "liquidator lost money"
+        );
+
+        // get total balance for Alice before liquidation
+        $combinedBalance0NoPremium = int256(
+            (int256(uint256($tokenData0.rightSlot())) - Math.max($premia.rightSlot(), 0)) +
+                PanopticMath.convert1to0(
+                    int256(uint256($tokenData1.rightSlot())) - Math.max($premia.leftSlot(), 0),
+                    TickMath.getSqrtRatioAtTick(TWAPtick)
+                )
+        );
+        $combinedBalance0Premium = int256(
+            ($tokenData0.rightSlot()) +
+                PanopticMath.convert1to0(
+                    $tokenData1.rightSlot(),
+                    TickMath.getSqrtRatioAtTick(TWAPtick)
+                )
+        );
+        $bonusCombined0 = Math.min(
+            $combinedBalance0Premium / 2,
+            int256(
+                $tokenData0.leftSlot() +
+                    PanopticMath.convert1to0(
+                        $tokenData1.leftSlot(),
+                        TickMath.getSqrtRatioAtTick(TWAPtick)
+                    )
+            ) - $combinedBalance0Premium
+        );
+
+        // make sure value outlay for Alice matches the bonus structure
+        // if Alice is completely insolvent the deltas will be wrong because
+        // some of the bonus will come from PLPs
+        // in that case we just assert that the delta is less than whatever the bonus was supposed to be
+        // which ensures Alice wasn't overcharged
+
+        // The protocol loss is the value of shares added to the supply multiplied by the portion of NON-DELEGATED collateral
+        // (losses in collateral that was returned to the liquidator post-delegation are compensated, so they are not included)
+        $protocolLoss0Actual =
+            int256((($totalSupply0 - $liquidateeBalancePost0) * $totalAssets0) / $totalSupply0) -
+            int256(ct0.convertToAssets($totalSupply0 - $liquidateeBalancePost0)) +
+            PanopticMath.convert1to0(
+                int256(
+                    (($totalSupply1 - $liquidateeBalancePost1) * $totalAssets1) / $totalSupply1
+                ) - int256(ct1.convertToAssets($totalSupply1 - $liquidateeBalancePost1)),
+                TickMath.getSqrtRatioAtTick(currentTickFinal)
+            );
+
+        // every time an option is burnt, the owner can lose up to 1 share (worth much less than 1 token) due to rounding
+        // (in this test n = number of options = numLegs)
+        // this happens on *both* liquidations and burns, but during liquidations 1-n shares can be clawed back from PLPs
+        // this is because the assets refunded to the liquidator are only rounded down once,
+        // so they could correspond to a higher amount of overall shares than the liquidatee had]
+        // vm.assume(numLegs > 1);
+        // vm.assume(
+        //     (ct0.totalSupply() - $totalSupply0 <= numLegs) &&
+        //     (ct1.totalSupply() - $totalSupply1 <= numLegs)
+        // );
+        if (
+            (ct0.totalSupply() - $totalSupply0 <= numLegs) &&
+            (ct1.totalSupply() - $totalSupply1 <= numLegs)
+        ) {
+            assertApproxEqAbs(
+                convertToAssets(ct0, $shareDelta0) +
+                    PanopticMath.convert1to0(
+                        convertToAssets(ct1, $shareDelta1),
+                        TickMath.getSqrtRatioAtTick(currentTickFinal)
+                    ),
+                Math.min(
+                    $combinedBalance0Premium / 2,
+                    int256(
+                        $tokenData0.leftSlot() +
+                            PanopticMath.convert1to0(
+                                $tokenData1.leftSlot(),
+                                TickMath.getSqrtRatioAtTick(TWAPtick)
+                            )
+                    ) - $combinedBalance0Premium
+                ),
+                10,
+                "liquidatee was debited incorrect bonus value (funds leftover)"
+            );
+
+            for (uint256 i = 0; i < $posIdLists[1].length; ++i) {
+                for (uint256 j = 0; j < $posIdLists[1][i].countLegs(); ++j) {
+                    bytes32 chunk = keccak256(
+                        abi.encodePacked(
+                            $posIdLists[1][i].strike(j),
+                            $posIdLists[1][i].width(j),
+                            $posIdLists[1][i].tokenType(j)
+                        )
+                    );
+
+                    // vm.assume(LeftRightUnsigned.unwrap($settledTokens[chunk]) > 0);
+                    console2.log("settledpp", LeftRightUnsigned.unwrap(pp.settledTokens(chunk)));
+                    console2.log("setteldactual", LeftRightUnsigned.unwrap($settledTokens[chunk]));
                     assertEq(
                         LeftRightUnsigned.unwrap(pp.settledTokens(chunk)),
                         LeftRightUnsigned.unwrap($settledTokens[chunk]),


### PR DESCRIPTION
During liquidations, the update of `s_settledTokens` with long premium paid by the liquidatee is deferred to the `haircutPremia` function (so the liquidatee's short positions can't withdraw premium that is haircut later), which updates `s_settledTokens` with the remaining amount of tokens after adjusting for the haircut. 

Currently, all settled tokens for a given tokenId are directed to the chunk of the first leg instead of divided between all the chunks. This results in a forfeit of any premium owed by the liquidatee for sellers in legs 2, 3, and 4. While the core settlement invariants still hold, this behavior results in unfair haircut distributions and potential unnecessary/wasteful premium forfeiture during liquidations of accounts with at least one long leg in indices 2, 3, or 4.