### PR TITLE
feat: add slippage checks to factory

### DIFF
--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -269,7 +269,7 @@ contract PanopticFactory is Multicall {
         // The SFPM will `safeTransferFrom` tokens from the donor during the mint callback
         (uint256 amount0, uint256 amount1) = _mintFullRange(v3Pool, token0, token1, fee);
 
-        if (amount0 >= amount0Max || amount1 >= amount1Max) revert Errors.PriceBoundFail();
+        if (amount0 > amount0Max || amount1 > amount1Max) revert Errors.PriceBoundFail();
 
         emit PoolDeployed(
             newPoolContract,

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -206,12 +206,16 @@ contract PanopticFactory is Multicall {
     /// @param token1 Address of token1 for the underlying Uniswap v3 pool
     /// @param fee The fee tier of the underlying Uniswap v3 pool, denominated in hundredths of bips
     /// @param salt User-defined salt used in CREATE2 for the PanopticPool (must contain caller addr as first 20 bytes)
+    /// @param amount0Max The maximum amount of token0 to spend on the full-range deployment, which serves as a slippage check
+    /// @param amount1Max The maximum amount of token1 to spend on the full-range deployment, which serves as a slippage check
     /// @return newPoolContract The address of the newly deployed Panoptic pool
     function deployNewPool(
         address token0,
         address token1,
         uint24 fee,
-        bytes32 salt
+        bytes32 salt,
+        uint256 amount0Max,
+        uint256 amount1Max
     ) external returns (PanopticPool newPoolContract) {
         // sort the tokens, if necessary:
         (token0, token1) = token0 < token1 ? (token0, token1) : (token1, token0);
@@ -257,13 +261,15 @@ contract PanopticFactory is Multicall {
         // When that happens, there will be a period of time where the PanopticPool is deployed, but not (safely) usable
         v3Pool.increaseObservationCardinalityNext(CARDINALITY_INCREASE);
 
+        // Issue reward NFT to donor
+        DONOR_NFT.issueNFT(msg.sender, newPoolContract, token0, token1, fee);
+
         // Mints the full-range initial deposit
         // which is why the deployer becomes also a "donor" of full-range liquidity
         // The SFPM will `safeTransferFrom` tokens from the donor during the mint callback
         (uint256 amount0, uint256 amount1) = _mintFullRange(v3Pool, token0, token1, fee);
 
-        // Issue reward NFT to donor
-        DONOR_NFT.issueNFT(msg.sender, newPoolContract, token0, token1, fee);
+        if (amount0 >= amount0Max || amount1 >= amount1Max) revert Errors.PriceBoundFail();
 
         emit PoolDeployed(
             newPoolContract,

--- a/scripts/DeployTestPool.s.sol
+++ b/scripts/DeployTestPool.s.sol
@@ -44,7 +44,9 @@ contract DeployTestPool is Script {
             address(token0),
             address(token1),
             500,
-            bytes32(uint256(uint160(vm.addr(DEPLOYER_PRIVATE_KEY))) << 96)
+            bytes32(uint256(uint160(vm.addr(DEPLOYER_PRIVATE_KEY))) << 96),
+            type(uint256).max,
+            type(uint256).max
         );
 
         vm.stopBroadcast();

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -250,7 +250,9 @@ contract Misctest is Test, PositionUtils {
                     address(token0),
                     address(token1),
                     500,
-                    bytes32(uint256(uint160(Deployer)) << 96)
+                    bytes32(uint256(uint160(Deployer)) << 96),
+                    type(uint256).max,
+                    type(uint256).max
                 )
             )
         );

--- a/test/foundry/core/PanopticFactory.t.sol
+++ b/test/foundry/core/PanopticFactory.t.sol
@@ -228,7 +228,14 @@ contract PanopticFactoryTest is Test {
         {
             // Deploy pool
             // links the uni v3 pool to the Panoptic pool
-            PanopticPool deployedPool = panopticFactory.deployNewPool(token0, token1, fee, salt);
+            PanopticPool deployedPool = panopticFactory.deployNewPool(
+                token0,
+                token1,
+                fee,
+                salt,
+                type(uint256).max,
+                type(uint256).max
+            );
 
             // see if pool exists at the precomputed address
             uint256 size;
@@ -292,7 +299,14 @@ contract PanopticFactoryTest is Test {
         {
             // Deploy pool
             // links the uni v3 pool to the Panoptic pool
-            PanopticPool deployedPool = panopticFactory.deployNewPool(token0, token1, fee, salt);
+            PanopticPool deployedPool = panopticFactory.deployNewPool(
+                token0,
+                token1,
+                fee,
+                salt,
+                type(uint256).max,
+                type(uint256).max
+            );
 
             // see if pool exists at the precomputed address
             uint256 size;
@@ -333,7 +347,14 @@ contract PanopticFactoryTest is Test {
 
         // Deploy pool
         // links the uni v3 pool to the Panoptic pool
-        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt));
+        panopticFactory.deployNewPool(
+            token0,
+            token1,
+            fee,
+            bytes32(salt),
+            type(uint256).max,
+            type(uint256).max
+        );
     }
 
     // deploy a pool with token1 as WETH
@@ -347,7 +368,57 @@ contract PanopticFactoryTest is Test {
 
         // Deploy pool
         // links the uni v3 pool to the Panoptic pool
-        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt));
+        panopticFactory.deployNewPool(
+            token0,
+            token1,
+            fee,
+            bytes32(salt),
+            type(uint256).max,
+            type(uint256).max
+        );
+    }
+
+    function test_Success_deployNewPool_SlippagePass() public {
+        _initWorld(0);
+
+        uint256 salt = uint96(block.timestamp) + (uint256(uint160(address(this))) << 96);
+
+        (, uint256 amount0, uint256 amount1) = computeFullRangeLiquidity();
+
+        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt), amount0, amount1);
+    }
+
+    function test_Fail_deployNewPool_Slippage0() public {
+        _initWorld(0);
+
+        uint256 salt = uint96(block.timestamp) + (uint256(uint160(address(this))) << 96);
+
+        (, uint256 amount0, uint256 amount1) = computeFullRangeLiquidity();
+
+        vm.expectRevert(Errors.PriceBoundFail.selector);
+        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt), amount0 - 1, amount1);
+    }
+
+    function test_Fail_deployNewPool_Slippage1() public {
+        _initWorld(0);
+
+        uint256 salt = uint96(block.timestamp) + (uint256(uint160(address(this))) << 96);
+
+        (, uint256 amount0, uint256 amount1) = computeFullRangeLiquidity();
+
+        vm.expectRevert(Errors.PriceBoundFail.selector);
+        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt), amount0, amount1 - 1);
+    }
+
+    function test_Fail_deployNewPool_Slippage0Both() public {
+        _initWorld(0);
+
+        uint256 salt = uint96(block.timestamp) + (uint256(uint160(address(this))) << 96);
+
+        (, uint256 amount0, uint256 amount1) = computeFullRangeLiquidity();
+
+        vm.expectRevert(Errors.PriceBoundFail.selector);
+        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt), amount0 - 1, amount1 - 1);
     }
 
     // Revert if trying to deploy a Panoptic Pool ontop of an invalid Uniswap Pool
@@ -357,7 +428,14 @@ contract PanopticFactoryTest is Test {
 
         // Deploy invalid pool (uninitalized tokens and fee)
         vm.expectRevert(Errors.UniswapPoolNotInitialized.selector);
-        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt));
+        panopticFactory.deployNewPool(
+            token0,
+            token1,
+            fee,
+            bytes32(salt),
+            type(uint256).max,
+            type(uint256).max
+        );
     }
 
     // Revert if deploying a Panoptic Pool that has already been initalized
@@ -370,12 +448,26 @@ contract PanopticFactoryTest is Test {
         uint256 salt = uint96(block.timestamp) + (uint256(uint160(address(this))) << 96);
 
         // Deploy pool
-        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt));
+        panopticFactory.deployNewPool(
+            token0,
+            token1,
+            fee,
+            bytes32(salt),
+            type(uint256).max,
+            type(uint256).max
+        );
 
         // Attempt to deploy pool again
         vm.expectRevert(Errors.PoolAlreadyInitialized.selector);
         unchecked {
-            panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt + 1));
+            panopticFactory.deployNewPool(
+                token0,
+                token1,
+                fee,
+                bytes32(salt + 1),
+                type(uint256).max,
+                type(uint256).max
+            );
         }
     }
 
@@ -390,7 +482,9 @@ contract PanopticFactoryTest is Test {
             token0,
             token1,
             fee,
-            bytes32(nonce + (uint256(uint160(randomAddr)) << 96))
+            bytes32(nonce + (uint256(uint160(randomAddr)) << 96)),
+            type(uint256).max,
+            type(uint256).max
         );
     }
 
@@ -402,7 +496,14 @@ contract PanopticFactoryTest is Test {
         uint256 salt = uint256(nonce) + (uint256(uint160(Deployer)) << 96);
 
         vm.expectRevert(Errors.NotOwner.selector);
-        panopticFactory.deployNewPool(token0, token1, fee, bytes32(salt));
+        panopticFactory.deployNewPool(
+            token0,
+            token1,
+            fee,
+            bytes32(salt),
+            type(uint256).max,
+            type(uint256).max
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -403,7 +403,9 @@ contract PanopticPoolTest is PositionUtils {
                     token0,
                     token1,
                     fee,
-                    bytes32(uint256(uint160(Deployer)) << 96)
+                    bytes32(uint256(uint160(Deployer)) << 96),
+                    type(uint256).max,
+                    type(uint256).max
                 )
             )
         );

--- a/test/foundry/periphery/PanopticHelper.t.sol
+++ b/test/foundry/periphery/PanopticHelper.t.sol
@@ -294,7 +294,9 @@ contract PanopticHelperTest is PositionUtils {
                     token0,
                     token1,
                     fee,
-                    bytes32(uint256(uint160(Deployer)) << 96)
+                    bytes32(uint256(uint160(Deployer)) << 96),
+                    type(uint256).max,
+                    type(uint256).max
                 )
             )
         );

--- a/test/foundry/periphery/UniswapMigrator.t.sol
+++ b/test/foundry/periphery/UniswapMigrator.t.sol
@@ -100,7 +100,9 @@ contract UniswapMigratorTest is Test {
                     address(USDC),
                     address(WETH),
                     500,
-                    bytes32(uint256(uint160(Deployer)) << 96)
+                    bytes32(uint256(uint160(Deployer)) << 96),
+                    type(uint256).max,
+                    type(uint256).max
                 )
             )
         );


### PR DESCRIPTION
This was brought up in the C4 audit. I initially disputed it but upon further thought it's a good point. 

If a user does infinite or very large approvals to the Panoptic Factory (our app should not do this by default, but some wallets like MetaMask detect approval transactions and allow the user to change the amount requested by the application anyway), that user could be frontrun for the entire approved value of (one) of their deposit tokens if someone manipulates the price before their `deployNewPool` transaction.

I added `amount0Max` and `amount1Max` parameters through which users can specify the maximum amount of tokens they would be willing to pay when deploying a pool. Our frontend can compute the values to set for these parameters from the current price and add a small buffer.