### PR TITLE
feat: optional ITM swaps

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1031,18 +1031,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
-            // add premium to be paid/collected on position close
-            int256 tokenToPay = -realizedPremium;
-
-            // if burning ITM and swap occurred, compute tokens to be paid through exercise and add swap fees
-            int256 intrinsicValue = swappedAmount - (longAmount - shortAmount);
-
-            if ((intrinsicValue != 0) && ((shortAmount != 0) || (longAmount != 0))) {
-                // intrinsic value is the amount that need to be exchanged due to burning in-the-money
-
-                // add the intrinsic value to the tokenToPay
-                tokenToPay += intrinsicValue;
-            }
+            // add premium and token deltas not covered by swap to be paid/collected on position close
+            int256 tokenToPay = swappedAmount - (longAmount - shortAmount) - realizedPremium;
 
             if (tokenToPay > 0) {
                 // if user must pay tokens, burn them from user balance (revert if balance too small)

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -489,29 +489,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
         return (portfolioPremium, balances);
     }
 
-    /// @notice Disable slippage checks if tickLimitLow == tickLimitHigh and reverses ticks if given in correct order to enable ITM swaps
-    /// @param tickLimitLow The lower slippage limit on the tick.
-    /// @param tickLimitHigh The upper slippage limit on the tick.
-    /// @return tickLimitLow Adjusted value for the lower tick limit.
-    /// @return tickLimitHigh Adjusted value for the upper tick limit.
-    function _getSlippageLimits(
-        int24 tickLimitLow,
-        int24 tickLimitHigh
-    ) internal pure returns (int24, int24) {
-        // disable slippage checks if tickLimitLow == tickLimitHigh
-        if (tickLimitLow == tickLimitHigh) {
-            // note the reversed order of the ticks
-            return (MAX_SWAP_TICK, MIN_SWAP_TICK);
-        }
-
-        // ensure tick limits are reversed (the SFPM uses low > high as a flag to do ITM swaps, which we need)
-        if (tickLimitLow < tickLimitHigh) {
-            return (tickLimitHigh, tickLimitLow);
-        }
-
-        return (tickLimitLow, tickLimitHigh);
-    }
-
     /*//////////////////////////////////////////////////////////////
                           ONBOARD MEDIAN TWAP
     //////////////////////////////////////////////////////////////*/
@@ -624,8 +601,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // do duplicate checks and the checks related to minting and positions
         _validatePositionList(msg.sender, positionIdList, 1);
-
-        (tickLimitLow, tickLimitHigh) = _getSlippageLimits(tickLimitLow, tickLimitHigh);
 
         // make sure the tokenId is for this Panoptic pool
         if (tokenId.poolId() != SFPM.getPoolId(address(s_univ3pool)))
@@ -828,9 +803,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
-        // Ensure that the current price is within the tick limits
-        (tickLimitLow, tickLimitHigh) = _getSlippageLimits(tickLimitLow, tickLimitHigh);
-
         uint128 positionSize = s_positionBalance[owner][tokenId].rightSlot();
 
         LeftRightSigned premiaOwed;
@@ -1083,8 +1055,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
             // Note: tick limits are not applied here since it is not the liquidator's position being liquidated
             (netExchanged, premiasByLeg) = _burnAllOptionsFrom(
                 liquidatee,
-                0,
-                0,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK,
                 DONOT_COMMIT_LONG_SETTLED,
                 positionIdList
             );
@@ -1221,8 +1193,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         s_collateralToken1.delegate(account, uint128(delegatedAmounts.leftSlot()));
 
         // Exercise the option
-        // Note: tick limits are not applied here since it is not the exercisor's position being closed
-        _burnAllOptionsFrom(account, 0, 0, COMMIT_LONG_SETTLED, touchedId);
+        // Turn off ITM swapping to prevent swap at potentially unfavorable price
+        _burnAllOptionsFrom(account, MIN_SWAP_TICK, MAX_SWAP_TICK, COMMIT_LONG_SETTLED, touchedId);
 
         // Compute the exerciseFee, this will decrease the further away the price is from the forcedExercised position
         /// @dev use the medianTick to prevent price manipulations based on swaps.

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1002,7 +1002,13 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
         _assumePositionValidity(Bob, tokenId, positionSize0);
 
-        panopticPool.mintOptions(positionIdList, positionSize0, 0, 0, 0);
+        panopticPool.mintOptions(
+            positionIdList,
+            positionSize0,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // Attempt a transfer to Alice from Bob
         vm.expectRevert(Errors.PositionCountNotZero.selector);
@@ -1088,7 +1094,13 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(positionIdList, positionSize0, 0, 0, 0);
+            panopticPool.mintOptions(
+                positionIdList,
+                positionSize0,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // approve Alice to move shares on Bob's behalf
@@ -1678,10 +1690,21 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.refund(address(0), address(0), 0);
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
-        collateralToken0.takeCommissionAddData(address(0), 0, 0, 0);
+        collateralToken0.takeCommissionAddData(
+            address(0),
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
-        collateralToken0.exercise(address(0), 0, 0, 0, 0);
+        collateralToken0.exercise(
+            address(0),
+            0,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -613,12 +613,12 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         vm.startPrank(Bob);
 
         vm.expectRevert(stdError.divisionError);
-        pp.mintOptions($tempIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($tempIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
     }
 
     // position length in hash should fail instead of overflowing its slot during construction
@@ -645,14 +645,14 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         TokenId[] memory longPositionList = new TokenId[](257);
 
         for (uint256 i; i < 257; ++i) longPositionList[i] = $posIdList[0];
 
         vm.expectRevert(stdError.arithmeticError);
-        pp.mintOptions(longPositionList, 1_000_000, 0, 0, 0);
+        pp.mintOptions(longPositionList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
     }
 
     // ensure all large mint/deposit amounts revert (instead of overflowing)
@@ -741,12 +741,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         vm.startPrank(Alice);
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         vm.startPrank(Bob);
-        pp.mintOptions($posIdList, 1_000_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
-        pp.mintOptions($tempIdList, 900_000_000, type(uint64).max, 0, 0);
+        pp.mintOptions($tempIdList, 900_000_000, type(uint64).max, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         vm.startPrank(Swapper);
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
@@ -763,20 +763,20 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Charlie);
 
         for (uint256 i = 0; i < 10; i++) {
-            pp.mintOptions($posIdList, 250_000_000, type(uint64).max, 0, 0);
+            pp.mintOptions($posIdList, 250_000_000, type(uint64).max, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
-            pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+            pp.burnOptions($posIdList[0], new TokenId[](0), Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
         }
 
         vm.startPrank(Alice);
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions($posIdList[0], new TokenId[](0), Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         uint256 delta0 = ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0;
         uint256 delta1 = ct1.convertToAssets(ct1.balanceOf(Alice)) - assetsBefore1;
         vm.revertTo(snap);
 
         vm.startPrank(Alice);
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions($posIdList[0], new TokenId[](0), Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         // there is a small amount of error in token0 -- this is the commissions from Charlie
         assertApproxEqAbs(
@@ -1860,7 +1860,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         editCollateral(ct0, Bob, ct0.convertToShares(266263));
         editCollateral(ct1, Bob, 0);
@@ -1892,7 +1892,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
@@ -1924,7 +1924,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         editCollateral(ct0, Bob, ct0.convertToShares(266262));
         editCollateral(ct1, Bob, 0);
@@ -1957,7 +1957,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
@@ -1990,7 +1990,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -373,9 +373,20 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_success_MintBurnStrangle() public {
@@ -397,9 +408,20 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_success_MintBurnCallSpread() public {
@@ -425,7 +447,13 @@ contract Misctest is Test, PositionUtils {
             )
         );
 
-        pp.mintOptions($posIdList, 2_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // mint OTM position
         $posIdList[0] = TokenId
@@ -436,9 +464,20 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, type(uint64).max, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_success_MintBurnPutSpread() public {
@@ -464,7 +503,13 @@ contract Misctest is Test, PositionUtils {
             )
         );
 
-        pp.mintOptions($posIdList, 2_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // mint OTM position
         $posIdList[0] = TokenId
@@ -475,9 +520,20 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, type(uint64).max, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     // these tests are PoCs for rounding issues in the premium distribution
@@ -508,7 +564,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         $posIdList.push(
             TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
@@ -528,10 +590,22 @@ contract Misctest is Test, PositionUtils {
         for (uint256 i = 0; i < 1000; i++) {
             vm.startPrank(Alice);
             $tempIdList[0] = $posIdList[1];
-            pp.mintOptions($tempIdList, 250_000, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $tempIdList,
+                250_000,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             vm.startPrank(Bob);
-            pp.mintOptions($posIdList, 250_000, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdList,
+                250_000,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             vm.startPrank(Swapper);
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
@@ -541,15 +615,30 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
             $tempIdList[0] = $posIdList[0];
-            pp.burnOptions($posIdList[1], $tempIdList, 0, 0);
+            pp.burnOptions(
+                $posIdList[1],
+                $tempIdList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             vm.startPrank(Alice);
-            pp.burnOptions($posIdList[1], new TokenId[](0), 0, 0);
+            pp.burnOptions(
+                $posIdList[1],
+                new TokenId[](0),
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         vm.startPrank(Bob);
         // burn Bob's short option
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_settledPremiumDistribution_demoInflatedOwed() public {
@@ -578,7 +667,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         $posIdList.push(
             TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
@@ -596,18 +691,34 @@ contract Misctest is Test, PositionUtils {
         // only 20 tokens actually settled, but 22 owed... 2 tokens taken from PLPs
         // we may need to redefine availablePremium as max(availablePremium, settledTokens)
         for (uint256 i = 0; i < 10; i++) {
-            pp.mintOptions($posIdList, 499_999, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdList,
+                499_999,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
             vm.startPrank(Swapper);
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
             // 1998600539
             accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1, 1);
             swapperc.swapTo(uniPool, 2 ** 96);
             vm.startPrank(Bob);
-            pp.burnOptions($posIdList[1], $tempIdList, 0, 0);
+            pp.burnOptions(
+                $posIdList[1],
+                $tempIdList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // burn Bob's short option
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_success_settleLongPremium() public {
@@ -639,15 +750,33 @@ contract Misctest is Test, PositionUtils {
         // 8.896% * 1.022x vegoid = +~10% of the fee amount accumulated will be owed by sellers
         vm.startPrank(Alice);
 
-        pp.mintOptions($posIdLists[0], 500_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdLists[0],
+            500_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdLists[0], 250_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdLists[0],
+            250_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Charlie);
 
-        pp.mintOptions($posIdLists[0], 250_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdLists[0],
+            250_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // sell unrelated, non-overlapping, dummy chunk (to buy for match testing)
         vm.startPrank(Seller);
@@ -665,7 +794,13 @@ contract Misctest is Test, PositionUtils {
             )
         );
 
-        pp.mintOptions($posIdLists[1], 1_000_000_000 - 9_884_444 * 3, 0, 0, 0);
+        pp.mintOptions(
+            $posIdLists[1],
+            1_000_000_000 - 9_884_444 * 3,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // position type A: 1-leg long primary
         $posIdLists[2].push(
@@ -683,7 +818,13 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions($posIdLists[2], 9_884_444, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[2],
+                9_884_444,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // position type B: 2-leg long primary and long dummy
@@ -697,7 +838,13 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions($posIdLists[2], 9_884_444, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[2],
+                9_884_444,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // position type C: 2-leg long primary and short dummy
@@ -711,7 +858,13 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions($posIdLists[2], 9_884_444, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[2],
+                9_884_444,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // position type D: 1-leg long dummy
@@ -730,7 +883,13 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions($posIdLists[2], 19_768_888, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[2],
+                19_768_888,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // populate collateralIdLists with each ending at a different token
@@ -917,7 +1076,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Bob));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
-        pp.burnOptions($posIdLists[0][0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdLists[0][0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(
             ct0.convertToAssets(ct0.balanceOf(Bob)) - assetsBefore0,
@@ -946,7 +1110,13 @@ contract Misctest is Test, PositionUtils {
             )
         );
 
-        pp.mintOptions($posIdLists[1], 1_000_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdLists[1],
+            1_000_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assetsBefore0Arr.push(ct0.convertToAssets(ct0.balanceOf(Buyers[0])));
         assetsBefore1Arr.push(ct1.convertToAssets(ct1.balanceOf(Buyers[0])));
@@ -1005,7 +1175,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
-        pp.burnOptions($posIdLists[0][0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdLists[0][0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(
             ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0,
@@ -1126,7 +1301,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        pp.burnOptions($posIdLists[0][0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdLists[0][0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(
             ct0.convertToAssets(ct0.balanceOf(Charlie)) - assetsBefore0,
@@ -1169,7 +1349,12 @@ contract Misctest is Test, PositionUtils {
             assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[i]));
             assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[i]));
             vm.startPrank(Buyers[i]);
-            pp.burnOptions($posIdLists[2], new TokenId[](0), 0, 0);
+            pp.burnOptions(
+                $posIdLists[2],
+                new TokenId[](0),
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             // the positive premium is from the dummy short chunk
             // @TODO might have to tweak this if rounding is changed upstream
@@ -1221,15 +1406,33 @@ contract Misctest is Test, PositionUtils {
         // Finally, close Charlie's position, they should receive ~27.5% (25% + 10% * 25%)
         vm.startPrank(Alice);
 
-        pp.mintOptions($posIdList, 500_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            500_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 250_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            250_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Charlie);
 
-        pp.mintOptions($posIdList, 250_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            250_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         $posIdList.push(
             TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
@@ -1247,12 +1450,24 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         // mint finely tuned amount of long options for Alice so premium paid = 1.1x
-        pp.mintOptions($posIdList, 44_468, type(uint64).max, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            44_468,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
         // mint finely tuned amount of long options for Bob so premium paid = 1.1x
-        pp.mintOptions($posIdList, 44_468, type(uint64).max, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            44_468,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Swapper);
 
@@ -1272,7 +1487,12 @@ contract Misctest is Test, PositionUtils {
         $tempIdList.push($posIdList[1]);
 
         // burn Bob's short option
-        pp.burnOptions($posIdList[0], $tempIdList, 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            $tempIdList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(
             ct0.convertToAssets(ct0.balanceOf(Bob)) - assetsBefore0,
@@ -1288,13 +1508,24 @@ contract Misctest is Test, PositionUtils {
         // re-mint the short option
         $posIdList[1] = $posIdList[0];
         $posIdList[0] = $tempIdList[0];
-        pp.mintOptions($posIdList, 1_000_000, 0, 0, 0);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         $tempIdList[0] = $posIdList[1];
 
         // Burn the long options, adds 1/2 of the removed liq
         // amount of premia paid = 50_000
-        pp.burnOptions($posIdList[0], $tempIdList, 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            $tempIdList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Alice);
 
@@ -1303,7 +1534,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         $tempIdList[0] = $posIdList[0];
-        pp.burnOptions($posIdList[1], $tempIdList, 0, 0);
+        pp.burnOptions(
+            $posIdList[1],
+            $tempIdList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(
             ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0,
@@ -1317,7 +1553,12 @@ contract Misctest is Test, PositionUtils {
         );
 
         // Burn other half of the removed liq
-        pp.burnOptions($posIdList[0], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Charlie);
 
@@ -1325,7 +1566,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        pp.burnOptions($posIdList[1], new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            $posIdList[1],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(
             ct0.convertToAssets(ct0.balanceOf(Charlie)) - assetsBefore0,
@@ -1357,7 +1603,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // mint 1 liquidity unit of wideish centered position
-        pp.mintOptions(posIdList, 3, 0, 0, 0);
+        pp.mintOptions(posIdList, 3, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         vm.startPrank(Swapper);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
@@ -1373,7 +1619,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // works fine
-        pp.burnOptions(tokenId, new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            tokenId,
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         uint256 balanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
         uint256 balanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
@@ -1381,7 +1632,13 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         // lock in almost-overflowed fees per liquidity
-        pp.mintOptions(posIdList, 1_000_000_000, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            1_000_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Swapper);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
@@ -1411,7 +1668,12 @@ contract Misctest is Test, PositionUtils {
         // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!)
         // + fee to move price initially (if applicable)
         // The solution is to freeze fee accumulation if one of the token accumulators overflow
-        pp.burnOptions(tokenId, new TokenId[](0), 0, 0);
+        pp.burnOptions(
+            tokenId,
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // make sure Alice earns no fees on token 0 (her delta is slightly negative due to commission fees/precision etc)
         // the accumulator overflowed, so the accumulation was frozen. If she had poked before the accumulator overflowed,
@@ -1465,7 +1727,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -1590,7 +1858,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -1669,7 +1943,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -1762,7 +2042,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -1854,7 +2140,13 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 5);
             ct1.deposit(5, Bob);
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -1946,7 +2238,13 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2033,7 +2331,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2111,7 +2415,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2204,7 +2514,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2293,7 +2609,13 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 15);
             ct1.deposit(15, Bob);
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2381,7 +2703,13 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
 
-            pp.mintOptions(posIdList, 3000, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                3000,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2449,7 +2777,13 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
+                pp.mintOptions(
+                    posIdList,
+                    1_000_000,
+                    0,
+                    Constants.MAX_V3POOL_TICK,
+                    Constants.MIN_V3POOL_TICK
+                );
 
                 // create spread tokenId
                 tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
@@ -2490,7 +2824,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 10_000, 2 ** 30, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                10_000,
+                2 ** 30,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2560,7 +2900,13 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
+                pp.mintOptions(
+                    posIdList,
+                    1_000_000,
+                    0,
+                    Constants.MAX_V3POOL_TICK,
+                    Constants.MIN_V3POOL_TICK
+                );
 
                 // create spread tokenId
                 tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
@@ -2601,7 +2947,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(150, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 10_000, 2 ** 30, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                10_000,
+                2 ** 30,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -2670,7 +3022,13 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(posIdList, 1_000_000, 0, 0, 0);
+                pp.mintOptions(
+                    posIdList,
+                    1_000_000,
+                    0,
+                    Constants.MAX_V3POOL_TICK,
+                    Constants.MIN_V3POOL_TICK
+                );
 
                 // create spread tokenId
                 tokenId = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool)));
@@ -2711,7 +3069,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(2500, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(posIdList, 10_000, 2 ** 30, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                10_000,
+                2 ** 30,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (, currentTick, , , , , ) = uniPool.slot0();
 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -2197,6 +2197,281 @@ contract Misctest is Test, PositionUtils {
         );
     }
 
+    function test_Success_ReverseIronCondor() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+
+        vm.startPrank(Seller);
+
+        $posIdList.push(
+            TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(
+                    0,
+                    1,
+                    1,
+                    0,
+                    1,
+                    0,
+                    4055, // 1.5 put
+                    1
+                )
+                .addLeg(
+                    1,
+                    1,
+                    1,
+                    0,
+                    0,
+                    1,
+                    -6935, // 0.5 call
+                    1
+                )
+        );
+
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // long put = 1.5, short put 1.25, short call 0.75, long call 0.5
+        $posIdList[0] = TokenId
+            .wrap(0)
+            .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+            .addLeg(0, 1, 1, 1, 1, 0, 4055, 1)
+            .addLeg(1, 1, 1, 0, 1, 1, 2235, 1)
+            .addLeg(2, 1, 1, 0, 0, 2, -2875, 1)
+            .addLeg(3, 1, 1, 1, 0, 3, -6935, 1);
+
+        uint256 balanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
+        uint256 balanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
+
+        vm.startPrank(Alice);
+
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // 0.25, 0.6, 0.9, 1.1, 1.4, 1.6
+        int16[6] memory ticks = [-13862, -5108, -1053, 952, 3364, 4699];
+
+        for (uint256 i = 0; i < ticks.length; ++i) {
+            uint256 snap = vm.snapshot();
+            vm.startPrank(Swapper);
+            swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
+
+            vm.startPrank(Alice);
+            pp.burnOptions(
+                $posIdList[0],
+                new TokenId[](0),
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
+
+            console2.log(
+                "balance0Delta",
+                int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore0)
+            );
+            console2.log(
+                "balance1Delta",
+                int256(ct1.convertToAssets(ct1.balanceOf(Alice))) - int256(balanceBefore1)
+            );
+            vm.revertTo(snap);
+        }
+    }
+
+    function test_Success_CallCondor() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+
+        vm.startPrank(Seller);
+
+        $posIdList.push(
+            TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+                .addLeg(
+                    0,
+                    1,
+                    1,
+                    0,
+                    0,
+                    0,
+                    2235, // 1.25 call
+                    1
+                )
+                .addLeg(
+                    1,
+                    1,
+                    1,
+                    0,
+                    0,
+                    1,
+                    6935, // 2 call
+                    1
+                )
+        );
+
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // long call = 1.25, short call = 1.5, short call = 1.75, long call = 2
+        $posIdList[0] = TokenId
+            .wrap(0)
+            .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+            .addLeg(0, 1, 1, 1, 0, 0, 2235, 1)
+            .addLeg(1, 1, 1, 0, 0, 1, 4055, 1)
+            .addLeg(2, 1, 1, 0, 0, 2, 5595, 1)
+            .addLeg(3, 1, 1, 1, 0, 3, 6935, 1);
+
+        uint256 balanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
+        uint256 balanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
+
+        vm.startPrank(Alice);
+
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // 1.3, 1.6, 1.8, 2.1
+        uint16[4] memory ticks = [2623, 4699, 5877, 7419];
+
+        for (uint256 i = 0; i < ticks.length; ++i) {
+            uint256 snap = vm.snapshot();
+            vm.startPrank(Swapper);
+            swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(int16(ticks[i])));
+
+            vm.startPrank(Alice);
+            pp.burnOptions(
+                $posIdList[0],
+                new TokenId[](0),
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
+
+            console2.log(
+                "balance0Delta",
+                int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore0)
+            );
+            console2.log(
+                "balance1Delta",
+                int256(ct1.convertToAssets(ct1.balanceOf(Alice))) - int256(balanceBefore1)
+            );
+            vm.revertTo(snap);
+        }
+    }
+
+    function test_Success_PutCondor() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+
+        vm.startPrank(Seller);
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                1,
+                0,
+                -13_865, // 0.25 put
+                1
+            )
+        );
+
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // long put = 0.25, short put = 0.5, short put = 0.75, short call = 0.9
+        $posIdList[0] = TokenId
+            .wrap(0)
+            .addPoolId(PanopticMath.getPoolId(address(uniPool)))
+            .addLeg(0, 1, 1, 1, 1, 0, -13_865, 1)
+            .addLeg(1, 1, 1, 0, 1, 1, -6935, 1)
+            .addLeg(2, 1, 1, 0, 1, 2, -2875, 1)
+            .addLeg(3, 1, 1, 0, 0, 3, -1055, 1);
+
+        uint256 balanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
+        uint256 balanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
+
+        vm.startPrank(Alice);
+
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // 0.2, 0.4, 0.6, 0.8, 1.1
+        int16[5] memory ticks = [-16093, -9162, -5108, -2231, 952];
+
+        for (uint256 i = 0; i < ticks.length; ++i) {
+            uint256 snap = vm.snapshot();
+            vm.startPrank(Swapper);
+            swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
+
+            vm.startPrank(Alice);
+            pp.burnOptions(
+                $posIdList[0],
+                new TokenId[](0),
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
+
+            console2.log(
+                "balance0Delta",
+                int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore0)
+            );
+            console2.log(
+                "balance1Delta",
+                int256(ct1.convertToAssets(ct1.balanceOf(Alice))) - int256(balanceBefore1)
+            );
+            vm.revertTo(snap);
+        }
+    }
+
     function test_success_liquidation_fuzzedSwapITM(uint256[4] memory prices) public {
         vm.startPrank(Swapper);
         // JIT a bunch of liquidity so swaps at mint can happen normally

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -613,12 +613,24 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
         vm.expectRevert(stdError.divisionError);
-        pp.mintOptions($tempIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $tempIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     // position length in hash should fail instead of overflowing its slot during construction
@@ -645,14 +657,26 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         TokenId[] memory longPositionList = new TokenId[](257);
 
         for (uint256 i; i < 257; ++i) longPositionList[i] = $posIdList[0];
 
         vm.expectRevert(stdError.arithmeticError);
-        pp.mintOptions(longPositionList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            longPositionList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     // ensure all large mint/deposit amounts revert (instead of overflowing)
@@ -741,12 +765,30 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         vm.startPrank(Alice);
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
-        pp.mintOptions($posIdList, 1_000_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
-        pp.mintOptions($tempIdList, 900_000_000, type(uint64).max, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $tempIdList,
+            900_000_000,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Swapper);
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
@@ -763,20 +805,41 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Charlie);
 
         for (uint256 i = 0; i < 10; i++) {
-            pp.mintOptions($posIdList, 250_000_000, type(uint64).max, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+            pp.mintOptions(
+                $posIdList,
+                250_000_000,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
-            pp.burnOptions($posIdList[0], new TokenId[](0), Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+            pp.burnOptions(
+                $posIdList[0],
+                new TokenId[](0),
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         vm.startPrank(Alice);
-        pp.burnOptions($posIdList[0], new TokenId[](0), Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         uint256 delta0 = ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0;
         uint256 delta1 = ct1.convertToAssets(ct1.balanceOf(Alice)) - assetsBefore1;
         vm.revertTo(snap);
 
         vm.startPrank(Alice);
-        pp.burnOptions($posIdList[0], new TokenId[](0), Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // there is a small amount of error in token0 -- this is the commissions from Charlie
         assertApproxEqAbs(
@@ -1860,7 +1923,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         editCollateral(ct0, Bob, ct0.convertToShares(266263));
         editCollateral(ct1, Bob, 0);
@@ -1892,7 +1961,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
@@ -1924,7 +1999,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         editCollateral(ct0, Bob, ct0.convertToShares(266262));
         editCollateral(ct1, Bob, 0);
@@ -1957,7 +2038,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
@@ -1990,7 +2077,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 1_000_000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -6784,7 +6784,7 @@ contract PanopticPoolTest is PositionUtils {
                 widths[i]
             );
         }
-        pp.mintOptions($posIdLists[0], positionSize * 2, 0, 0, 0);
+        pp.mintOptions($posIdLists[0], positionSize * 2, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         twoWaySwap(swapSizeSeed);
 
@@ -6805,7 +6805,7 @@ contract PanopticPoolTest is PositionUtils {
             );
         }
 
-        pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+        pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         twoWaySwap(swapSizeSeed);
 
@@ -6892,7 +6892,7 @@ contract PanopticPoolTest is PositionUtils {
         int24 currentTickFinal;
         {
             (LeftRightSigned[4][] memory premiasByLeg, LeftRightSigned netExchanged) = pp
-                .burnAllOptionsFrom($posIdLists[1], 0, 0);
+                .burnAllOptionsFrom($posIdLists[1], Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
             shareDeltasLiquidatee = [
                 int256(ct0.balanceOf(Alice)) - shareDeltasLiquidatee[0],

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -6784,7 +6784,13 @@ contract PanopticPoolTest is PositionUtils {
                 widths[i]
             );
         }
-        pp.mintOptions($posIdLists[0], positionSize * 2, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdLists[0],
+            positionSize * 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         twoWaySwap(swapSizeSeed);
 
@@ -6805,7 +6811,13 @@ contract PanopticPoolTest is PositionUtils {
             );
         }
 
-        pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdLists[1],
+            positionSize,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         twoWaySwap(swapSizeSeed);
 
@@ -6892,7 +6904,11 @@ contract PanopticPoolTest is PositionUtils {
         int24 currentTickFinal;
         {
             (LeftRightSigned[4][] memory premiasByLeg, LeftRightSigned netExchanged) = pp
-                .burnAllOptionsFrom($posIdLists[1], Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+                .burnAllOptionsFrom(
+                    $posIdLists[1],
+                    Constants.MAX_V3POOL_TICK,
+                    Constants.MIN_V3POOL_TICK
+                );
 
             shareDeltasLiquidatee = [
                 int256(ct0.balanceOf(Alice)) - shareDeltasLiquidatee[0],

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -257,8 +257,6 @@ contract PanopticPoolTest is PositionUtils {
     int128[] $expectedPremias0;
     int128[] $expectedPremias1;
 
-    int256 $swap0;
-    int256 $swap1;
     int256 $itm0;
     int256 $itm1;
     int256 $intrinsicValue0;
@@ -970,67 +968,12 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
-    function updateSwappedAmountsBurn(uint256 numLegs, uint256[4] memory isLongs) public {
-        int128[] memory liquidityDeltas = new int128[](numLegs);
-        for (uint256 i = 0; i < numLegs; i++) {
-            liquidityDeltas[i] =
-                int128(numLegs == 1 ? expectedLiq : expectedLiqs[i]) *
-                (isLongs[i] == 1 ? int8(1) : -1);
-        }
-        bool zeroForOne; // The direction of the swap, true for token0 to token1, false for token1 to token0
-        int256 swapAmount; // The amount of token0 or token1 to swap
-
-        if (($itm0 != 0) && ($itm1 != 0)) {
-            int256 net0 = $itm0 - PanopticMath.convert1to0($itm1, currentSqrtPriceX96);
-
-            // if net0 is negative, then the protocol has a net shortage of token0
-            zeroForOne = net0 < 0;
-
-            //compute the swap amount, set as positive (exact input)
-            swapAmount = -net0;
-        } else if ($itm0 != 0) {
-            zeroForOne = $itm0 < 0;
-            swapAmount = -$itm0;
-        } else {
-            zeroForOne = $itm1 > 0;
-            swapAmount = -$itm1;
-        }
-
-        if (numLegs == 1) {
-            tickLowers.push(tickLower);
-            tickUppers.push(tickUpper);
-        }
-
-        if (swapAmount != 0) {
-            vm.startPrank(address(sfpm));
-            ($swap0, $swap1) = PositionUtils.simulateSwapSingleBurn(
-                pool,
-                tickLowers,
-                tickUppers,
-                liquidityDeltas,
-                router,
-                token0,
-                token1,
-                fee,
-                zeroForOne,
-                swapAmount
-            );
-            vm.startPrank(Alice);
-        }
-    }
-
     function updateIntrinsicValueBurn(
         LeftRightSigned longAmounts,
         LeftRightSigned shortAmounts
     ) public {
-        $intrinsicValue0 =
-            ($swap0 + $amount0MovedBurn) -
-            longAmounts.rightSlot() +
-            shortAmounts.rightSlot();
-        $intrinsicValue1 =
-            ($swap1 + $amount1MovedBurn) -
-            longAmounts.leftSlot() +
-            shortAmounts.leftSlot();
+        $intrinsicValue0 = $amount0MovedBurn - longAmounts.rightSlot() + shortAmounts.rightSlot();
+        $intrinsicValue1 = $amount1MovedBurn - longAmounts.leftSlot() + shortAmounts.leftSlot();
     }
 
     function populatePositionData(
@@ -1667,7 +1610,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSizes[0], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[0],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         LeftRightSigned poolUtilizationsAtMint;
@@ -1690,7 +1639,13 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(posIdList, positionSizes[1], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[1],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             twoWaySwap(swapSizeSeed);
         }
@@ -1778,7 +1733,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         premiaSeed[0] = bound(premiaSeed[0], 2 ** 64, 2 ** 120);
         premiaSeed[1] = bound(premiaSeed[1], 2 ** 64, 2 ** 120);
@@ -1874,7 +1835,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSizes[0], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[0],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         {
@@ -1882,7 +1849,13 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(posIdList, positionSizes[1], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[1],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             userBalance[tokenId] = LeftRightUnsigned.wrap(0).toRightSlot(positionSizes[0]);
             userBalance[tokenId2] = LeftRightUnsigned.wrap(0).toRightSlot(positionSizes[1]);
@@ -1943,7 +1916,13 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         // mint option from another account to change the effective liquidity
-        pp.mintOptions(posIdList, positionSize * 2, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize * 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Alice);
 
@@ -1965,7 +1944,13 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         // type(uint64).max = no limit, ensure the operation works given the changed liquidity limit
-        pp.mintOptions(posIdList, positionSize, type(uint64).max, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(
             sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)),
@@ -2053,7 +2038,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
         // mint option from another account to change the effective liquidity
-        pp.mintOptions(posIdList, positionSize * 2, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize * 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Alice);
 
@@ -2075,7 +2066,13 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         // type(uint64).max = no limit, ensure the operation works given the changed liquidity limit
-        pp.mintOptions(posIdList, positionSize, type(uint64).max - 1, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            type(uint64).max - 1,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -2155,7 +2152,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize * 2, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize * 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Alice);
 
@@ -2163,7 +2166,13 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.EffectiveLiquidityAboveThreshold.selector);
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_Success_mintOptions_OTMShortCall_SlippageSet(
@@ -2285,7 +2294,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -2369,7 +2384,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -2556,6 +2577,128 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
+    function test_Success_mintOptions_ITMShortCall_NoSwap(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getITMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        TokenId[] memory posIdList = new TokenId[](1);
+        posIdList[0] = tokenId;
+
+        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK);
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
+
+        uint256 amount0 = LiquidityAmounts.getAmount0ForLiquidity(
+            sqrtLower,
+            sqrtUpper,
+            expectedLiq
+        );
+
+        {
+            (, uint256 inAMM, ) = ct0.getPoolData();
+            assertApproxEqAbs(inAMM, amount0, 10, "inAMM0");
+        }
+
+        {
+            (, uint256 inAMM, ) = ct1.getPoolData();
+            assertEq(inAMM, 0, "inAMM1");
+        }
+        {
+            assertEq(
+                pp.positionsHash(Alice),
+                uint248(uint256(keccak256(abi.encodePacked(tokenId))))
+            );
+
+            assertEq(pp.numberOfPositions(Alice), 1);
+
+            (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = pp
+                .optionPositionBalance(Alice, tokenId);
+
+            assertEq(balance, positionSize, "balance");
+            assertEq(poolUtilization0, (amount0 * 10000) / ct0.totalSupply(), "utilization 1");
+            assertEq(poolUtilization1, 0, "utilization 0");
+        }
+
+        {
+            (, LeftRightSigned shortAmounts) = PanopticMath.computeExercisedAmounts(
+                tokenId,
+                positionSize
+            );
+
+            int256 amount0Moved = currentSqrtPriceX96 > sqrtUpper
+                ? int256(0)
+                : SqrtPriceMath.getAmount0Delta(
+                    currentSqrtPriceX96 < sqrtLower ? sqrtLower : currentSqrtPriceX96,
+                    sqrtUpper,
+                    int128(expectedLiq)
+                );
+
+            int256 amount1Moved = sqrtLower > currentSqrtPriceX96
+                ? int256(0)
+                : SqrtPriceMath.getAmount1Delta(
+                    sqrtLower,
+                    sqrtUpper > currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtUpper,
+                    int128(expectedLiq)
+                );
+
+            int256 notionalVal = amount0Moved - shortAmounts.rightSlot();
+
+            int256 ITMSpread = notionalVal > 0
+                ? (notionalVal * int24(2 * (fee / 100))) / 10_000
+                : -(notionalVal * int24(2 * (fee / 100))) / 10_000;
+
+            assertApproxEqAbs(
+                ct0.balanceOf(Alice),
+                uint256(
+                    int256(uint256(type(uint104).max)) -
+                        notionalVal -
+                        ITMSpread -
+                        (shortAmounts.rightSlot() * 10) /
+                        10_000
+                ),
+                uint256(int256(shortAmounts.rightSlot()) / 1_000_000 + 10),
+                "alice balance 0"
+            );
+
+            assertApproxEqAbs(
+                ct1.balanceOf(Alice),
+                uint256(
+                    int256(uint256(type(uint104).max)) -
+                        amount1Moved -
+                        (amount1Moved * int24(2 * (fee / 100))) /
+                        10_000
+                ),
+                10,
+                "alice balance 1"
+            );
+        }
+    }
+
     function test_Success_mintOptions_ITMShortPutShortCall(
         uint256 x,
         uint256[2] memory widthSeeds,
@@ -2623,7 +2766,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
         (, currentTick, observationIndex, observationCardinality, , , ) = pool.slot0();
 
@@ -2721,6 +2870,162 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
+    function test_Success_mintOptions_ITMShortPutShortCall_NoSwap(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width0, int24 strike0) = PositionUtils.getITMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            1
+        );
+
+        (int24 width1, int24 strike1) = PositionUtils.getITMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData([width0, width1], [strike0, strike1], positionSizeSeed);
+
+        // put leg
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            1,
+            0,
+            strike0,
+            width0
+        );
+        // call leg
+        tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
+
+        int256 netSurplus0 = $amount0Moveds[0] -
+            PanopticMath.convert1to0($amount1Moveds[1], currentSqrtPriceX96);
+
+        (, LeftRightSigned shortAmounts) = PanopticMath.computeExercisedAmounts(
+            tokenId,
+            positionSize
+        );
+
+        {
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            pp.mintOptions(
+                posIdList,
+                positionSize,
+                0,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK
+            );
+        }
+        (, currentTick, observationIndex, observationCardinality, , , ) = pool.slot0();
+
+        fastOracleTick = PanopticMath.computeMedianObservedPrice(
+            pool,
+            observationIndex,
+            observationCardinality,
+            3,
+            1
+        );
+
+        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
+            observationIndex,
+            observationCardinality,
+            60,
+            pp.miniMedian(),
+            pool
+        );
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
+
+        {
+            (, uint256 inAMM, ) = ct0.getPoolData();
+            assertApproxEqAbs(inAMM, uint128(shortAmounts.rightSlot()), 10);
+        }
+
+        {
+            (, uint256 inAMM, ) = ct1.getPoolData();
+            assertApproxEqAbs(inAMM, uint128(shortAmounts.leftSlot()), 10);
+        }
+
+        {
+            assertEq(
+                pp.positionsHash(Alice),
+                uint248(uint256(keccak256(abi.encodePacked(tokenId))))
+            );
+
+            assertEq(pp.numberOfPositions(Alice), 1);
+
+            (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = pp
+                .optionPositionBalance(Alice, tokenId);
+
+            assertEq(balance, positionSize);
+            assertEq(
+                poolUtilization0,
+                Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
+                    ? 10_001
+                    : (uint256($amount0Moveds[0] + $amount0Moveds[1]) * 10000) / ct0.totalSupply()
+            );
+            assertEq(
+                poolUtilization1,
+                Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
+                    ? 10_001
+                    : (uint256($amount1Moveds[0] + $amount1Moveds[1]) * 10000) / ct1.totalSupply()
+            );
+        }
+
+        {
+            int256[2] memory notionalVals = [
+                $amount0Moveds[0] + $amount0Moveds[1] - shortAmounts.rightSlot(),
+                $amount1Moveds[0] + $amount1Moveds[1] - shortAmounts.leftSlot()
+            ];
+            int256[2] memory ITMSpreads = [
+                notionalVals[0] > 0
+                    ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
+                    : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
+                notionalVals[1] > 0
+                    ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
+                    : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
+            ];
+
+            assertApproxEqAbs(
+                ct0.balanceOf(Alice),
+                uint256(
+                    int256(uint256(type(uint104).max)) -
+                        notionalVals[0] -
+                        ITMSpreads[0] -
+                        (shortAmounts.rightSlot() * 10) /
+                        10_000
+                ),
+                uint256(int256(shortAmounts.rightSlot()) / 1_000_000 + 10)
+            );
+
+            assertApproxEqAbs(
+                ct1.balanceOf(Alice),
+                uint256(
+                    int256(uint256(type(uint104).max)) -
+                        notionalVals[1] -
+                        ITMSpreads[1] -
+                        (shortAmounts.leftSlot() * 10) /
+                        10_000
+                ),
+                uint256(int256(shortAmounts.leftSlot()) / 1_000_000 + 10)
+            );
+        }
+    }
+
     function test_Success_mintOptions_ITMShortPutLongCall(
         uint256 x,
         uint256[2] memory widthSeeds,
@@ -2770,7 +3075,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSizes[0], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[0],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // put leg
@@ -2858,7 +3169,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSizes[1], type(uint64).max, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[1],
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // price changes afters swap at mint so we need to update the price
@@ -2922,6 +3239,255 @@ contract PanopticPoolTest is PositionUtils {
                 "Alice balance 1"
             );
         }
+    }
+
+    function test_Success_mintOptions_ITMShortPutLongCall_NoSwap(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds,
+        uint256[2] memory positionSizeSeeds
+    ) public {
+        _initPool(x);
+
+        (int24 width0, int24 strike0) = PositionUtils.getITMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            1
+        );
+
+        (int24 width1, int24 strike1) = PositionUtils.getITMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionDataLong([width0, width1], [strike0, strike1], positionSizeSeeds);
+
+        // sell short companion to long option
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike1,
+            width1
+        );
+
+        (, LeftRightSigned shortAmountsSold) = PanopticMath.computeExercisedAmounts(
+            tokenId,
+            positionSizes[0]
+        );
+
+        vm.startPrank(Seller);
+
+        {
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            pp.mintOptions(
+                posIdList,
+                positionSizes[0],
+                0,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK
+            );
+        }
+
+        // put leg
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 1, 0, strike0, width0);
+        // call leg (long)
+        tokenId = tokenId.addLeg(1, 1, isWETH, 1, 0, 1, strike1, width1);
+
+        // price changes afters swap at mint so we need to update the price
+        (currentSqrtPriceX96, currentTick, observationIndex, observationCardinality, , , ) = pool
+            .slot0();
+
+        fastOracleTick = PanopticMath.computeMedianObservedPrice(
+            pool,
+            observationIndex,
+            observationCardinality,
+            3,
+            1
+        );
+
+        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
+            observationIndex,
+            observationCardinality,
+            60,
+            pp.miniMedian(),
+            pool
+        );
+
+        updatePositionDataLong();
+
+        int256 netSurplus0 = $amount0Moveds[1] -
+            PanopticMath.convert1to0($amount1Moveds[2], currentSqrtPriceX96);
+
+        vm.startPrank(Alice);
+
+        (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
+            .computeExercisedAmounts(tokenId, positionSizes[1]);
+
+        uint256 sharesToBurn;
+        int256[2] memory notionalVals;
+        int256[2] memory ITMSpreads;
+        {
+            notionalVals = [
+                $amount0Moveds[1] +
+                    $amount0Moveds[2] -
+                    shortAmounts.rightSlot() +
+                    longAmounts.rightSlot(),
+                $amount1Moveds[1] + $amount1Moveds[2] - shortAmounts.leftSlot()
+            ];
+
+            ITMSpreads = [
+                notionalVals[0] > 0
+                    ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
+                    : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
+                notionalVals[1] > 0
+                    ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
+                    : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
+            ];
+
+            uint256 tokenToPay = uint256(
+                notionalVals[0] +
+                    ITMSpreads[0] +
+                    ((shortAmounts.rightSlot() + longAmounts.rightSlot()) * 10) /
+                    10_000
+            );
+
+            sharesToBurn = Math.mulDivRoundingUp(tokenToPay, ct0.totalSupply(), ct0.totalAssets());
+        }
+
+        {
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            pp.mintOptions(
+                posIdList,
+                positionSizes[1],
+                type(uint64).max,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK
+            );
+        }
+
+        // price changes afters swap at mint so we need to update the price
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSizes[1]);
+
+        {
+            (, uint256 inAMM, ) = ct0.getPoolData();
+            assertApproxEqAbs(
+                inAMM,
+                uint128(shortAmountsSold.rightSlot() - longAmounts.rightSlot()),
+                10
+            );
+        }
+
+        {
+            (, uint256 inAMM, ) = ct1.getPoolData();
+            assertApproxEqAbs(inAMM, uint128(shortAmounts.leftSlot()), 10);
+        }
+
+        {
+            assertEq(
+                pp.positionsHash(Alice),
+                uint248(uint256(keccak256(abi.encodePacked(tokenId))))
+            );
+
+            assertEq(pp.numberOfPositions(Alice), 1);
+
+            (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = pp
+                .optionPositionBalance(Alice, tokenId);
+
+            assertEq(balance, positionSizes[1]);
+            assertEq(
+                int64(poolUtilization0),
+                Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
+                    ? int64(10_001)
+                    : ($amount0Moveds[0] + $amount0Moveds[1] + $amount0Moveds[2] * 10000) /
+                        int256(ct0.totalSupply())
+            );
+            assertEq(
+                int64(poolUtilization1),
+                Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
+                    ? int64(10_001)
+                    : ($amount1Moveds[0] + $amount1Moveds[1] + $amount1Moveds[2] * 10000) /
+                        int256(ct1.totalSupply())
+            );
+        }
+
+        {
+            assertApproxEqAbs(
+                ct0.balanceOf(Alice),
+                uint256(
+                    int256(uint256(type(uint104).max)) -
+                        notionalVals[0] -
+                        ITMSpreads[0] -
+                        (longAmounts.rightSlot() * 10) /
+                        10_000
+                ),
+                uint256(int256(longAmounts.rightSlot()) / 1_000_000 + 10),
+                "Alice balance 0"
+            );
+
+            assertApproxEqAbs(
+                ct1.balanceOf(Alice),
+                uint256(
+                    int256(uint256(type(uint104).max)) -
+                        notionalVals[1] -
+                        ITMSpreads[1] -
+                        (shortAmounts.leftSlot() * 10) /
+                        10_000
+                ),
+                uint256(int256(shortAmounts.leftSlot()) / 1_000_000 + 10),
+                "Alice balance 1"
+            );
+        }
+    }
+
+    function test_Fail_mintOptions_PriceBoundEqualFail(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOTMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        TokenId[] memory posIdList = new TokenId[](1);
+        posIdList[0] = tokenId;
+
+        vm.expectRevert(Errors.PriceBoundFail.selector);
+        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
     }
 
     function test_Fail_mintOptions_LowerPriceBoundFail(
@@ -3029,7 +3595,13 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTokenIdParameter.selector, 0));
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_Fail_mintOptions_PositionAlreadyMinted(
@@ -3064,14 +3636,26 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         posIdList = new TokenId[](2);
         posIdList[0] = tokenId;
         posIdList[1] = tokenId;
 
         vm.expectRevert(Errors.PositionAlreadyMinted.selector);
-        pp.mintOptions(posIdList, uint128(positionSize), 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            uint128(positionSize),
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_Fail_mintOptions_PositionSizeZero(
@@ -3107,7 +3691,13 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.OptionsBalanceZero.selector);
-        pp.mintOptions(posIdList, positionSize * 0, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize * 0,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_Fail_mintOptions_OTMShortCall_NotEnoughCollateral(
@@ -3156,7 +3746,13 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         vm.expectRevert(Errors.NotEnoughCollateral.selector);
-        pp.mintOptions(posIdList, uint128(positionSize), 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            uint128(positionSize),
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_Fail_mintOptions_TooManyPositionsOpen() public {
@@ -3187,7 +3783,13 @@ contract PanopticPoolTest is PositionUtils {
                 )
             );
             if (i == 32) vm.expectRevert(Errors.TooManyPositionsOpen.selector);
-            pp.mintOptions(tokenIds, positionSize, 0, 0, 0);
+            pp.mintOptions(
+                tokenIds,
+                positionSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             if (i < 32) {
                 positionsHash =
@@ -3235,8 +3837,14 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
-        pp.burnOptions(tokenId, emptyList, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        pp.burnOptions(tokenId, emptyList, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), 0);
 
@@ -3330,7 +3938,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // poke uniswap pool to update tokens owed - needed because swap happens after mint
@@ -3361,7 +3975,12 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         {
-            pp.burnOptions(tokenId, emptyList, 0, 0);
+            pp.burnOptions(
+                tokenId,
+                emptyList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), 0);
 
@@ -3488,7 +4107,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -3520,7 +4145,12 @@ contract PanopticPoolTest is PositionUtils {
             int128(expectedLiq)
         );
         {
-            pp.burnOptions(tokenId, emptyList, 0, 0);
+            pp.burnOptions(
+                tokenId,
+                emptyList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), 0);
 
@@ -3653,7 +4283,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenIds[0];
 
-            pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             // poke uniswap pool to update tokens owed - needed because swap happens after mint
             vm.startPrank(address(sfpm));
@@ -3676,8 +4312,8 @@ contract PanopticPoolTest is PositionUtils {
                 posIdList,
                 (positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000,
                 type(uint64).max,
-                0,
-                0
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
             );
 
             twoWaySwap(swapSizeSeed);
@@ -3703,8 +4339,8 @@ contract PanopticPoolTest is PositionUtils {
                 posIdList,
                 (((positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000) * 100) / 89,
                 0,
-                0,
-                0
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
             );
 
             // poke uniswap pool to update tokens owed - needed because swap happens after mint
@@ -3739,7 +4375,12 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.startPrank(Alice);
         {
-            pp.burnOptions(tokenIds[0], emptyList, 0, 0);
+            pp.burnOptions(
+                tokenIds[0],
+                emptyList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         //snapshot balances and revert to old snapshot
@@ -3794,6 +4435,210 @@ contract PanopticPoolTest is PositionUtils {
             int256(balanceBefores[1]) - int256(uint256(type(uint104).max)),
             int256(uint256(tokensOwed1)),
             tokensOwed1 / 1_000_000 + 10,
+            "Incorrect token1 delta"
+        );
+    }
+
+    // minting a long position to reduce the premium that can be paid
+    function test_Success_burnOptions_ITMShortCall_premia_insufficientLocked_NoSwap(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed,
+        uint256 swapSizeSeed,
+        uint256 longPercentageSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getITMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        tokenIds.push(
+            TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, isWETH, 0, 0, 0, strike, width)
+        );
+
+        tokenIds.push(
+            TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, isWETH, 1, 0, 0, strike, width)
+        );
+
+        int256[2] memory amount0Moveds;
+        int256[2] memory amount1Moveds;
+
+        amount0Moveds[0] = currentSqrtPriceX96 > sqrtUpper
+            ? int256(0)
+            : SqrtPriceMath.getAmount0Delta(
+                currentSqrtPriceX96 < sqrtLower ? sqrtLower : currentSqrtPriceX96,
+                sqrtUpper,
+                int128(expectedLiq)
+            );
+
+        amount1Moveds[0] = -SqrtPriceMath.getAmount1Delta(
+            sqrtLower,
+            sqrtUpper > currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtUpper,
+            int128(expectedLiq)
+        );
+
+        uint128 tokensOwed0;
+        uint128 tokensOwed1;
+        {
+            uint128[] memory tokensOwedTemp = new uint128[](2);
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenIds[0];
+
+            pp.mintOptions(
+                posIdList,
+                positionSize,
+                0,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK
+            );
+
+            // poke uniswap pool to update tokens owed - needed because swap happens after mint
+            vm.startPrank(address(sfpm));
+            pool.burn(tickLower, tickUpper, 0);
+
+            // calculate additional fees owed to position
+            (, , , tokensOwed0, tokensOwed1) = pool.positions(
+                PositionKey.compute(address(sfpm), tickLower, tickUpper)
+            );
+
+            tokensOwedTemp[0] = tokensOwed0;
+            tokensOwedTemp[1] = tokensOwed1;
+
+            // mint a long option at some percentage of Alice's liquidity so the premium is reduced
+            vm.startPrank(Bob);
+
+            posIdList[0] = tokenIds[1];
+
+            pp.mintOptions(
+                posIdList,
+                (positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000,
+                type(uint64).max,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK
+            );
+
+            twoWaySwap(swapSizeSeed);
+
+            // poke uniswap pool to update tokens owed - needed because swap happens after mint
+            vm.startPrank(address(sfpm));
+            pool.burn(tickLower, tickUpper, 0);
+
+            // calculate additional fees owed to position
+            (, , , tokensOwed0, tokensOwed1) = pool.positions(
+                PositionKey.compute(address(sfpm), tickLower, tickUpper)
+            );
+
+            tokensOwedTemp[0] += tokensOwed0;
+            tokensOwedTemp[1] += tokensOwed1;
+
+            // sell enough liquidity for alice to exit
+            vm.startPrank(Seller);
+
+            posIdList[0] = tokenIds[0];
+
+            pp.mintOptions(
+                posIdList,
+                (((positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000) * 100) / 89,
+                0,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK
+            );
+
+            // poke uniswap pool to update tokens owed - needed because swap happens after mint
+            vm.startPrank(address(sfpm));
+            pool.burn(tickLower, tickUpper, 0);
+
+            // calculate additional fees owed to position
+            (, , , tokensOwed0, tokensOwed1) = pool.positions(
+                PositionKey.compute(address(sfpm), tickLower, tickUpper)
+            );
+
+            tokensOwed0 += tokensOwedTemp[0];
+            tokensOwed1 += tokensOwedTemp[1];
+        }
+
+        // price changes afters swap at mint so we need to update the price
+        (currentSqrtPriceX96, , , , , , ) = pool.slot0();
+
+        amount0Moveds[1] = currentSqrtPriceX96 > sqrtUpper
+            ? int256(0)
+            : SqrtPriceMath.getAmount0Delta(
+                currentSqrtPriceX96 < sqrtLower ? sqrtLower : currentSqrtPriceX96,
+                sqrtUpper,
+                int128(expectedLiq)
+            );
+
+        amount1Moveds[1] = SqrtPriceMath.getAmount1Delta(
+            sqrtLower,
+            sqrtUpper > currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtUpper,
+            int128(expectedLiq)
+        );
+
+        vm.startPrank(Alice);
+        {
+            pp.burnOptions(
+                tokenIds[0],
+                emptyList,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK
+            );
+        }
+
+        //snapshot balances and revert to old snapshot
+        uint256[2] memory balanceBefores = [ct0.balanceOf(Alice), ct1.balanceOf(Alice)];
+
+        (, LeftRightSigned shortAmounts) = PanopticMath.computeExercisedAmounts(
+            tokenIds[0],
+            uint128(positionSize)
+        );
+
+        int256[2] memory notionalVals = [
+            amount0Moveds[0] - shortAmounts.rightSlot(),
+            -amount0Moveds[1] + shortAmounts.rightSlot()
+        ];
+
+        int256[2] memory notionalVals1 = [-amount1Moveds[0], -amount1Moveds[1]];
+
+        int256 ITMSpread = notionalVals[0] > 0
+            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
+            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+
+        int256 ITMSpread1 = notionalVals1[0] > 0
+            ? (notionalVals1[0] * int24(2 * (fee / 100))) / 10_000
+            : -((notionalVals1[0] * int24(2 * (fee / 100))) / 10_000);
+
+        console2.log("ITMSpread", ITMSpread);
+        console2.log("notionalVals[0]", notionalVals[0]);
+        console2.log("notionalVals[1]", notionalVals[1]);
+        console2.log("tokensOwed0", tokensOwed0);
+        assertApproxEqAbs(
+            int256(balanceBefores[0]) - int256(uint256(type(uint104).max)),
+            -ITMSpread -
+                notionalVals[0] -
+                notionalVals[1] -
+                (shortAmounts.rightSlot() * 10) /
+                10_000 +
+                int128(tokensOwed0),
+            (uint256(int256(shortAmounts.rightSlot())) + tokensOwed0) / 1_000_000 + 10,
+            "Incorrect token0 delta"
+        );
+
+        console2.log("ITMSpread1", ITMSpread1);
+        console2.log("notionalVals1[0]", notionalVals1[0]);
+        console2.log("notionalVals1[1]", notionalVals1[1]);
+        console2.log("tokensOwed1", tokensOwed1);
+        assertApproxEqAbs(
+            int256(balanceBefores[1]) - int256(uint256(type(uint104).max)),
+            -ITMSpread1 - notionalVals1[0] - notionalVals1[1] + int256(uint256(tokensOwed1)),
+            tokensOwed1 / 1_000_000 + 10 + uint256(ITMSpread1) / 1_000_000,
             "Incorrect token1 delta"
         );
     }
@@ -3859,7 +4704,13 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSizes[0], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[0],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         {
@@ -3867,9 +4718,20 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(posIdList, uint128(positionSizes[1]), 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                uint128(positionSizes[1]),
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
-            pp.burnOptions(posIdList, emptyList, 0, 0);
+            pp.burnOptions(
+                posIdList,
+                emptyList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (uint256 token0Balance, , ) = pp.optionPositionBalance(Alice, tokenId);
             (uint256 token1Balance, , ) = pp.optionPositionBalance(Alice, tokenId2);
@@ -3949,7 +4811,13 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions($posIdLists[0], positionSize * 10, 0, 0, 0);
+            pp.mintOptions(
+                $posIdLists[0],
+                positionSize * 10,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         // now we can mint the long option we are force exercising
@@ -3968,7 +4836,13 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[1],
+                positionSize,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             if ($posIdLists[3].length < legsToBurn) {
                 $posIdLists[3].push($posIdLists[1][i]);
@@ -3983,9 +4857,19 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             if ($posIdLists[3].length > 1) {
-                pp.burnOptions($posIdLists[3], $posIdLists[2], 0, 0);
+                pp.burnOptions(
+                    $posIdLists[3],
+                    $posIdLists[2],
+                    Constants.MAX_V3POOL_TICK,
+                    Constants.MIN_V3POOL_TICK
+                );
             } else {
-                pp.burnOptions($posIdLists[3][0], $posIdLists[2], 0, 0);
+                pp.burnOptions(
+                    $posIdLists[3][0],
+                    $posIdLists[2],
+                    Constants.MAX_V3POOL_TICK,
+                    Constants.MIN_V3POOL_TICK
+                );
             }
 
             int256 balanceDelta0 = int256(ct0.balanceOf(Alice)) -
@@ -4084,9 +4968,19 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.expectRevert();
         if ($posIdLists[3].length > 1) {
-            pp.burnOptions($posIdLists[3], $posIdLists[2], 0, 0);
+            pp.burnOptions(
+                $posIdLists[3],
+                $posIdLists[2],
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         } else {
-            pp.burnOptions($posIdLists[3][0], $posIdLists[2], 0, 0);
+            pp.burnOptions(
+                $posIdLists[3][0],
+                $posIdLists[2],
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
     }
 
@@ -4095,7 +4989,12 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.expectRevert(Errors.OptionsBalanceZero.selector);
 
-        pp.burnOptions(TokenId.wrap(0), emptyList, 0, 0);
+        pp.burnOptions(
+            TokenId.wrap(0),
+            emptyList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
     }
 
     function test_Fail_burnOptions_WrongIdList(
@@ -4130,11 +5029,17 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.expectRevert(Errors.InputListFail.selector);
 
-        pp.burnOptions(tokenId, posIdList, 0, 0);
+        pp.burnOptions(tokenId, posIdList, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
     }
 
     function test_fail_burnOptions_burnAllOptionsFrom(
@@ -4220,10 +5125,21 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSizes[0], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[0],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(tokenId, posIdList, 0, 0);
+            pp.burnOptions(
+                tokenId,
+                posIdList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         {
@@ -4231,10 +5147,21 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(posIdList, uint128(positionSizes[1]), 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                uint128(positionSizes[1]),
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(tokenId, emptyList, 0, 0);
+            pp.burnOptions(
+                tokenId,
+                emptyList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
         {
             TokenId[] memory posIdList = new TokenId[](3);
@@ -4242,10 +5169,21 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[1] = tokenId2;
             posIdList[2] = tokenId3;
 
-            pp.mintOptions(posIdList, uint128(positionSizes[0]), 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                uint128(positionSizes[0]),
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(tokenId, posIdList, 0, 0);
+            pp.burnOptions(
+                tokenId,
+                posIdList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         {
@@ -4255,20 +5193,36 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[2] = tokenId3;
             posIdList[3] = tokenId4;
 
-            pp.mintOptions(posIdList, uint128(positionSizes[1]), 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                uint128(positionSizes[1]),
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             TokenId[] memory burnIdList = new TokenId[](2);
             burnIdList[0] = tokenId;
             burnIdList[1] = tokenId2;
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(burnIdList, posIdList, 0, 0);
+            pp.burnOptions(
+                burnIdList,
+                posIdList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             TokenId[] memory leftoverIdList = new TokenId[](2);
             leftoverIdList[0] = tokenId3;
             leftoverIdList[1] = tokenId4;
 
-            pp.burnOptions(burnIdList, leftoverIdList, 0, 0);
+            pp.burnOptions(
+                burnIdList,
+                leftoverIdList,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
     }
 
@@ -4352,7 +5306,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize * 2, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize * 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         // now we can mint the long option we are force exercising
         vm.startPrank(Alice);
@@ -4378,9 +5338,15 @@ contract PanopticPoolTest is PositionUtils {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        try pp.mintOptions(posIdList, positionSize, type(uint64).max, 0, 0) {} catch (
-            bytes memory reason
-        ) {
+        try
+            pp.mintOptions(
+                posIdList,
+                positionSize,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            )
+        {} catch (bytes memory reason) {
             if (bytes4(reason) == Errors.TransferFailed.selector) {
                 vm.assume(false);
             }
@@ -4399,14 +5365,6 @@ contract PanopticPoolTest is PositionUtils {
         updatePositionDataVariable(numLegs, isLongs);
 
         updateITMAmountsBurn(numLegs, tokenTypes);
-
-        updateSwappedAmountsBurn(numLegs, isLongs);
-
-        // make sure pool has enough tokens to perform the swap (if there is tons of slippage it may not)
-        vm.assume(
-            2 * $swap0 <= int256(IERC20Partial(token0).balanceOf(address(pp))) &&
-                2 * $swap1 <= int256(IERC20Partial(token1).balanceOf(address(pp)))
-        );
 
         updateIntrinsicValueBurn(longAmounts, shortAmounts);
 
@@ -4722,7 +5680,13 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions($posIdLists[0], positionSize * 10, 0, 0, 0);
+            pp.mintOptions(
+                $posIdLists[0],
+                positionSize * 10,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -4756,7 +5720,13 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[3].pop();
             }
 
-            pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[1],
+                positionSize,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -4916,7 +5886,13 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions($posIdLists[0], positionSize * 2, 0, 0, 0);
+            pp.mintOptions(
+                $posIdLists[0],
+                positionSize * 2,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -4950,7 +5926,13 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[3].pop();
             }
 
-            pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[1],
+                positionSize,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -5107,7 +6089,13 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions($posIdLists[0], positionSize * 2, 0, 0, 0);
+            pp.mintOptions(
+                $posIdLists[0],
+                positionSize * 2,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -5141,7 +6129,13 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[3].pop();
             }
 
-            pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[1],
+                positionSize,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -5193,7 +6187,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         posIdList = new TokenId[](2);
         posIdList[0] = tokenId;
@@ -5211,7 +6211,13 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[1] = tokenId2;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
@@ -5261,7 +6267,13 @@ contract PanopticPoolTest is PositionUtils {
         touchedIds[0] = tokenId;
 
         vm.startPrank(Alice);
-        pp.mintOptions(touchedIds, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            touchedIds,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
@@ -5343,7 +6355,13 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions($posIdLists[0], positionSize * 2, 0, 0, 0);
+            pp.mintOptions(
+                $posIdLists[0],
+                positionSize * 2,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -5365,7 +6383,13 @@ contract PanopticPoolTest is PositionUtils {
                 )
             );
 
-            pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[1],
+                positionSize,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -5451,8 +6475,13 @@ contract PanopticPoolTest is PositionUtils {
 
         int24 currentTickFinal;
         {
+            // no swap flag (liquidations always have swaps disabled)
             (LeftRightSigned[4][] memory premiasByLeg, LeftRightSigned netExchanged) = pp
-                .burnAllOptionsFrom($posIdLists[1], 0, 0);
+                .burnAllOptionsFrom(
+                    $posIdLists[1],
+                    Constants.MIN_V3POOL_TICK,
+                    Constants.MAX_V3POOL_TICK
+                );
 
             shareDeltasLiquidatee = [
                 int256(ct0.balanceOf(Alice)) - shareDeltasLiquidatee[0],
@@ -5827,7 +6856,13 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         posIdList = new TokenId[](2);
         posIdList[0] = tokenId;
@@ -5845,7 +6880,13 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[1] = tokenId2;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
@@ -5889,11 +6930,23 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         editCollateral(ct0, Alice, 0);
         editCollateral(ct1, Alice, 0);
@@ -5996,7 +7049,13 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions($posIdLists[0], positionSize * 2, 0, 0, 0);
+            pp.mintOptions(
+                $posIdLists[0],
+                positionSize * 2,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);
@@ -6018,7 +7077,13 @@ contract PanopticPoolTest is PositionUtils {
                 )
             );
 
-            pp.mintOptions($posIdLists[1], positionSize, type(uint64).max, 0, 0);
+            pp.mintOptions(
+                $posIdLists[1],
+                positionSize,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         twoWaySwap(swapSizeSeed);

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -6906,8 +6906,8 @@ contract PanopticPoolTest is PositionUtils {
             (LeftRightSigned[4][] memory premiasByLeg, LeftRightSigned netExchanged) = pp
                 .burnAllOptionsFrom(
                     $posIdLists[1],
-                    Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    Constants.MAX_V3POOL_TICK
                 );
 
             shareDeltasLiquidatee = [

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -2910,9 +2910,6 @@ contract PanopticPoolTest is PositionUtils {
         // call leg
         tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
 
-        int256 netSurplus0 = $amount0Moveds[0] -
-            PanopticMath.convert1to0($amount1Moveds[1], currentSqrtPriceX96);
-
         (, LeftRightSigned shortAmounts) = PanopticMath.computeExercisedAmounts(
             tokenId,
             positionSize
@@ -3325,9 +3322,6 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         updatePositionDataLong();
-
-        int256 netSurplus0 = $amount0Moveds[1] -
-            PanopticMath.convert1to0($amount1Moveds[2], currentSqrtPriceX96);
 
         vm.startPrank(Alice);
 

--- a/test/foundry/periphery/PanopticHelper.t.sol
+++ b/test/foundry/periphery/PanopticHelper.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 import {Errors} from "@libraries/Errors.sol";
 import {PanopticMath} from "@libraries/PanopticMath.sol";
+import {Constants} from "@libraries/Constants.sol";
 import {TokenId} from "@types/TokenId.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
@@ -1071,7 +1072,13 @@ contract PanopticHelperTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(posIdList, positionSizes[0], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[0],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
         }
 
         {
@@ -1079,7 +1086,13 @@ contract PanopticHelperTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(posIdList, positionSizes[1], 0, 0, 0);
+            pp.mintOptions(
+                posIdList,
+                positionSizes[1],
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
 
             (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = pp
                 .calculateAccumulatedFeesBatch(Alice, false, posIdList);


### PR DESCRIPTION
This PR
- removes support for the undocumented `tickLimitLow==tickLimitHigh` flag for disabling slippage checks
- reinstates `tickLimitHigh < tickLimitLow` flag support in the PanopticPool, allowing users to skip ITM swaps during mints and burns (will document this more clearly in a follow up later)
- disables ITM swapping during force exercises and liquidations

ITM swaps (in theory) improve trading UX by allowing users to denominate their profits and losses due to intrinsic value changes in a single token instead of paying to exercise their option and receiving the proceeds directly.

In traditional finance, options contracts are exchanged for USD but denominated in stock units. This means unwinding completely requires an extra stock leg: to exercise an ITM put you must purchase the stock on another exchange, and to exercise an ITM call you must sell the stocks received after exercising the options.

That's not so bad. In Panoptic, however, things get even more complicated. Opening or closing ITM positions requires either providing a token not borrowed/previously removed from the Uniswap pool or paying back a loan/funding a strategy in a different token (short/long). Without ITM swaps, users would need far more tokens available to create and settle options (ex: If a user wants to sell a (1-tick-wide) 1000 USDC put at s=1000, but the price is 999 USDC, they would need to provide 999 USDC worth of ETH to create the position and hold the borrowed 1000 USDC in their account, effectively limiting their leverage to ~1x even though the capital efficiency remains the same post-mint. If ITM swaps are enabled, they just swap the 1000 USDC they borrowed for ETH instead).

That being said, there's nothing inherently insecure about options traders settling manually, and because we have fairly robust handling of token deltas already, it doesn't make sense to arbitrarily force ITM swaps. Many (or even most) users will probably want ITM swaps in some form for convenience, but swapping through Uniswap directly can get expensive and some users (especially those migrating from Uniswap) have a lower tolerance for execution costs. At some point (maybe in a future version of the protocol) ITM swaps will probably occur in separate frames instead of being enshrined.

For force exercises and liquidations, ITM swaps increase the attack surface significantly and create incentives for price manipulation (as the swapping account has no control over slippage). The impact on liquidations is somewhat limited because we have an enshrined slippage check against an oracle price, but that check can lead to liquidation delays in certain situations and still allows some degree of manipulation (ideally, we would remove that check in a future PR after swaps are disabled).

Force exercisors compensate exercisees for unfavorable token deltas in long legs between the current and oracle prices, but that does not cover price manipulation outside the range of the position. (ex: Alice purchases a 1 ETH (1-tick-wide) call at S=1000. The price moves organically to 2000 (so Alice's profit should be ~1000 USDC). Before Alice can exercise her position, Bob manipulates the price to 1001 USDC/ETH and force exercises Alice. At that price, Alice still owes 1000 USDC to the option seller, but is now forced to sell her ETH at a steep discount to Bob and is left with a profit (or even a loss!) of <1 USDC. If ITM swaps are disabled, settlement at a price of 1001 proceeds exactly the same as it would at 2000 (Alice pays 1000 USDC to recreate the LP position and receives the 1 ETH she was holding, which will be worth 2000 USDC in the open market regardless of what the pool price says at that point)).

We already have mechanisms for liquidators and exercisors to exchange tokens required to settle the position with surplus tokens, so disabling the ITM swaps there to solve these issues doesn't have any new side effects (besides being a potential inconvenience for force exercisees)