### PR TITLE
fix: apply loss compensation to ->ITM long legs

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -722,23 +722,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     );
                 }
 
-                uint256 tokenType = positionId.tokenType(leg);
                 // compensate user for loss in value if chunk has lost money between current and median tick
                 // note: the delta for one token will be positive and the other will be negative. This cancels out any moves in their positions
-                if (
-                    (tokenType == 0 && currentValue1 < oracleValue1) ||
-                    (tokenType == 1 && currentValue0 < oracleValue0)
-                )
-                    exerciseFees = exerciseFees.sub(
-                        LeftRightSigned
-                            .wrap(0)
-                            .toRightSlot(
-                                int128(uint128(oracleValue0)) - int128(uint128(currentValue0))
-                            )
-                            .toLeftSlot(
-                                int128(uint128(oracleValue1)) - int128(uint128(currentValue1))
-                            )
-                    );
+                exerciseFees = exerciseFees.sub(
+                    LeftRightSigned
+                        .wrap(0)
+                        .toRightSlot(int128(uint128(oracleValue0)) - int128(uint128(currentValue0)))
+                        .toLeftSlot(int128(uint128(oracleValue1)) - int128(uint128(currentValue1)))
+                );
             }
 
             // note: we HAVE to start with a negative number as the base exercise cost because when shifting a negative number right by n bits,

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -4379,13 +4379,8 @@ contract PanopticPoolTest is PositionUtils {
 
             // compensate user for loss in value if chunk has lost money between current and median tick
             // note: the delta for one token will be positive and the other will be negative. This cancels out any moves in their positions
-            if (
-                (tokenTypes[i] == 0 && currentValue1 < medianValue1) ||
-                (tokenTypes[i] == 1 && currentValue0 < medianValue0)
-            ) {
-                exerciseFeeAmounts[0] += int256(medianValue0) - int256(currentValue0);
-                exerciseFeeAmounts[1] += int256(medianValue1) - int256(currentValue1);
-            }
+            exerciseFeeAmounts[0] += int256(medianValue0) - int256(currentValue0);
+            exerciseFeeAmounts[1] += int256(medianValue1) - int256(currentValue1);
         }
 
         // since the position is sufficiently OTM, the spread between value at current tick and median tick is 0


### PR DESCRIPTION
I scrapped the rest of the loss compensation changes, but this one is critical.

The original thinking (when we still had ITM swaps) was that long legs moving to an unnatural further ITM would always be favorable for the exercisee. This is no longer the case, so we need to apply loss compensation there too:

```
The current price of ETH is 1000. Bob has a 1 ETH long call option with a strike price of 2000 USDC that can be exercised or liquidated.
Alice could manipulate the price to 2000 USDC and force exercise or liquidate Bob, forcing him to "purchase" 1 ETH at a price of 2000 USDC.
Effectively, Bob is paying 2000 USDC to settle his position, leaving him with 1 ETH of backing (worth 1000 USDC at the unmanipulated price).
At the "true" price of 1000 USDC, Bob only needs to pay 1 ETH to settle his position with the option seller.
```

Essentially, a sale at any long option's strike price (which is always at a worse price relative to market) can be forced by any user that has control over the (slippage for a) closing transaction, regardless of whether the "option" is a put or a call. The same could be said of short positions, but compensation is not needed for those because the price will always be better than market.