### PR TITLE
feat: add optional `assertMinCollateralValues` slippage check

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -328,17 +328,17 @@ contract PanopticPool is ERC1155Holder, Multicall {
                              QUERY HELPERS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Reverts if current Uniswap price is not within the provided bounds.
+    /// @notice Reverts if the caller has a lower collateral balance than required to meet the provided `minValue0` and `minValue1`.
     /// @dev Can be used for composable slippage checks with `multicall` (such as for a force exercise or liquidation)
-    /// @dev Can also be used for more granular subtick precision on slippage checks
-    /// @param sqrtLowerBound The lower bound of the acceptable open interval for `currentSqrtPriceX96`
-    /// @param sqrtUpperBound The upper bound of the acceptable open interval for `currentSqrtPriceX96`
-    function assertPriceWithinBounds(uint160 sqrtLowerBound, uint160 sqrtUpperBound) external view {
-        (uint160 currentSqrtPriceX96, , , , , , ) = s_univ3pool.slot0();
-
-        if (currentSqrtPriceX96 <= sqrtLowerBound || currentSqrtPriceX96 >= sqrtUpperBound) {
-            revert Errors.PriceBoundFail();
-        }
+    /// @param minValue0 The minimum acceptable `token0` value of collateral
+    /// @param minValue1 The minimum acceptable `token1` value of collateral
+    function assertMinCollateralValues(uint256 minValue0, uint256 minValue1) external view {
+        CollateralTracker ct0 = s_collateralToken0;
+        CollateralTracker ct1 = s_collateralToken1;
+        if (
+            ct0.convertToAssets(ct0.balanceOf(msg.sender)) < minValue0 ||
+            ct1.convertToAssets(ct1.balanceOf(msg.sender)) < minValue1
+        ) revert Errors.NotEnoughCollateral();
     }
 
     /// @notice Determines if account is eligible to withdraw or transfer collateral.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -329,7 +329,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Reverts if the caller has a lower collateral balance than required to meet the provided `minValue0` and `minValue1`.
-    /// @dev Can be used for composable slippage checks with `multicall` (such as for a force exercise or liquidation)
+    /// @dev Can be used for composable slippage checks with `multicall` (such as for a force exercise or liquidation).
     /// @param minValue0 The minimum acceptable `token0` value of collateral
     /// @param minValue1 The minimum acceptable `token1` value of collateral
     function assertMinCollateralValues(uint256 minValue0, uint256 minValue1) external view {

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1572,7 +1572,7 @@ contract PanopticPoolTest is PositionUtils {
     function test_Success_assertMinCollateralValues() public {
         _initPool(0);
 
-        changePrank(Bob);
+        vm.startPrank(Bob);
         pp.assertMinCollateralValues(
             ct0.convertToAssets(ct0.balanceOf(Bob)),
             ct1.convertToAssets(ct1.balanceOf(Bob))
@@ -1582,34 +1582,37 @@ contract PanopticPoolTest is PositionUtils {
     function test_Fail_assertMinCollateralValues_Below0() public {
         _initPool(0);
 
-        changePrank(Bob);
+        vm.startPrank(Bob);
+
+        uint256 assets0 = ct0.convertToAssets(ct0.balanceOf(Bob));
+        uint256 assets1 = ct1.convertToAssets(ct1.balanceOf(Bob));
+
         vm.expectRevert(Errors.NotEnoughCollateral.selector);
-        pp.assertMinCollateralValues(
-            ct0.convertToAssets(ct0.balanceOf(Bob)) + 1,
-            ct1.convertToAssets(ct1.balanceOf(Bob))
-        );
+        pp.assertMinCollateralValues(assets0 + 1, assets1);
     }
 
     function test_Fail_assertMinCollateralValues_Below1() public {
         _initPool(0);
 
-        changePrank(Bob);
+        vm.startPrank(Bob);
+
+        uint256 assets0 = ct0.convertToAssets(ct0.balanceOf(Bob));
+        uint256 assets1 = ct1.convertToAssets(ct1.balanceOf(Bob));
+
         vm.expectRevert(Errors.NotEnoughCollateral.selector);
-        pp.assertMinCollateralValues(
-            ct0.convertToAssets(ct0.balanceOf(Bob)),
-            ct1.convertToAssets(ct1.balanceOf(Bob)) + 1
-        );
+        pp.assertMinCollateralValues(assets0, assets1 + 1);
     }
 
     function test_Fail_assertMinCollateralValues_BelowBoth() public {
         _initPool(0);
 
-        changePrank(Bob);
+        vm.startPrank(Bob);
+
+        uint256 assets0 = ct0.convertToAssets(ct0.balanceOf(Bob));
+        uint256 assets1 = ct1.convertToAssets(ct1.balanceOf(Bob));
+
         vm.expectRevert(Errors.NotEnoughCollateral.selector);
-        pp.assertMinCollateralValues(
-            ct0.convertToAssets(ct0.balanceOf(Bob)) + 1,
-            ct1.convertToAssets(ct1.balanceOf(Bob)) + 1
-        );
+        pp.assertMinCollateralValues(assets0 + 1, assets1 + 1);
     }
 
     /// forge-config: default.fuzz.runs = 10

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1569,46 +1569,47 @@ contract PanopticPoolTest is PositionUtils {
                              STATIC QUERIES
     //////////////////////////////////////////////////////////////*/
 
-    function test_Success_assertPriceWithinBounds(
-        uint256 x,
-        uint256 sqrtPriceX96,
-        uint256 sqrtPriceX96Lower,
-        uint256 sqrtPriceX96Upper
-    ) public {
-        sqrtPriceX96 = bound(
-            sqrtPriceX96,
-            TickMath.MIN_SQRT_RATIO + 1,
-            TickMath.MAX_SQRT_RATIO - 1
-        );
-        sqrtPriceX96Lower = bound(sqrtPriceX96Lower, TickMath.MIN_SQRT_RATIO, sqrtPriceX96 - 1);
-        sqrtPriceX96Upper = bound(sqrtPriceX96Upper, sqrtPriceX96 + 1, TickMath.MAX_SQRT_RATIO);
+    function test_Success_assertMinCollateralValues() public {
+        _initPool(0);
 
-        _initWorldAtPrice(x, 0, uint160(sqrtPriceX96));
-        pp.assertPriceWithinBounds(uint160(sqrtPriceX96Lower), uint160(sqrtPriceX96Upper));
+        changePrank(Bob);
+        pp.assertMinCollateralValues(
+            ct0.convertToAssets(ct0.balanceOf(Bob)),
+            ct1.convertToAssets(ct1.balanceOf(Bob))
+        );
     }
 
-    function test_Fail_assertPriceWithinBounds(
-        uint256 x,
-        uint256 sqrtPriceX96,
-        uint256 sqrtPriceX96Lower,
-        uint256 sqrtPriceX96Upper
-    ) public {
-        sqrtPriceX96 = bound(sqrtPriceX96, TickMath.MIN_SQRT_RATIO, TickMath.MAX_SQRT_RATIO);
-        sqrtPriceX96Lower = bound(
-            sqrtPriceX96Lower,
-            TickMath.MIN_SQRT_RATIO,
-            TickMath.MAX_SQRT_RATIO
-        );
-        sqrtPriceX96Upper = bound(
-            sqrtPriceX96Upper,
-            TickMath.MIN_SQRT_RATIO,
-            TickMath.MAX_SQRT_RATIO
-        );
+    function test_Fail_assertMinCollateralValues_Below0() public {
+        _initPool(0);
 
-        vm.assume(sqrtPriceX96 <= sqrtPriceX96Lower || sqrtPriceX96 >= sqrtPriceX96Upper);
-        _initWorldAtPrice(x, 0, uint160(sqrtPriceX96));
-        vm.expectRevert(Errors.PriceBoundFail.selector);
-        pp.assertPriceWithinBounds(uint160(sqrtPriceX96Lower), uint160(sqrtPriceX96Upper));
+        changePrank(Bob);
+        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        pp.assertMinCollateralValues(
+            ct0.convertToAssets(ct0.balanceOf(Bob)) - 1,
+            ct1.convertToAssets(ct1.balanceOf(Bob))
+        );
+    }
+
+    function test_Fail_assertMinCollateralValues_Below1() public {
+        _initPool(0);
+
+        changePrank(Bob);
+        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        pp.assertMinCollateralValues(
+            ct0.convertToAssets(ct0.balanceOf(Bob)),
+            ct1.convertToAssets(ct1.balanceOf(Bob)) - 1
+        );
+    }
+
+    function test_Fail_assertMinCollateralValues_BelowBoth() public {
+        _initPool(0);
+
+        changePrank(Bob);
+        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        pp.assertMinCollateralValues(
+            ct0.convertToAssets(ct0.balanceOf(Bob)) - 1,
+            ct1.convertToAssets(ct1.balanceOf(Bob)) - 1
+        );
     }
 
     /// forge-config: default.fuzz.runs = 10

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1585,7 +1585,7 @@ contract PanopticPoolTest is PositionUtils {
         changePrank(Bob);
         vm.expectRevert(Errors.NotEnoughCollateral.selector);
         pp.assertMinCollateralValues(
-            ct0.convertToAssets(ct0.balanceOf(Bob)) - 1,
+            ct0.convertToAssets(ct0.balanceOf(Bob)) + 1,
             ct1.convertToAssets(ct1.balanceOf(Bob))
         );
     }
@@ -1597,7 +1597,7 @@ contract PanopticPoolTest is PositionUtils {
         vm.expectRevert(Errors.NotEnoughCollateral.selector);
         pp.assertMinCollateralValues(
             ct0.convertToAssets(ct0.balanceOf(Bob)),
-            ct1.convertToAssets(ct1.balanceOf(Bob)) - 1
+            ct1.convertToAssets(ct1.balanceOf(Bob)) + 1
         );
     }
 
@@ -1607,8 +1607,8 @@ contract PanopticPoolTest is PositionUtils {
         changePrank(Bob);
         vm.expectRevert(Errors.NotEnoughCollateral.selector);
         pp.assertMinCollateralValues(
-            ct0.convertToAssets(ct0.balanceOf(Bob)) - 1,
-            ct1.convertToAssets(ct1.balanceOf(Bob)) - 1
+            ct0.convertToAssets(ct0.balanceOf(Bob)) + 1,
+            ct1.convertToAssets(ct1.balanceOf(Bob)) + 1
         );
     }
 


### PR DESCRIPTION
Force exercisors (and in particular, liquidators) can use this more granular slippage check to prevent sandwich attacks/unwanted token deltas without having to trade through a custom contract.