### PR TITLE
fix: miscellaneous low-sev/documentation fixes

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -34,7 +34,6 @@ import {TokenId} from "@types/TokenId.sol";
 //
 /// @notice 2) get any gain in capital that results from buying an option that becomes in-the-money.
 contract CollateralTracker is ERC20Minimal, Multicall {
-    // Used for safecasting
     using Math for uint256;
 
     /*//////////////////////////////////////////////////////////////
@@ -105,57 +104,59 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                            PANOPTIC POOL DATA
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev The Collateral Tracker keeps a reference to the Panoptic Pool using it.
+    /// @notice The Collateral Tracker keeps a reference to the Panoptic Pool using it.
     PanopticPool internal s_panopticPool;
 
-    /// @dev Cached amount of assets accounted to be held by the Panoptic Pool — ignores donations, pending fee payouts, and other untracked balance changes.
+    /// @notice Cached amount of assets accounted to be held by the Panoptic Pool — ignores donations, pending fee payouts, and other untracked balance changes.
     uint128 internal s_poolAssets;
 
-    /// @dev Amount of assets moved from the Panoptic Pool to the AMM.
+    /// @notice Amount of assets moved from the Panoptic Pool to the AMM.
     uint128 internal s_inAMM;
 
-    /// @notice additional risk premium charged on intrinsic value of ITM positions,
+    /// @notice Additional risk premium charged on intrinsic value of ITM positions,
     /// defined in hundredths of basis points.
     /// @dev The result of the calculation is stored instead of the multiple to save gas during usage.
-    /// When the fee is set, the multiple is calculated and stored
+    /// When the fee is set, the multiple is calculated and stored.
     uint128 internal s_ITMSpreadFee;
 
-    /// @dev The fee of the Uniswap pool.
+    /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
 
     /*//////////////////////////////////////////////////////////////
                             RISK PARAMETERS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice when creating an option, collect a commission for the Panoptic LPs.
-    /// In Panoptic, options never expire, commissions are only paid when a new position is minted.
-    /// We believe that this will eliminate the impact of the commission fee on the user's decision-making process when closing a position.
+    /// @notice The commission fee, in basis points, collected from PLPs at option mint.
+    /// @dev In Panoptic, options never expire, commissions are only paid when a new position is minted.
+    /// @dev We believe that this will eliminate the impact of the commission fee on the user's decision-making process when closing a position.
     uint256 immutable COMMISSION_FEE;
 
     // base collateral ratios
+
     /// @notice Required collateral ratios for buying, represented as percentage * 10_000.
-    /// i.e 20% -> 0.2 * 10_000 = 2_000.
+    /// @dev i.e 20% -> 0.2 * 10_000 = 2_000.
     uint256 immutable SELLER_COLLATERAL_RATIO;
 
     /// @notice Required collateral ratios for selling, represented as percentage * 10_000.
-    /// i.e 10% -> 0.1 * 10_000 = 1_000.
+    /// @dev i.e 10% -> 0.1 * 10_000 = 1_000.
     uint256 immutable BUYER_COLLATERAL_RATIO;
 
-    // liquidation parameters
-    /// @notice basal cost to force exercise a position that is barely far-the-money (out-of-range).
+    // miscellaneous parameters
+
+    /// @notice Basal cost (in bps of notional) to force exercise a position that is barely far-the-money (out-of-range).
     int256 immutable FORCE_EXERCISE_COST;
 
     // Targets a pool utilization (balance between buying and selling)
     /// @notice Target pool utilization below which buying+selling is optimal, represented as percentage * 10_000.
-    /// i.e 50% -> 0.5 * 10_000 = 5_000.
+    /// @dev i.e 50% -> 0.5 * 10_000 = 5_000.
     uint256 immutable TARGET_POOL_UTIL;
 
     /// @notice Pool utilization above which selling is 100% collateral backed, represented as percentage * 10_000.
-    /// i.e 90% -> 0.9 * 10_000 = 9_000.
+    /// @dev i.e 90% -> 0.9 * 10_000 = 9_000.
     uint256 immutable SATURATED_POOL_UTIL;
 
-    /// @notice multiplier, in basis points, to the pool fee that is charged on the intrinsic value of ITM positions.
-    /// e.g. ITM_SPREAD_MULTIPLIER = 20_000, s_ITMSpreadFee = 2 * s_poolFee
+    /// @notice Multiplier, in basis points, to the pool fee that is charged on the intrinsic value of ITM positions.
+    /// @dev e.g. ITM_SPREAD_MULTIPLIER = 20_000, s_ITMSpreadFee = 2 * s_poolFee.
     uint256 immutable ITM_SPREAD_MULTIPLIER;
 
     /*//////////////////////////////////////////////////////////////
@@ -172,6 +173,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                   INITIALIZATION & PARAMETER SETTINGS
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Set immutable parameters for the Collateral Tracker.
+    /// @param _commissionFee The commission fee, in basis points, collected from PLPs at option mint.
+    /// @param _sellerCollateralRatio Required collateral ratios for buying, represented as percentage * 10_000.
+    /// @param _buyerCollateralRatio Required collateral ratios for selling, represented as percentage * 10_000.
+    /// @param _forceExerciseCost Basal cost (in bps of notional) to force exercise a position that is barely far-the-money (out-of-range).
+    /// @param _targetPoolUtilization Target pool utilization below which buying+selling is optimal, represented as percentage * 10_000.
+    /// @param _saturatedPoolUtilization Pool utilization above which selling is 100% collateral backed, represented as percentage * 10_000.
+    /// @param _ITMSpreadMultiplier Multiplier, in basis points, to the pool fee that is charged on the intrinsic value of ITM positions.
     constructor(
         uint256 _commissionFee,
         uint256 _sellerCollateralRatio,
@@ -192,12 +201,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Initialize a new collateral tracker for a specific token corresponding to the Panoptic Pool being created by the factory that called it.
     /// @dev The factory calls this function to start a new collateral tracking system for the incoming token at 'underlyingToken'.
-    /// The factory will do this for each of the two tokens being tracked. Thus, the collateral tracking system does not track *both* tokens at once.
-    /// @param underlyingIsToken0 whether this collateral tracker is for token0 (true) or token1 (false).
-    /// @param token0 token 0 of the Uniswap pool.
-    /// @param token1 token 1 of the Uniswap pool.
-    /// @param fee the fee of the Uniswap pool.
-    /// @param panopticPool the address of the Panoptic Pool being created and linked to this Collateral Tracker.
+    /// @dev The factory will do this for each of the two tokens being tracked. Thus, the collateral tracking system does not track *both* tokens at once.
+    /// @param underlyingIsToken0 whether this collateral tracker is for token0 (true) or token1 (false)
+    /// @param token0 token 0 of the Uniswap pool
+    /// @param token1 token 1 of the Uniswap pool
+    /// @param fee the fee of the Uniswap pool
+    /// @param panopticPool the address of the Panoptic Pool being created and linked to this Collateral Tracker
     function startToken(
         bool underlyingIsToken0,
         address token0,
@@ -243,13 +252,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         COLLATERAL TOKEN INFORMATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Get the Panoptic pool data.
-    /// @dev the Panoptic pool owns this collateral token. This token, in turn, keeps a reference to the Panoptic pool.
-    /// @return poolAssets cached amount of assets accounted to be held by the Panoptic Pool - ignores donations, pending fee payouts, and other untracked balance changes.
-    /// @return insideAMM the underlying token amount held in the AMM.
+    /// @notice Get information about the utilization of this collateral vault.
+    /// @return poolAssets cached amount of assets accounted to be held by the Panoptic Pool - ignores donations, pending fee payouts, and other untracked balance changes
+    /// @return insideAMM the underlying token amount held in the AMM
     /// @return currentPoolUtilization Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
-    /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets().
-    /// Where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool.
+    /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets()
+    /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
     function getPoolData()
         external
         view
@@ -261,7 +269,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Returns name of token composed of underlying token symbol and pool data.
-    /// @return name The name of the token.
+    /// @return name The name of the token
     function name() external view returns (string memory) {
         // this logic requires multiple external calls and error handling, so we do it in a delegatecall to a library to save bytecode size
         return
@@ -275,14 +283,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Returns symbol as prefixed symbol of underlying token.
-    /// @return symbol The symbol of the token.
+    /// @return symbol The symbol of the token
     function symbol() external view returns (string memory) {
         // this logic requires multiple external calls and error handling, so we do it in a delegatecall to a library to save bytecode size
         return InteractionHelper.computeSymbol(s_underlyingToken, TICKER_PREFIX);
     }
 
-    /// @notice Returns decimals of underlying token (0 if not present)
-    /// @return decimals The decimals of the token.
+    /// @notice Returns decimals of underlying token (0 if not present).
+    /// @return decimals The decimals of the token
     function decimals() external view returns (uint8) {
         // this logic requires multiple external calls and error handling, so we do it in a delegatecall to a library to save bytecode size
         return InteractionHelper.computeDecimals(s_underlyingToken);
@@ -302,7 +310,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     ) public override(ERC20Minimal) returns (bool) {
         // make sure the caller does not have any open option positions
         // if they do: we don't want them sending panoptic pool shares to others
-        // since that's like reducing collateral
+        // as this would reduce their amount of collateral against the opened positions
 
         if (s_panopticPool.numberOfPositions(msg.sender) != 0) revert Errors.PositionCountNotZero();
 
@@ -333,7 +341,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Get the token contract address of the underlying asset being managed.
-    /// @return assetTokenAddress The address of the underlying asset.
+    /// @return assetTokenAddress The address of the underlying asset
     function asset() external view returns (address assetTokenAddress) {
         return s_underlyingToken;
     }
@@ -342,7 +350,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @dev This returns the total tracked assets in the AMM and PanopticPool,
     /// @dev - EXCLUDING the amount of collected fees (because they are reserved for short options)
     /// @dev - EXCLUDING any donations that have been made to the pool
-    /// @return totalManagedAssets The total amount of assets managed.
+    /// @return totalManagedAssets The total amount of assets managed
     function totalAssets() public view returns (uint256 totalManagedAssets) {
         unchecked {
             return s_poolAssets + s_inAMM;
@@ -350,28 +358,28 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Returns the amount of shares that can be minted for the given amount of assets.
-    /// @param assets The amount of assets to be deposited.
-    /// @return shares The amount of shares that can be minted.
+    /// @param assets The amount of assets to be deposited
+    /// @return shares The amount of shares that can be minted
     function convertToShares(uint256 assets) public view returns (uint256 shares) {
         return Math.mulDiv(assets, totalSupply, totalAssets());
     }
 
     /// @notice Returns the amount of assets that can be redeemed for the given amount of shares.
-    /// @param shares The amount of shares to be redeemed.
-    /// @return assets The amount of assets that can be redeemed.
+    /// @param shares The amount of shares to be redeemed
+    /// @return assets The amount of assets that can be redeemed
     function convertToAssets(uint256 shares) public view returns (uint256 assets) {
         return Math.mulDiv(shares, totalAssets(), totalSupply);
     }
 
-    /// @notice returns The maximum deposit amount.
-    /// @return maxAssets The maximum amount of assets that can be deposited.
+    /// @notice Returns the maximum deposit amount.
+    /// @return maxAssets The maximum amount of assets that can be deposited
     function maxDeposit(address) external pure returns (uint256 maxAssets) {
         return type(uint104).max;
     }
 
     /// @notice Returns shares received for depositing given amount of assets.
-    /// @param assets The amount of assets to be deposited.
-    /// @return shares The amount of shares that can be minted.
+    /// @param assets The amount of assets to be deposited
+    /// @return shares The amount of shares that can be minted
     function previewDeposit(uint256 assets) public view returns (uint256 shares) {
         // compute the MEV tax, which is equal to a single payment of the commissionRate on the FINAL (post mev-tax) assets paid
         unchecked {
@@ -384,12 +392,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Deposit underlying tokens (assets) to the Panoptic pool from the LP and mint corresponding amount of shares.
-    /// There is a maximum asset deposit limit of (2 ** 104) - 1.
-    /// An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
+    /// @dev There is a maximum asset deposit limit of (2 ** 104) - 1.
+    /// @dev An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP ('receiver').
-    /// @param assets Amount of assets deposited.
-    /// @param receiver User to receive the shares.
-    /// @return shares The amount of Panoptic pool shares that were minted to the recipient.
+    /// @param assets Amount of assets deposited
+    /// @param receiver User to receive the shares
+    /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
 
@@ -662,12 +670,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// - 10% if the position is liquidated when the price is between 950 and 1000, or if it is between 1050 and 1100
     /// - 5% if the price is between 900 and 950 or (1100, 1150)
     /// - 2.5% if between (850, 900) or (1150, 1200)
-    /// @param currentTick The current price tick.
-    /// @param oracleTick The price oracle tick.
+    /// @param currentTick The current price tick
+    /// @param oracleTick The price oracle tick
     /// @param positionId The position to be exercised
     /// @param positionBalance The balance in `account` of the position to be exercised
-    /// @param longAmounts The amount of longs in the position.
-    /// @return exerciseFees The fees for exercising the option position.
+    /// @param longAmounts The amount of longs in the position
+    /// @return exerciseFees The fees for exercising the option position
     function exerciseCost(
         int24 currentTick,
         int24 oracleTick,
@@ -748,8 +756,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Get the pool utilization; it is a measure of the ratio of assets in the AMM vs the total assets managed by the pool.
     // With total assets being the current Panoptic pool balance + the amount in the AMM.
     /// @dev compute: inAMM/totalAssets().
-    /// @dev 1bps precision controlled by DECIMALS.
-    /// @return poolUtilization the pool utilization as a fraction.
+    /// @return poolUtilization The pool utilization in basis points
     function _poolUtilization() internal view returns (int256 poolUtilization) {
         unchecked {
             return int256((s_inAMM * DECIMALS) / totalAssets());
@@ -758,8 +765,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Get the (sell) collateral ratio that is paid when a short option is minted at a specific pool utilization.
     /// @dev This is computed at the time the position is minted.
-    /// @param utilization The fraction of totalAssets() that belongs to the Uniswap Pool.
-    /// @return sellCollateralRatio The sell collateral ratio.
+    /// @param utilization The fraction of totalAssets() that belongs to the Uniswap Pool
+    /// @return sellCollateralRatio The sell collateral ratio at `utilization`
     function _sellCollateralRatio(
         int256 utilization
     ) internal view returns (uint256 sellCollateralRatio) {
@@ -813,8 +820,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Get the (buy) collateral ratio that is paid when a long option is minted at a specific pool utilization.
     /// @dev This is computed at the time the position is minted.
-    /// @param utilization The fraction of totalBalance() that belongs to the Uniswap Pool.
-    /// @return buyCollateralRatio The buy collateral ratio.
+    /// @param utilization The fraction of totalBalance() that belongs to the Uniswap Pool
+    /// @return buyCollateralRatio The buy collateral ratio at `utilization`
     function _buyCollateralRatio(
         uint256 utilization
     ) internal view returns (uint256 buyCollateralRatio) {
@@ -870,9 +877,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Delegate and transfer shares corresponding to the incoming assets 'from' delegator 'to' delegatee.
     /// @dev This is controlled by the Panoptic Pool - not individual users.
-    /// @param delegator The delegator to send shares from - the sender of the shares.
-    /// @param delegatee The delegatee to send shares to - the recipient of the shares.
-    /// @param assets The assets to which the shares delegated correspond.
+    /// @param delegator The delegator to send shares from - the sender of the shares
+    /// @param delegatee The delegatee to send shares to - the recipient of the shares
+    /// @param assets The assets to which the shares delegated correspond
     function delegate(
         address delegator,
         address delegatee,
@@ -900,26 +907,26 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Delegate and transfer shares corresponding to the incoming assets from the protocol to `delegatee`.
     /// @dev This is controlled by the Panoptic Pool - not individual users.
-    /// @dev mints ghost shares so a position can be settled - the total supply is not affected.
-    /// @param delegatee The delegatee to send shares to - the recipient of the shares.
-    /// @param assets The assets to which the shares delegated correspond.
+    /// @dev Mints ghost shares so a position can be settled - the total supply is not affected.
+    /// @param delegatee The delegatee to send shares to - the recipient of the shares
+    /// @param assets The assets to which the shares delegated correspond
     function delegate(address delegatee, uint256 assets) external onlyPanopticPool {
         balanceOf[delegatee] += convertToShares(assets);
     }
 
-    /// @notice Refunds delegated tokens back to the protocol
-    /// @dev Assumes that `delegatee` has enough money to pay for the refund
-    /// @dev burns ghost shares after a position has been settled - the total supply is not affected.
-    /// @param delegatee The account refunding tokens to 'delegatee'.
-    /// @param assets The amount of assets to which the shares to refund to the protocol correspond.
+    /// @notice Refunds delegated tokens back to the protocol.
+    /// @dev Assumes that `delegatee` has enough money to pay for the refund.
+    /// @dev Burns ghost shares after a position has been settled - the total supply is not affected.
+    /// @param delegatee The account refunding tokens to 'delegatee'
+    /// @param assets The amount of assets to which the shares to refund to the protocol correspond
     function refund(address delegatee, uint256 assets) external onlyPanopticPool {
         balanceOf[delegatee] -= convertToShares(assets);
     }
 
     /// @notice Revoke previously delegated shares. The opposite of 'delegate'.
-    /// @param delegator The delegator to send shares *to* (because we are revoking - opposite when we delegate).
-    /// @param delegatee The delegatee to send shares *from* (because we are revoking - opposite when we delegate).
-    /// @param assets The assets to which the shares revoked correspond.
+    /// @param delegator The delegator to send shares *to* (because we are revoking - opposite when we delegate)
+    /// @param delegatee The delegatee to send shares *from* (because we are revoking - opposite when we delegate)
+    /// @param assets The assets to which the shares revoked correspond
     function revoke(
         address delegator,
         address delegatee,
@@ -978,12 +985,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         }
     }
 
-    /// @notice Refunds delegated tokens to 'refunder' from 'refundee', similar to 'revoke'
-    /// @dev Assumes that the refunder has enough money to pay for the refund
-    /// @dev can handle negative refund amounts that go from refundee to refunder in the case of high exercise fees.
-    /// @param refunder The account refunding tokens to 'refundee'.
-    /// @param refundee The account being refunded to.
-    /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative.
+    /// @notice Refunds delegated tokens to 'refunder' from 'refundee', similar to 'revoke'.
+    /// @dev Assumes that the refunder has enough money to pay for the refund.
+    /// @dev Can handle negative refund amounts that go from refundee to refunder in the case of high exercise fees.
+    /// @param refunder The account refunding tokens to 'refundee'
+    /// @param refundee The account being refunded to
+    /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative
     function refund(address refunder, address refundee, int256 assets) external onlyPanopticPool {
         if (assets > 0) {
             _transferFrom(refunder, refundee, convertToShares(uint256(assets)));
@@ -999,11 +1006,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Take commission on option creation/opening (commissions will not be taken on closing).
-    /// @param optionOwner The user minting the option.
-    /// @param longAmount The amount of longs.
-    /// @param shortAmount The amount of shorts.
-    /// @param swappedAmount The amount of tokens swapped during creation of the option position (non-zero for options minted ITM).
-    /// @return utilization The utilization of the Panoptic Pool.
+    /// @param optionOwner The user minting the option
+    /// @param longAmount The amount of longs
+    /// @param shortAmount The amount of shorts
+    /// @param swappedAmount The amount of tokens moved during creation of the option position
+    /// @return utilization The final utilization of the collateral vault
     function takeCommissionAddData(
         address optionOwner,
         int128 longAmount,
@@ -1046,12 +1053,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Exercise an option and pay to the seller what is owed from the buyer.
     /// @dev Called when a position is burnt because it may need to be exercised.
-    /// @param optionOwner The owner of the option being burned and potentially exercised.
-    /// @param longAmount The amount of longs to be exercised (if any).
-    /// @param shortAmount The amount of shorts to be exercised (if any).
-    /// @param swappedAmount The amount of tokens potentially swapped.
-    /// @param realizedPremium Premium to settle on the current positions.
-    /// @return paidAmount The amount of tokens paid when closing that position.
+    /// @param optionOwner The owner of the option being burned and potentially exercised
+    /// @param longAmount The amount of longs to be exercised (if any)
+    /// @param shortAmount The amount of shorts to be exercised (if any)
+    /// @param swappedAmount The amount of tokens moved during the option close
+    /// @param realizedPremium Premium to settle on the current positions
+    /// @return paidAmount The amount of tokens paid when closing that position
     function exercise(
         address optionOwner,
         int128 longAmount,
@@ -1091,10 +1098,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Get the amount exchanged to mint an option.
-    /// @param longAmount The amount of long options held.
-    /// @param shortAmount The amount of short options held.
-    /// @param swappedAmount The (potential) amount swapped during any ITM option creations.
-    /// @return exchangedAmount The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value).
+    /// @param longAmount The amount of long options held
+    /// @param shortAmount The amount of short options held
+    /// @param swappedAmount The amount of tokens moved during creation of the option position
+    /// @return exchangedAmount The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
     function _getExchangedAmount(
         int128 longAmount,
         int128 shortAmount,
@@ -1132,13 +1139,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Get the collateral status/margin details of an account/user.
-    /// NOTE: It's up to the caller to confirm from the returned result that the account has enough collateral.
+    /// @dev NOTE: It's up to the caller to confirm from the returned result that the account has enough collateral.
     /// @dev This can be used to check the health: how many tokens a user has compared to the margin threshold.
-    /// @param user The account to check collateral/margin health for.
-    /// @param currentTick The current AMM price tick.
-    /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...].
-    /// @param premiumAllPositions The premium collected thus far across all positions.
-    /// @return tokenData Information collected for the tokens about the health of the account.
+    /// @param user The account to check collateral/margin health for
+    /// @param currentTick The tick at which to evaluate the account's positions
+    /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...]
+    /// @param premiumAllPositions The premium collected thus far across all positions
+    /// @return tokenData Information collected for the tokens about the health of the account
     /// The collateral balance of the user is in the right slot and the threshold for margin call is in the left slot.
     function getAccountMarginDetails(
         address user,
@@ -1150,14 +1157,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Get the collateral status/margin details of an account/user.
-    /// NOTE: It's up to the caller to confirm from the returned result that the account has enough collateral.
+    /// @dev NOTE: It's up to the caller to confirm from the returned result that the account has enough collateral.
     /// @dev This can be used to check the health: how many tokens a user has compared to the margin threshold.
-    /// @param user the account to check collateral/margin health for.
-    /// @param atTick tick to convert values at. This can be the current tick or the Uniswap pool TWAP tick.
-    /// @param positionBalanceArray the list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...].
-    /// @param premiumAllPositions the premium collected thus far across all positions.
-    /// @return tokenData information collected for the tokens about the health of the account.
-    /// The collateral balance of the user is in the right slot and the threshold for margin call is in the left slot.
+    /// @param user The account to check collateral/margin health for.
+    /// @param atTick The tick at which to evaluate the account's positions
+    /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...]
+    /// @param premiumAllPositions The premium collected thus far across all positions
+    /// @return tokenData Information collected for the tokens about the health of the account;
+    /// the collateral balance of the user is in the right slot and the threshold for margin call is in the left slot
     function _getAccountMargin(
         address user,
         int24 atTick,
@@ -1196,9 +1203,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Get the total required amount of collateral tokens of a user/account across all active positions to stay above the margin requirement.
     /// @dev Returns the token amounts required for the entire account with active positions in 'positionIdList' (list of tokenIds).
-    /// @param atTick Tick to convert values at. This can be the current tick or the Uniswap pool TWAP tick.
-    /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...].
-    /// @return tokenRequired The amount of tokens required to stay above the margin threshold for all active positions of user.
+    /// @param atTick The tick at which to evaluate the account's positions
+    /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...]
+    /// @return tokenRequired The amount of tokens required to stay above the margin threshold for all active positions of user
     function _getTotalRequiredCollateral(
         int24 atTick,
         uint256[2][] memory positionBalanceArray
@@ -1239,11 +1246,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Get the required amount of collateral tokens corresponding to a specific single position 'tokenId' at a price 'tick'.
     /// The required collateral of an account depends on the price ('tick') in the AMM pool: if in the position's favor less collateral needed, etc.
-    /// @param tokenId The option position.
-    /// @param positionSize The size of the option position.
-    /// @param atTick Tick to convert values at. This can be the current tick or the Uniswap pool TWAP tick.
-    /// @param poolUtilization The utilization of the Panoptic pool (balance of buying and selling).
-    /// @return tokenRequired total required tokens for all legs of the specified tokenId.
+    /// @param tokenId The option position
+    /// @param positionSize The size of the option position
+    /// @param atTick The tick at which to evaluate the account's positions
+    /// @param poolUtilization The utilization of the collateral vault (balance of buying and selling)
+    /// @return tokenRequired Total required tokens for all legs of the specified tokenId.
     function _getRequiredCollateralAtTickSinglePosition(
         TokenId tokenId,
         uint128 positionSize,
@@ -1269,14 +1276,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         }
     }
 
-    /// @notice Calculate the required amount of collateral for a single leg 'index' of position 'tokenId' when the leg does not have a risk partner.
-    /// @dev Also called "undefined risk."
-    /// @param tokenId The option position.
-    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for.
-    /// @param positionSize The size of the position.
-    /// @param atTick Tick to convert values at. This can be the current tick or the Uniswap pool TWAP tick.
-    /// @param poolUtilization The pool utilization: how much funds are in the Panoptic pool versus the AMM pool.
-    /// @return required The required amount collateral needed for this leg 'index'.
+    /// @notice Calculate the required amount of collateral for a single leg 'index' of position 'tokenId'.
+    /// @param tokenId The option position
+    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for
+    /// @param positionSize The size of the position
+    /// @param atTick The tick at which to evaluate the account's positions
+    /// @param poolUtilization The pool utilization: how much funds are in the Panoptic pool versus the AMM pool
+    /// @return required The required amount collateral needed for this leg 'index'
     function _getRequiredCollateralSingleLeg(
         TokenId tokenId,
         uint256 index,
@@ -1303,13 +1309,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Calculate the required amount of collateral for leg 'index' of position 'tokenId' when the leg does not have a risk partner.
-    /// @dev Also called "defined risk."
-    /// @param tokenId The option position.
-    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for.
-    /// @param positionSize The size of the position.
-    /// @param atTick Tick to convert values at. This can be the current tick or the Uniswap pool TWAP tick.
-    /// @param poolUtilization The pool utilization: ratio of how much funds are in the Panoptic pool versus the AMM pool.
-    /// @return required The required amount collateral needed for this leg 'index'.
+    /// @param tokenId The option position
+    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for
+    /// @param positionSize The size of the position
+    /// @param atTick The tick at which to evaluate the account's positions
+    /// @param poolUtilization The pool utilization: ratio of how much funds are in the Panoptic pool versus the AMM pool
+    /// @return required The required amount collateral needed for this leg 'index'
     function _getRequiredCollateralSingleLegNoPartner(
         TokenId tokenId,
         uint256 index,
@@ -1376,7 +1381,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         ((atTick < tickLower) && (tokenType == 1)) || // strike ITM but out of range price < lowerTick for tokenType=1
                         ((atTick >= tickUpper) && (tokenType == 0)) // strike ITM but out of range when price >= upperTick for tokenType=0
                     ) {
-                        /**
+                        /*
                                     Short put BPR = 100% - (price/strike) + SCR
 
                            BUYING
@@ -1424,20 +1429,19 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Calculate the required amount of collateral for leg 'index' for position 'tokenId' accounting for its partner leg.
-    /// @notice If the two token long-types are different (one is a long, the other a short, e.g.) but the tokenTypes are the same, this is a spread
+    /// @dev If the two token long-types are different (one is a long, the other a short, e.g.) but the tokenTypes are the same, this is a spread
     /// a spread is a defined risk position which has a max loss given by difference between the long and short strikes.
-    /// @notice If the two token long-types are the same but the tokenTypes are different (one is a call, the other a put, e.g.), this is a strangle -
+    /// @dev If the two token long-types are the same but the tokenTypes are different (one is a call, the other a put, e.g.), this is a strangle -
     /// a strangle benefits from enhanced capital efficiency because only one side can be ITM at a time.
     /// @dev if the position is a spread, then the collateral requirement consists of two components:
-    ///   1) The difference in notional value at both strikes: abs(strikeLong - strikeShort) or abs(strikeShort - strikeLong)
-    ///   2) A spread term which is relevant for legs that have different widths (calendar spreads)
-    /// @dev If a position is a strangle, only one leg can be tested at a time which allows us to increase the capital efficiency.
-    /// @param tokenId the option position
-    /// @param index the leg index (associated with a liquidity chunk) to consider a partner for
-    /// @param positionSize the size of the position
-    /// @param atTick tick to convert values at. This can be the current tick or the Uniswap pool TWAP tick.
-    /// @param poolUtilization the pool utilization: how much funds are in the Panoptic pool versus the AMM pool.
-    /// @return required the required amount collateral needed for this leg 'index', accounting for what the leg's risk partner is.
+    /// @dev 1) The difference in notional value at both strikes: abs(strikeLong - strikeShort) or abs(strikeShort - strikeLong)
+    /// @dev 2) A spread term which is relevant for legs that have different widths (calendar spreads)
+    /// @param tokenId The option position
+    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for
+    /// @param positionSize The size of the position
+    /// @param atTick The tick at which to evaluate the account's positions
+    /// @param poolUtilization The pool utilization: how much funds are in the Panoptic pool versus the AMM pool
+    /// @return required The required amount collateral needed for this leg 'index', accounting for what the leg's risk partner is
     function _getRequiredCollateralSingleLegPartner(
         TokenId tokenId,
         uint256 index,
@@ -1467,11 +1471,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Get the base collateral requirement for an 'amount' at the current Panoptic pool 'utilization' level.
     /// @notice For a given incoming 'amount' - which is the size of a user position (e.g. opening a position), what is the corresponding required collateral to have.
-    /// @dev NOTE this does not depend on the price of the AMM pool. This only computes what is needed in response to the current utilization.
-    /// @param amount The amount from which required collateral is computed.
-    /// @param isLong Whether the position is long (=1) or short (=0).
-    /// @param utilization The utilization of the Panoptic pool (balance between sellers and buyers).
-    /// @return required The required collateral corresponding to the incoming 'amount'.
+    /// @dev NOTE: this does not depend on the price of the AMM pool. This only computes what is needed in response to the current utilization.
+    /// @param amount The amount from which required collateral is computed
+    /// @param isLong Whether the position is long (=1) or short (=0)
+    /// @param utilization The utilization of the Panoptic pool (balance between sellers and buyers)
+    /// @return required The required collateral corresponding to the incoming 'amount'
     function _getRequiredCollateralAtUtilization(
         uint128 amount,
         uint256 isLong,
@@ -1501,14 +1505,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Calculate the required amount of collateral for the spread portion of the spread position.
-    /// @dev long leg requirement + 100% collateralized risk
-    /// @dev may be higher than the requirement of non risk-partnered legs if the spread is very wide (risky)
-    /// @param tokenId the option position.
-    /// @param positionSize the size of the position.
-    /// @param index the leg index of the LONG leg in the spread position.
-    /// @param partnerIndex the index of the partnered SHORT leg in the spread position.
-    /// @param poolUtilization the pool utilization: how much funds are in the Panoptic pool versus the AMM pool.
-    /// @return spreadRequirement the required amount of collateral needed for the spread portion.
+    /// @dev (long leg requirement + 100% collateralized risk)
+    /// @dev May be higher than the requirement of non risk-partnered legs if the spread is very wide (risky).
+    /// @param tokenId The option position
+    /// @param positionSize The size of the position
+    /// @param index The leg index of the LONG leg in the spread position
+    /// @param partnerIndex The index of the partnered SHORT leg in the spread position
+    /// @param poolUtilization The pool utilization: how much funds are in the Panoptic pool versus the AMM pool
+    /// @return spreadRequirement The required amount of collateral needed for the spread portion
     function _computeSpread(
         TokenId tokenId,
         uint128 positionSize,
@@ -1591,14 +1595,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Calculate the required amount of collateral for a strangle leg.
-    /// Strangle legs are evaluated at 2x capital efficiency at low pool utilizations.
+    /// @dev Strangle legs are evaluated at 2x capital efficiency at low pool utilizations.
     /// @dev A strangle can only have only one of its leg tested at the same time, so this reduces the total risk and collateral requirement.
-    /// @param tokenId The option position.
-    /// @param positionSize The size of the position.
-    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for.
-    /// @param atTick Tick to convert values at. This can be the current tick or the Uniswap pool TWAP tick.
-    /// @param poolUtilization The pool utilization: how much funds are in the Panoptic pool versus the AMM pool.
-    /// @return strangleRequired The required amount of collateral needed for the strangle leg.
+    /// @param tokenId The option position
+    /// @param positionSize The size of the position
+    /// @param index The leg index (associated with a liquidity chunk) to consider a partner for
+    /// @param atTick The tick at which to evaluate the account's positions
+    /// @param poolUtilization The pool utilization: how much funds are in the Panoptic pool versus the AMM pool
+    /// @return strangleRequired The required amount of collateral needed for the strangle leg
     function _computeStrangle(
         TokenId tokenId,
         uint256 index,

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -269,7 +269,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Returns name of token composed of underlying token symbol and pool data.
-    /// @return name The name of the token
+    /// @return The name of the token
     function name() external view returns (string memory) {
         // this logic requires multiple external calls and error handling, so we do it in a delegatecall to a library to save bytecode size
         return
@@ -283,14 +283,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Returns symbol as prefixed symbol of underlying token.
-    /// @return symbol The symbol of the token
+    /// @return The symbol of the token
     function symbol() external view returns (string memory) {
         // this logic requires multiple external calls and error handling, so we do it in a delegatecall to a library to save bytecode size
         return InteractionHelper.computeSymbol(s_underlyingToken, TICKER_PREFIX);
     }
 
     /// @notice Returns decimals of underlying token (0 if not present).
-    /// @return decimals The decimals of the token
+    /// @return The decimals of the token
     function decimals() external view returns (uint8) {
         // this logic requires multiple external calls and error handling, so we do it in a delegatecall to a library to save bytecode size
         return InteractionHelper.computeDecimals(s_underlyingToken);
@@ -731,7 +731,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 }
 
                 // compensate user for loss in value if chunk has lost money between current and median tick
-                // note: the delta for one token will be positive and the other will be negative. This cancels out any moves in their positions
+                // NOTE: the delta for one token will be positive and the other will be negative. This cancels out any moves in their positions
                 exerciseFees = exerciseFees.sub(
                     LeftRightSigned
                         .wrap(0)
@@ -740,7 +740,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 );
             }
 
-            // note: we HAVE to start with a negative number as the base exercise cost because when shifting a negative number right by n bits,
+            // NOTE: we HAVE to start with a negative number as the base exercise cost because when shifting a negative number right by n bits,
             // the result is rounded DOWN and NOT toward zero
             // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
             // subtract 1 from max half ranges from strike so fee starts at FORCE_EXERCISE_COST when moving OTM
@@ -1058,7 +1058,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param shortAmount The amount of shorts to be exercised (if any)
     /// @param swappedAmount The amount of tokens moved during the option close
     /// @param realizedPremium Premium to settle on the current positions
-    /// @return paidAmount The amount of tokens paid when closing that position
+    /// @return The amount of tokens paid when closing that position
     function exercise(
         address optionOwner,
         int128 longAmount,

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -56,19 +56,19 @@ contract PanopticFactory is FactoryNFT, Multicall {
                          CONSTANTS & IMMUTABLE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice The Uniswap V3 factory contract to use
+    /// @notice The Uniswap V3 factory contract to use.
     IUniswapV3Factory internal immutable UNIV3_FACTORY;
 
-    /// @notice The Semi Fungible Position Manager (SFPM) which tracks option positions across Panoptic Pools
+    /// @notice The Semi Fungible Position Manager (SFPM) which tracks option positions across Panoptic Pools.
     SemiFungiblePositionManager internal immutable SFPM;
 
-    /// @notice Reference implementation of the `PanopticPool` to clone
+    /// @notice Reference implementation of the `PanopticPool` to clone.
     address internal immutable POOL_REFERENCE;
 
-    /// @notice Reference implementation of the `CollateralTracker` to clone
+    /// @notice Reference implementation of the `CollateralTracker` to clone.
     address internal immutable COLLATERAL_REFERENCE;
 
-    /// @notice Address of the Wrapped Ether (or other numeraire token) contract
+    /// @notice Address of the Wrapped Ether (or other numeraire token) contract.
     address internal immutable WETH;
 
     /// @notice An amount of `WETH` deployed when initializing the SFPM against a new AMM pool.
@@ -79,14 +79,14 @@ contract PanopticFactory is FactoryNFT, Multicall {
     /// @dev Deploy 1e6 worth of tokens if not WETH.
     uint256 internal constant FULL_RANGE_LIQUIDITY_AMOUNT_TOKEN = 1e6;
 
-    /// @notice The `observationCardinalityNext` to set on the Uniswap pool when a new PanopticPool is deployed
+    /// @notice The `observationCardinalityNext` to set on the Uniswap pool when a new PanopticPool is deployed.
     uint16 internal constant CARDINALITY_INCREASE = 100;
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Mapping from address(UniswapV3Pool) to address(PanopticPool) that stores the address of all deployed Panoptic Pools
+    /// @notice Mapping from address(UniswapV3Pool) to address(PanopticPool) that stores the address of all deployed Panoptic Pools.
     mapping(IUniswapV3Pool univ3pool => PanopticPool panopticPool) internal s_getPanopticPool;
 
     /*//////////////////////////////////////////////////////////////
@@ -114,7 +114,6 @@ contract PanopticFactory is FactoryNFT, Multicall {
     ) FactoryNFT(properties, indices, pointers) {
         WETH = _WETH9;
         SFPM = _SFPM;
-        // We store the Uniswap Factory contract - later we can use this to verify uniswap pools
         UNIV3_FACTORY = _univ3Factory;
         POOL_REFERENCE = _poolReference;
         COLLATERAL_REFERENCE = _collateralReference;
@@ -159,10 +158,9 @@ contract PanopticFactory is FactoryNFT, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Create a new Panoptic Pool linked to the given Uniswap pool identified uniquely by the incoming parameters.
-    /// @dev Pool deployment is restricted to the factory owner until transferred to the zero address.
     /// @dev There is a 1:1 mapping between a Panoptic Pool and a Uniswap Pool.
     /// @dev A Uniswap pool is uniquely identified by its tokens and the fee.
-    /// @dev Salt used in PanopticPool CREATE2 is [leading 20 msg.sender chars][leading 20 pool address chars][salt]
+    /// @dev Salt used in PanopticPool CREATE2 is [leading 20 msg.sender chars][leading 20 pool address chars][salt].
     /// @param token0 Address of token0 for the underlying Uniswap v3 pool
     /// @param token1 Address of token1 for the underlying Uniswap v3 pool
     /// @param fee The fee tier of the underlying Uniswap v3 pool, denominated in hundredths of bips
@@ -252,8 +250,8 @@ contract PanopticFactory is FactoryNFT, Multicall {
     /// @notice Find the salt which would give a Panoptic Pool the highest rarity within the search parameters.
     /// @dev The rarity is defined in terms of how many leading zeros the Panoptic pool address has.
     /// @dev Note that the final salt may overflow if too many loops are given relative to the amount in `salt`.
-    /// @param deployerAddress address of the account that deploys the new PanopticPool
-    /// @param v3Pool address of the underlying UniswapV3Pool
+    /// @param deployerAddress Address of the account that deploys the new PanopticPool
+    /// @param v3Pool Address of the underlying UniswapV3Pool
     /// @param salt Salt value ([96-bit nonce]) to start from, useful as a checkpoint across multiple calls
     /// @param loops The number of mining operations starting from 'salt' in trying to find the highest rarity
     /// @param minTargetRarity The minimum target rarity to mine for. The internal loop stops when this is reached *or* when no more iterations
@@ -398,7 +396,7 @@ contract PanopticFactory is FactoryNFT, Multicall {
 
     /// @notice Return the address of the Panoptic Pool associated with 'univ3pool'.
     /// @param univ3pool The Uniswap V3 pool address to query
-    /// @return Address of the Panoptic Pool associated with 'univ3pool'.
+    /// @return Address of the Panoptic Pool associated with 'univ3pool'
     function getPanopticPool(IUniswapV3Pool univ3pool) external view returns (PanopticPool) {
         return s_getPanopticPool[univ3pool];
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -20,10 +20,9 @@ import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
 
-/// @title The Panoptic Pool: Create permissionless options on top of a concentrated liquidity AMM like Uniswap v3.
+/// @title The Panoptic Pool: Create permissionless options on a CLAMM.
 /// @author Axicon Labs Limited
 /// @notice Manages positions, collateral, liquidations and forced exercises.
-/// @dev All liquidity deployed to/from the AMM is owned by this smart contract.
 contract PanopticPool is ERC1155Holder, Multicall {
     /*//////////////////////////////////////////////////////////////
                                 EVENTS
@@ -31,10 +30,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
     /// @notice Emitted when an account is liquidated.
     /// @dev Need to unpack bonusAmounts to get raw numbers, which are always positive.
-    /// @param liquidator Address of the caller whom is liquidating the distressed account.
-    /// @param liquidatee Address of the distressed/liquidatable account.
-    /// @param bonusAmounts LeftRight encoding for the the bonus paid for token 0 (right slot) and 1 (left slot) from the Panoptic Pool to the liquidator.
-    /// The token0 bonus is in the right slot, and token1 bonus is in the left slot.
+    /// @param liquidator Address of the caller liquidating the distressed account
+    /// @param liquidatee Address of the distressed/liquidatable account
+    /// @param bonusAmounts LeftRight encoding for the the bonus paid for token 0 (right slot) and 1 (left slot) from the Panoptic Pool to the liquidator
     event AccountLiquidated(
         address indexed liquidator,
         address indexed liquidatee,
@@ -42,12 +40,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
     );
 
     /// @notice Emitted when a position is force exercised.
-    /// @dev Need to unpack exerciseFee to get raw numbers, represented as a negative value (fee debited).
-    /// @param exercisor Address of the account that forces the exercise of the position.
+    /// @param exercisor Address of the account that forces the exercise of the position
     /// @param user Address of the owner of the liquidated position
-    /// @param tokenId TokenId of the liquidated position.
-    /// @param exerciseFee LeftRight encoding for the cost paid by the exercisor to force the exercise of the token.
-    /// The token0 fee is in the right slot, and token1 fee is in the left slot.
+    /// @param tokenId TokenId of the liquidated position
+    /// @param exerciseFee LeftRight encoding for the cost paid by the exercisor to force the exercise of the token;
+    /// the cost for token 0 (right slot) and 1 (left slot) is represented as negative
     event ForcedExercised(
         address indexed exercisor,
         address indexed user,
@@ -55,10 +52,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightSigned exerciseFee
     );
 
-    /// @notice Emitted when premium is settled independent of a mint/burn (e.g. during `settleLongPremium`)
-    /// @param user Address of the owner of the settled position.
-    /// @param tokenId TokenId of the settled position.
-    /// @param settledAmounts LeftRight encoding for the amount of premium settled for token0 (right slot) and token1 (left slot).
+    /// @notice Emitted when premium is settled independent of a mint/burn (e.g. during `settleLongPremium`).
+    /// @param user Address of the owner of the settled position
+    /// @param tokenId TokenId of the settled position
+    /// @param settledAmounts LeftRight encoding for the amount of premium settled for token0 (right slot) and token1 (left slot)
     event PremiumSettled(
         address indexed user,
         TokenId indexed tokenId,
@@ -66,12 +63,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
     );
 
     /// @notice Emitted when an option is burned.
-    /// @dev Is not emitted when a position is liquidated or force exercised.
-    /// @param recipient User that burnt the option.
-    /// @param positionSize The number of contracts burnt, expressed in terms of the asset.
-    /// @param tokenId TokenId of the burnt option.
-    /// @param premia LeftRight packing for the amount of premia collected for token0 and token1.
-    /// The token0 premia is in the right slot, and token1 premia is in the left slot.
+    /// @param recipient User that burnt the option
+    /// @param positionSize The number of contracts burnt, expressed in terms of the asset
+    /// @param tokenId TokenId of the burnt option
+    /// @param premia LeftRight packing for the amount of premia collected for token0 (right) and token1 (left)
     event OptionBurnt(
         address indexed recipient,
         uint128 positionSize,
@@ -80,13 +75,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     );
 
     /// @notice Emitted when an option is minted.
-    /// @dev Cannot add liquidity to an existing position
-    /// @param recipient User that minted the option.
-    /// @param positionSize The number of contracts minted, expressed in terms of the asset.
-    /// @param tokenId TokenId of the created option.
+    /// @param recipient User that minted the option
+    /// @param positionSize The number of contracts minted, expressed in terms of the asset
+    /// @param tokenId TokenId of the created option
     /// @param poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
-    /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets().
-    /// Where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool.
+    /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets()
+    /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
     event OptionMinted(
         address indexed recipient,
         uint128 positionSize,
@@ -98,104 +92,101 @@ contract PanopticPool is ERC1155Holder, Multicall {
                          IMMUTABLES & CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
-    // specifies what the MIN/MAX slippage ticks are:
+    /// @notice Lower price bound used when no slippage check is required.
     int24 internal constant MIN_SWAP_TICK = Constants.MIN_V3POOL_TICK - 1;
+
+    /// @notice Upper price bound used when no slippage check is required.
     int24 internal constant MAX_SWAP_TICK = Constants.MAX_V3POOL_TICK + 1;
 
-    // Flags used as arguments to premia caluculation functions
-    /// @dev 'COMPUTE_ALL_PREMIA' calculates premia for all legs of a position
+    /// @notice Flag that signals to compute premia for both the short and long legs of a position.
     bool internal constant COMPUTE_ALL_PREMIA = true;
-    /// @dev 'COMPUTE_LONG_PREMIA' calculates premia for only the long legs of a position
+    /// @notice Flag that signals to compute premia only for the long legs of a position.
     bool internal constant COMPUTE_LONG_PREMIA = false;
 
-    /// @dev Only include the share of (settled) premium that is available to collect when calling `_calculateAccumulatedPremia`
+    /// @notice Flag that indicates only to include the share of (settled) premium that is available to collect when calling `_calculateAccumulatedPremia`.
     bool internal constant ONLY_AVAILABLE_PREMIUM = false;
 
-    /// @dev Flag on the function `updateSettlementPostBurn`
-    /// @dev 'COMMIT_LONG_SETTLED' commits both collected Uniswap fees and settled long premium to `s_settledTokens`
-    /// @dev 'DONOT_COMMIT_LONG__SETTLED' only commits collected Uniswap fees to `s_settledTokens`
+    /// @notice Flag that signals to commit both collected Uniswap fees and settled long premium to `s_settledTokens`.
     bool internal constant COMMIT_LONG_SETTLED = true;
+    /// @notice Flag that signals to only commit collected Uniswap fees to `s_settledTokens`.
     bool internal constant DONOT_COMMIT_LONG_SETTLED = false;
 
-    /// @dev Boolean flag to determine wether a position is added (true) or not (!ADD = false)
+    /// @notice Flag that signals to add a new position to the user's positions hash (as opposed to removing an existing position).
     bool internal constant ADD = true;
 
-    /// @dev The window to calculate the TWAP used for solvency checks
-    /// Currently calculated by dividing this value into 20 periods, averaging them together, then taking the median
-    /// May be configurable on a pool-by-pool basis in the future, but hardcoded for now
+    /// @notice The minimum window (in seconds) used to calculate the TWAP price for solvency checks during liquidations.
     uint32 internal constant TWAP_WINDOW = 600;
 
-    // If false, an 8-slot internal median array is used to compute the "slow" oracle price
-    // This oracle is updated with the last Uniswap observation during `mintOptions` if MEDIAN_PERIOD has elapsed past the last observation
-    // If true, the "slow" oracle price is instead computed on-the-fly from 8 Uniswap observations (spaced 5 observations apart) irrespective of the frequency of `mintOptions` calls
+    /// @notice Parameter that determines which oracle type to use for the "slow" oracle price on non-liquidation solvency checks.
+    /// @dev If false, an 8-slot internal median array is used to compute the "slow" oracle price.
+    /// @dev This oracle is updated with the last Uniswap observation during `mintOptions` if MEDIAN_PERIOD has elapsed past the last observation.
+    /// @dev If true, the "slow" oracle price is instead computed on-the-fly from 8 Uniswap observations (spaced 5 observations apart) irrespective of the frequency of `mintOptions` calls.
     bool internal constant SLOW_ORACLE_UNISWAP_MODE = false;
 
-    // The minimum amount of time, in seconds, permitted between internal TWAP updates.
+    /// @notice The minimum amount of time, in seconds, permitted between internal TWAP updates.
     uint256 internal constant MEDIAN_PERIOD = 60;
 
-    /// @dev Amount of Uniswap observations to take in computing the "fast" oracle price
+    /// @notice Amount of Uniswap observations to include in the "fast" oracle price.
     uint256 internal constant FAST_ORACLE_CARDINALITY = 3;
 
-    /// @dev Amount of observation indices to skip in between each observation for the "fast" oracle price
-    /// Note that the *minimum* total observation time is determined by the blocktime and may need to be adjusted by chain
-    /// Uniswap observations snapshot the last block's closing price at the first interaction with the pool in a block
-    /// In this case, if there is an interaction every block, the "fast" oracle can consider 3 consecutive block end prices (min=36 seconds on Ethereum)
+    /// @dev Amount of observation indices to skip in between each observation for the "fast" oracle price.
+    /// @dev Note that the *minimum* total observation time is determined by the blocktime and may need to be adjusted by chain.
+    /// @dev Uniswap observations snapshot the last block's closing price at the first interaction with the pool in a block.
+    /// @dev In this case, if there is an interaction every block, the "fast" oracle can consider 3 consecutive block end prices (min=36 seconds on Ethereum).
     uint256 internal constant FAST_ORACLE_PERIOD = 1;
 
-    /// @dev Amount of Uniswap observations to take in computing the "slow" oracle price (in Uniswap mode)
+    /// @notice Amount of Uniswap observations to include in the "slow" oracle price (in Uniswap mode).
     uint256 internal constant SLOW_ORACLE_CARDINALITY = 8;
 
-    /// @dev Amount of observation indices to skip in between each observation for the "slow" oracle price
-    /// @dev Structured such that the minimum total observation time is 8 minutes on Ethereum (similar to internal median mode)
+    /// @notice Amount of observation indices to skip in between each observation for the "slow" oracle price.
+    /// @dev Structured such that the minimum total observation time is 8 minutes on Ethereum (similar to internal median mode).
     uint256 internal constant SLOW_ORACLE_PERIOD = 5;
 
-    // The maximum allowed delta between the currentTick and the Uniswap TWAP tick during a liquidation (~5% down, ~5.26% up)
-    // Prevents manipulation of the currentTick to liquidate positions at a less favorable price
+    /// @notice The maximum allowed delta between the currentTick and the Uniswap TWAP tick during a liquidation (~5% down, ~5.26% up).
+    /// @dev Mitigates manipulation of the currentTick that causes positions to be liquidated at a less favorable price.
     int256 internal constant MAX_TWAP_DELTA_LIQUIDATION = 513;
 
-    /// The maximum allowed delta between the fast and slow oracle ticks
-    /// Falls back on the more conservative (less solvent) tick during times of extreme volatility (to ensure the account is always solvent)
+    /// @notice The maximum allowed delta between the fast and slow oracle ticks before solvency is evaluated at the slow oracle tick.
+    /// @dev Falls back on the more conservative (less solvent) tick during times of extreme volatility.
     int256 internal constant MAX_SLOW_FAST_DELTA = 1800;
 
-    /// @dev The maximum allowed ratio for a single chunk, defined as: removedLiquidity / netLiquidity
-    /// The long premium spread multiplier that corresponds with the MAX_SPREAD value depends on VEGOID,
-    /// which can be explored in this calculator: https://www.desmos.com/calculator/mdeqob2m04
+    /// @notice The maximum allowed ratio for a single chunk, defined as: removedLiquidity / netLiquidity.
+    /// @dev The long premium spread multiplier that corresponds with the MAX_SPREAD value depends on VEGOID,
+    /// which can be explored in this calculator: https://www.desmos.com/calculator/mdeqob2m04.
     uint64 internal constant MAX_SPREAD = 9 * (2 ** 32);
 
-    /// @dev The maximum allowed number of opened positions
+    /// @notice The maximum allowed number of opened positions for a user.
     uint64 internal constant MAX_POSITIONS = 32;
 
-    // multiplier (x10k) for the collateral requirement in the event of a buying power decrease, such as minting or force exercising
+    /// @notice Multiplier in basis points for the collateral requirement in the event of a buying power decrease, such as minting or force exercising another user.
     uint256 internal constant BP_DECREASE_BUFFER = 13_333;
 
-    // multiplier (x10k) for the collateral requirement in the general case
+    /// @notice Multiplier for the collateral requirement in the general case.
     uint256 internal constant NO_BUFFER = 10_000;
 
-    // Panoptic ecosystem contracts - addresses are set in the constructor
-
-    /// @notice The "engine" of Panoptic - manages AMM liquidity and executes all mints/burns/exercises
+    /// @notice The "engine" of Panoptic - manages AMM liquidity and executes all mints/burns/exercises.
     SemiFungiblePositionManager internal immutable SFPM;
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE 
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev The Uniswap v3 pool that this instance of Panoptic is deployed on
+    /// @notice The Uniswap v3 pool that this instance of Panoptic is deployed on.
     IUniswapV3Pool internal s_univ3pool;
 
-    /// @notice Mini-median storage slot
-    /// @dev The data for the last 8 interactions is stored as such:
-    /// LAST UPDATED BLOCK TIMESTAMP (40 bits)
-    /// [BLOCK.TIMESTAMP]
+    /// @notice Stores a sorted set of 8 price observations used to compute the internal median oracle price.
+    // The data for the last 8 interactions is stored as such:
+    // LAST UPDATED BLOCK TIMESTAMP (40 bits)
+    // [BLOCK.TIMESTAMP]
     // (00000000000000000000000000000000) // dynamic
     //
-    /// @dev ORDERING of tick indices least --> greatest (24 bits)
-    /// The value of the bit codon ([#]) is a pointer to a tick index in the tick array.
-    /// The position of the bit codon from most to least significant is the ordering of the
-    /// tick index it points to from least to greatest.
+    // ORDERING of tick indices least --> greatest (24 bits)
+    // The value of the bit codon ([#]) is a pointer to a tick index in the tick array.
+    // The position of the bit codon from most to least significant is the ordering of the
+    // tick index it points to from least to greatest.
     //
-    /// @dev [7] [5] [3] [1] [0] [2] [4] [6]
-    /// 111 101 011 001 000 010 100 110
+    // [7] [5] [3] [1] [0] [2] [4] [6]
+    // 111 101 011 001 000 010 100 110
     //
     // [Constants.MIN_V3POOL_TICK-1] [7]
     // 111100100111011000010111
@@ -215,77 +206,80 @@ contract PanopticPool is ERC1155Holder, Multicall {
     // [Constants.MAX_V3POOL_TICK+1] [2]
     // 000011011000100111101001
     //
-    ///  @dev [CURRENT TICK] [4]
-    /// (000000000000000000000000) // dynamic
+    // [CURRENT TICK] [4]
+    // (000000000000000000000000) // dynamic
     //
-    ///  @dev [CURRENT TICK] [3]
-    /// (000000000000000000000000) // dynamic
+    // [CURRENT TICK] [3]
+    // (000000000000000000000000) // dynamic
     uint256 internal s_miniMedian;
 
-    /// @dev ERC4626 vaults that users collateralize their positions with
-    /// Each token has its own vault, listed in the same order as the tokens in the pool
-    /// In addition to collateral deposits, these vaults also handle various collateral/bonus/exercise computations
-    /// underlying collateral token0
+    // ERC4626 vaults that users collateralize their positions with
+    // Each token has its own vault, listed in the same order as the tokens in the pool
+    // In addition to collateral deposits, these vaults also handle various collateral/bonus/exercise computations
+
+    /// @notice Collateral vault for token0 in the Uniswap pool.
     CollateralTracker internal s_collateralToken0;
-    /// @dev underlying collateral token1
+    /// @notice Collateral vault for token1 in the Uniswap pool.
     CollateralTracker internal s_collateralToken1;
 
-    /// @dev Nested mapping that tracks the option formation: address => tokenId => leg => premiaGrowth
-    // premia growth is taking a snapshot of the chunk premium in SFPM, which is measuring the amount of fees
-    // collected for every chunk per unit of liquidity (net or short, depending on the isLong value of the specific leg index)
+    /// @notice Nested mapping that tracks the option formation: address => tokenId => leg => premiaGrowth.
+    /// @dev Premia growth is taking a snapshot of the chunk premium in SFPM, which is measuring the amount of fees
+    /// collected for every chunk per unit of liquidity (net or short, depending on the isLong value of the specific leg index).
     mapping(address account => mapping(TokenId tokenId => mapping(uint256 leg => LeftRightUnsigned premiaGrowth)))
         internal s_options;
 
-    /// @dev Per-chunk `last` value that gives the aggregate amount of premium owed to all sellers when multiplied by the total amount of liquidity `totalLiquidity`
-    /// totalGrossPremium = totalLiquidity * (grossPremium(perLiquidityX64) - lastGrossPremium(perLiquidityX64)) / 2**64
-    /// Used to compute the denominator for the fraction of premium available to sellers to collect
-    /// LeftRight - right slot is token0, left slot is token1
+    /// @notice Per-chunk `last` value that gives the aggregate amount of premium owed to all sellers when multiplied by the total amount of liquidity `totalLiquidity`.
+    /// @dev totalGrossPremium = totalLiquidity * (grossPremium(perLiquidityX64) - lastGrossPremium(perLiquidityX64)) / 2**64.
+    /// @dev Used to compute the denominator for the fraction of premium available to sellers to collect.
+    /// @dev LeftRight - right slot is token0, left slot is token1.
     mapping(bytes32 chunkKey => LeftRightUnsigned lastGrossPremium) internal s_grossPremiumLast;
 
-    /// @dev per-chunk accumulator for tokens owed to sellers that have been settled and are now available
-    /// This number increases when buyers pay long premium and when tokens are collected from Uniswap
-    /// It decreases when sellers close positions and collect the premium they are owed
-    /// LeftRight - right slot is token0, left slot is token1
+    /// @notice Per-chunk accumulator for tokens owed to sellers that have been settled and are now available.
+    /// @dev This number increases when buyers pay long premium and when tokens are collected from Uniswap.
+    /// @dev It decreases when sellers close positions and collect the premium they are owed.
+    /// @dev LeftRight - right slot is token0, left slot is token1.
     mapping(bytes32 chunkKey => LeftRightUnsigned settledTokens) internal s_settledTokens;
 
-    /// @dev Tracks the amount of liquidity for a user+tokenId (right slot) and the initial pool utilizations when that position was minted (left slot)
-    ///    poolUtilizations when minted (left)    liquidity=ERC1155 balance (right)
-    ///        token0          token1
-    ///  |<-- 64 bits -->|<-- 64 bits -->|<---------- 128 bits ---------->|
-    ///  |<-------------------------- 256 bits -------------------------->|
+    /// @notice Tracks the amount of liquidity for a user+tokenId (right slot) and the initial pool utilizations when that position was minted (left slot).
+    //    poolUtilizations when minted (left)    liquidity=ERC1155 balance (right)
+    //        token0          token1
+    //  |<-- 64 bits -->|<-- 64 bits -->|<---------- 128 bits ---------->|
+    //  |<-------------------------- 256 bits -------------------------->|
     mapping(address account => mapping(TokenId tokenId => LeftRightUnsigned balanceAndUtilizations))
         internal s_positionBalance;
 
-    /// @dev numPositions (32 positions max)    user positions hash
-    ///  |<-- 8 bits -->|<------------------ 248 bits ------------------->|
-    ///  |<---------------------- 256 bits ------------------------------>|
-    /// @dev Tracks the position list hash i.e keccak256(XORs of abi.encodePacked(positionIdList)).
-    /// The order and content of this list is emitted in an event every time it is changed
-    /// If the user has no positions, the hash is not the hash of "[]" but just bytes32(0) for consistency.
-    /// The accumulator also tracks the total number of positions (ie. makes sure the length of the provided positionIdList matches);
-    /// @dev The purpose of the positionIdList is to reduce storage usage when a user has more than one active position
-    /// instead of having to manage an unwieldy storage array and do lots of loads, we just store a hash of the array
-    /// this hash can be cheaply verified on every operation with a user provided positionIdList - and we can use that for operations
-    /// without having to every load any other data from storage
+    //    numPositions (32 positions max)    user positions hash
+    //  |<-- 8 bits -->|<------------------ 248 bits ------------------->|
+    //  |<---------------------- 256 bits ------------------------------>|
+    /// @notice Tracks the position list hash i.e keccak256(XORs of abi.encodePacked(positionIdList)).
+    /// @dev The order and content of this list (the preimage for the hash) is emitted in an event every time it is changed.
+    /// @dev A component of this hash also tracks the total number of positions (i.e. makes sure the length of the provided positionIdList matches).
+    /// @dev The purpose of this system is to reduce storage usage when a user has more than one active position.
+    /// @dev Instead of having to manage an unwieldy storage array and do lots of loads, we just store a hash of the array.
+    /// @dev This hash can be cheaply verified on every operation with a user provided positionIdList - which can then be used for operations
+    /// without having to every load any other data from storage.
+    //    numPositions (32 positions max)    user positions hash
+    //  |<-- 8 bits -->|<------------------ 248 bits ------------------->|
+    //  |<---------------------- 256 bits ------------------------------>|
     mapping(address account => uint256 positionsHash) internal s_positionsHash;
 
     /*//////////////////////////////////////////////////////////////
                              INITIALIZATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice During construction: sets the address of the panoptic factory smart contract and the SemiFungiblePositionMananger (SFPM).
-    /// @param _sfpm The address of the SemiFungiblePositionManager (SFPM) contract.
+    /// @notice Store the address of the canonical SemiFungiblePositionManager (SFPM) contract.
+    /// @param _sfpm The address of the SemiFungiblePositionManager (SFPM) contract
     constructor(SemiFungiblePositionManager _sfpm) {
         SFPM = _sfpm;
     }
 
-    /// @notice Creates a method for creating a Panoptic Pool on top of an existing Uniswap v3 pair.
-    /// @dev Must be called first before any transaction can occur. Must also deploy collateralReference first.
-    /// @param _univ3pool Address of the target Uniswap v3 pool.
-    /// @param token0 Address of the pool's token0.
-    /// @param token1 Address of the pool's token1.
-    /// @param collateralTracker0 Interface for collateral token0.
-    /// @param collateralTracker1 Interface for collateral token1.
+    /// @notice Initializes a Panoptic Pool on top of an existing Uniswap v3 + collateral vault pair.
+    /// @dev Must be called first (by a factory contract) before any transaction can occur.
+    /// @param _univ3pool Address of the target Uniswap v3 pool
+    /// @param token0 Address of the pool's token0
+    /// @param token1 Address of the pool's token1
+    /// @param collateralTracker0 Address of the collateral vault for token0
+    /// @param collateralTracker1 Address of the collateral vault for token1
     function startPool(
         IUniswapV3Pool _univ3pool,
         address token0,
@@ -355,11 +349,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Returns the total number of contracts owned by user for a specified position.
-    /// @param user Address of the account to be checked.
-    /// @param tokenId TokenId of the option position to be checked.
-    /// @return balance Number of contracts of tokenId owned by the user.
-    /// @return poolUtilization0 The utilization of token0 in the Panoptic pool at mint.
-    /// @return poolUtilization1 The utilization of token1 in the Panoptic pool at mint.
+    /// @param user Address of the account to be checked
+    /// @param tokenId TokenId of the option position to be checked
+    /// @return balance Number of contracts of tokenId owned by the user
+    /// @return poolUtilization0 The utilization of token0 in the Panoptic pool at mint
+    /// @return poolUtilization1 The utilization of token1 in the Panoptic pool at mint
     function optionPositionBalance(
         address user,
         TokenId tokenId
@@ -382,13 +376,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Compute the total amount of premium accumulated for a list of positions.
-    /// @dev Can be costly as it reads information from 2 ticks for each leg of each tokenId.
-    /// @param user Address of the user that owns the positions.
-    /// @param positionIdList List of positions. Written as [tokenId1, tokenId2, ...].
-    /// @param includePendingPremium true = include premium that is owed to the user but has not yet settled, false = only include premium that is available to collect.
-    /// @return premium0 Premium for token0 (negative = amount is owed).
-    /// @return premium1 Premium for token1 (negative = amount is owed).
-    /// @return balances A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...].
+    /// @param user Address of the user that owns the positions
+    /// @param positionIdList List of positions. Written as [tokenId1, tokenId2, ...]
+    /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
+    /// @return premium0 Premium for token0 (negative = amount is owed)
+    /// @return premium1 Premium for token1 (negative = amount is owed)
+    /// @return balances A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
     function calculateAccumulatedFeesBatch(
         address user,
         bool includePendingPremium,
@@ -410,14 +403,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         return (premia.rightSlot(), premia.leftSlot(), balances);
     }
 
-    /// @notice Compute the total value of the portfolio defined by the positionIdList at the given tick.
-    /// @dev The return values do not include the value of the accumulated fees.
-    /// @dev value0 and value1 are related to one another according to: value1 = value0 * price(atTick).
+    /// @notice Compute the net token amounts owned by a given positionIdList in the Uniswap pool at the given price tick.
     /// @param user Address of the user that owns the positions.
-    /// @param atTick Tick at which the portfolio value is evaluated.
-    /// @param positionIdList List of positions. Written as [tokenId1, tokenId2, ...].
-    /// @return value0 Portfolio value in terms of token0 (negative = loss, when compared with starting value).
-    /// @return value1 Portfolio value in terms of token1 (negative = loss, when compared to starting value).
+    /// @param atTick Tick at which the portfolio value is evaluated
+    /// @param positionIdList List of positions. Written as [tokenId1, tokenId2, ...]
+    /// @return value0 Net amount of token0 in the Uniswap pool owned by the positionIdList (negative = borrowed liquidity owed to sellers)
+    /// @return value1 Net amount of token1 in the Uniswap pool owned by the positionIdList (negative = borrowed liquidity owed to sellers)
     function calculatePortfolioValue(
         address user,
         int24 atTick,
@@ -431,12 +422,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Calculate the accumulated premia owed from the option buyer to the option seller.
-    /// @param user The holder of options.
-    /// @param positionIdList The list of all option positions held by user.
-    /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false).
-    /// @param includePendingPremium true = include premium that is owed to the user but has not yet settled, false = only include premium that is available to collect.
-    /// @return portfolioPremium The computed premia of the user's positions, where premia contains the accumulated premia for token0 in the right slot and for token1 in the left slot.
-    /// @return balances A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...].
+    /// @param user The holder of options
+    /// @param positionIdList The list of all option positions held by user
+    /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false)
+    /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
+    /// @return portfolioPremium The computed premia of the user's positions, where premia contains the accumulated premia for token0 in the right slot and for token1 in the left slot
+    /// @return balances A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
     function _calculateAccumulatedPremia(
         address user,
         TokenId[] calldata positionIdList,
@@ -526,12 +517,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Validates the current options of the user, and mints a new position.
-    /// @param positionIdList the list of currently held positions by the user, where the newly minted position(token) will be the last element in 'positionIdList'.
-    /// @param positionSize The size of the position to be minted, expressed in terms of the asset.
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as removedLiquidity/netLiquidity for a new position.
-    /// denominated as X32 = (ratioLimit * 2**32). Set to 0 for no limit / only short options.
-    /// @param tickLimitLow The lower tick slippagelimit.
-    /// @param tickLimitHigh The upper tick slippagelimit.
+    /// @param positionIdList The list of currently held positions by the user, where the newly minted position(token) will be the last element in 'positionIdList'
+    /// @param positionSize The size of the position to be minted, expressed in terms of the asset
+    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as removedLiquidity/netLiquidity for a new position and
+    /// denominated as X32 = (ratioLimit * 2**32)
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function mintOptions(
         TokenId[] calldata positionIdList,
         uint128 positionSize,
@@ -548,12 +539,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
         );
     }
 
-    /// @notice Burns the entire balance of tokenId of the caller(msg.sender).
-    /// @dev Will exercise if necessary, and will revert if user does not have enough collateral to exercise.
-    /// @param tokenId The tokenId of the option position to be burnt.
-    /// @param newPositionIdList The new positionIdList without the token being burnt.
-    /// @param tickLimitLow Price slippage limit when burning an ITM option.
-    /// @param tickLimitHigh Price slippage limit when burning an ITM option.
+    /// @notice Closes and burns the caller's entire balance of `tokenId`.
+    /// @param tokenId The tokenId of the option position to be burnt
+    /// @param newPositionIdList The new positionIdList without the token being burnt
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function burnOptions(
         TokenId tokenId,
         TokenId[] calldata newPositionIdList,
@@ -565,12 +555,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
     }
 
-    /// @notice Burns the entire balance of all tokenIds provided in positionIdList of the caller(msg.sender).
-    /// @dev Will exercise if necessary, and will revert if user does not have enough collateral to exercise.
-    /// @param positionIdList The list of tokenIds for the option positions to be burnt.
-    /// @param newPositionIdList The new positionIdList without the token(s) being burnt.
-    /// @param tickLimitLow Price slippage limit when burning an ITM option.
-    /// @param tickLimitHigh Price slippage limit when burning an ITM option.
+    /// @notice Closes and burns the caller's entire balance of each `tokenId` in `positionIdList.
+    /// @param positionIdList The list of tokenIds for the option positions to be burnt
+    /// @param newPositionIdList The new positionIdList without the token(s) being burnt
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function burnOptions(
         TokenId[] calldata positionIdList,
         TokenId[] calldata newPositionIdList,
@@ -593,12 +582,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Validates the current options of the user, and mints a new position.
-    /// @param positionIdList the list of currently held positions by the user, where the newly minted position(token) will be the last element in 'positionIdList'.
-    /// @param positionSize The size of the position to be minted, expressed in terms of the asset.
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as removedLiquidity/netLiquidity for a new position.
-    /// denominated as X32 = (ratioLimit * 2**32). Set to 0 for no limit / only short options.
-    /// @param tickLimitLow The lower tick slippagelimit.
-    /// @param tickLimitHigh The upper tick slippagelimit.
+    /// @param positionIdList The list of currently held positions by the user, where the newly minted position(token) will be the last element in 'positionIdList'
+    /// @param positionSize The size of the position to be minted, expressed in terms of the asset
+    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as removedLiquidity/netLiquidity for a new position and
+    /// denominated as X32 = (ratioLimit * 2**32)
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function _mintOptions(
         TokenId[] calldata positionIdList,
         uint128 positionSize,
@@ -652,43 +641,36 @@ contract PanopticPool is ERC1155Holder, Multicall {
         emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations);
     }
 
-    /// @notice Check user health (collateral status).
-    /// @dev Moves the required liquidity and checks for user health.
-    /// @param tokenId The option position to be minted.
-    /// @param positionSize The size of the position, expressed in terms of the asset.
-    /// @param tickLimitLow The lower slippage limit on the tick.
-    /// @param tickLimitHigh The upper slippage limit on the tick.
+    /// @notice Move all the required liquidity to/from the AMM and settle any required collateral deltas.
+    /// @param tokenId The option position to be minted
+    /// @param positionSize The size of the position, expressed in terms of the asset
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @return poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool) at the time of minting,
-    /// right 64bits for token0 and left 64bits for token1.
+    /// right 64bits for token0 and left 64bits for token1
     function _mintInSFPMAndUpdateCollateral(
         TokenId tokenId,
         uint128 positionSize,
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (uint128) {
-        // Mint position by using the SFPM. totalSwapped will reflect tokens swapped because of minting ITM.
-        // Switch order of tickLimits to create "swapAtMint" flag
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
-        // update premium settlement info
         _updateSettlementPostMint(tokenId, collectedByLeg, positionSize);
 
-        // pay commission based on total moved amount (long + short)
-        // write data about inAMM in collateralBase
         uint128 poolUtilizations = _payCommissionAndWriteData(tokenId, positionSize, totalSwapped);
 
         return poolUtilizations;
     }
 
-    /// @notice Pay the commission fees for creating the options and update internal state.
-    /// @dev Computes long+short amounts, extracts pool utilizations.
+    /// @notice Take the commission fees for minting `tokenId` and settle any other required collateral deltas.
     /// @param tokenId The option position
     /// @param positionSize The size of the position, expressed in terms of the asset
-    /// @param totalSwapped How much was swapped (if in-the-money position).
+    /// @param totalSwapped The amount of tokens moved during creation of the option position
     /// @return poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
-    /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets().
-    /// Where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool.
+    /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets()
+    /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
@@ -717,11 +699,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
     }
 
-    /// @notice Store user option data. Track fees collected for the options.
-    /// @dev Computes and stores the option data for each leg.
-    /// @param tokenId The id of the minted option position.
+    /// @notice Add a new option to the user's position hash, perform required checks, and initialize the premium accumulators.
+    /// @param tokenId The minted option position
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as removedLiquidity/netLiquidity for a new position
-    /// denominated as X32 = (ratioLimit * 2**32). Set to 0 for no limit / only short options.
+    /// denominated as X32 = (ratioLimit * 2**32)
     function _addUserOption(TokenId tokenId, uint64 effectiveLiquidityLimitX32) internal {
         // Update the position list hash (hash = XOR of all keccak256(tokenId)). Remove hash by XOR'ing again
         _updatePositionsHash(msg.sender, tokenId, ADD);
@@ -771,12 +752,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
                          POSITION BURNING LOGIC
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Helper to burn option during a liquidation from an account _owner.
-    /// @param owner the owner of the option position to be liquidated.
-    /// @param tickLimitLow Price slippage limit when burning an ITM option
-    /// @param tickLimitHigh Price slippage limit when burning an ITM option
-    /// @param commitLongSettled Whether to commit the long premium that will be settled to storage
-    /// @param positionIdList the option position to liquidate.
+    /// @notice Close all options in `positionIdList.
+    /// @param owner The owner of the option position to be closed
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
+    /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
+    /// @param positionIdList The list of option positions to close
+    /// @return netPaid The net amount of tokens paid after closing the positions
+    /// @return premiasByLeg The amount of premia owed to the user for each leg of the position
     function _burnAllOptionsFrom(
         address owner,
         int24 tickLimitLow,
@@ -801,13 +784,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
     }
 
-    /// @notice Helper to burn an option position held by '_owner'.
-    /// @param tokenId the option position to burn.
-    /// @param owner the owner of the option position to be burned.
-    /// @param tickLimitLow Price slippage limit when burning an ITM option
-    /// @param tickLimitHigh Price slippage limit when burning an ITM option
-    /// @param commitLongSettled Whether to commit the long premium that will be settled to storage
-    /// @return paidAmounts The amount of tokens paid when closing the option
+    /// @notice Close a single option position.
+    /// @param tokenId The option position to burn
+    /// @param owner The owner of the option position to be burned
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
+    /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
+    /// @return paidAmounts The net amount of tokens paid after closing the position
     /// @return premiaByLeg The amount of premia owed to the user for each leg of the position
     function _burnOptions(
         bool commitLongSettled,
@@ -832,13 +815,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // erase position data
         _updatePositionDataBurn(owner, tokenId);
 
-        // emit event
         emit OptionBurnt(owner, positionSize, tokenId, premiaOwed);
     }
 
-    /// @notice Update the internal tracking of the owner's position data upon burning a position.
-    /// @param owner The owner of the option position.
-    /// @param tokenId The option position to burn.
+    /// @notice Remove an option position from a user's position hash and reset its premium accumulators on close.
+    /// @param owner The owner of the option position
+    /// @param tokenId The option position being closed
     function _updatePositionDataBurn(address owner, TokenId tokenId) internal {
         // reset balances and delete stored option data
         s_positionBalance[owner][tokenId] = LeftRightUnsigned.wrap(0);
@@ -860,11 +842,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _updatePositionsHash(owner, tokenId, !ADD);
     }
 
-    /// @notice Validates the solvency of `user` at the fast oracle tick.
-    /// @notice Falls back to the more conservative tick if the delta between the fast and slow oracle exceeds `MAX_SLOW_FAST_DELTA`.
+    /// @notice Validates the solvency of `user`.
+    /// @dev Falls back to the more conservative tick if the delta between the fast and slow oracle exceeds `MAX_SLOW_FAST_DELTA`.
     /// @dev Effectively, this means that the users must be solvent at both the fast and slow oracle ticks if one of them is stale to mint or burn options.
-    /// @param user The account to validate.
-    /// @param positionIdList The new positionIdList without the token(s) being burnt.
+    /// @param user The account to validate
+    /// @param positionIdList The list of positions to validate solvency for
     /// @param buffer The buffer to apply to the collateral requirement for `user`
     /// @return medianData If nonzero (enough time has passed since last observation), the updated value for `s_miniMedian` with a new observation
     function _validateSolvency(
@@ -929,12 +911,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Burns and handles the exercise of options.
-    /// @param commitLongSettled Whether to commit the long premium that will be settled to storage
-    /// @param tickLimitLow The lower slippage limit on the tick.
-    /// @param tickLimitHigh The upper slippage limit on the tick.
-    /// @param tokenId The option position to burn.
-    /// @param positionSize The size of the option position, expressed in terms of the asset.
-    /// @param owner The owner of the option position.
+    /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param tokenId The option position to burn
+    /// @param positionSize The size of the option position, expressed in terms of the asset
+    /// @param owner The owner of the option position
+    /// @return realizedPremia The net premia paid/received from the option position
+    /// @return premiaByLeg The premia owed to the user for each leg of the option position
+    /// @return paidAmounts The net amount of tokens paid after closing the position
     function _burnAndHandleExercise(
         bool commitLongSettled,
         int24 tickLimitLow,
@@ -991,12 +976,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     LIQUIDATIONS & FORCED EXERCISES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Liquidates a distressed account. Will burn all positions and will issue a bonus to the liquidator.
+    /// @notice Liquidates a distressed account. Will burn all positions and issue a bonus to the liquidator.
     /// @dev Will revert if liquidated account is solvent at the TWAP tick or if TWAP tick is too far away from the current tick.
-    /// @param positionIdListLiquidator List of positions owned by the liquidator.
-    /// @param liquidatee Address of the distressed account.
-    /// @param delegations LeftRight amounts of token0 and token1 (token0:token1 right:left) delegated to the liquidatee by the liquidator so the option can be smoothly exercised.
-    /// @param positionIdList List of positions owned by the user. Written as [tokenId1, tokenId2, ...].
+    /// @param positionIdListLiquidator List of positions owned by the liquidator
+    /// @param liquidatee Address of the distressed account
+    /// @param delegations LeftRight amounts of token0 and token1 (token0:token1 right:left) delegated to the liquidatee by the liquidator so the option can be smoothly exercised
+    /// @param positionIdList List of positions owned by the user. Written as [tokenId1, tokenId2, ...]
     function liquidate(
         TokenId[] calldata positionIdListLiquidator,
         address liquidatee,
@@ -1154,7 +1139,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Force the exercise of a single position. Exercisor will have to pay a fee to the force exercisee.
-    /// @dev Will revert if: number of touchedId is larger than 1 or if user force exercises their own position
     /// @param account Address of the distressed account
     /// @param touchedId List of position to be force exercised. Can only contain one tokenId, written as [tokenId]
     /// @param positionIdListExercisee Post-burn list of open positions in the exercisee's (account) account
@@ -1210,7 +1194,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _burnAllOptionsFrom(account, MIN_SWAP_TICK, MAX_SWAP_TICK, COMMIT_LONG_SETTLED, touchedId);
 
         // Compute the exerciseFee, this will decrease the further away the price is from the forcedExercised position
-        /// @dev use the medianTick to prevent price manipulations based on swaps.
+        // Use an oracle tick to prevent price manipulations based on swaps.
         LeftRightSigned exerciseFees = s_collateralToken0.exerciseCost(
             currentTick,
             twapTick,
@@ -1264,12 +1248,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
                             SOLVENCY CHECKS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice check whether an account is solvent at a given `atTick` with a collateral requirement of `buffer`/10_000 multiplied by the requirement of `positionIdList`.
-    /// @param account The account to check solvency for.
-    /// @param positionIdList The list of positions to check solvency for.
-    /// @param currentTick The current tick of the Uniswap pool (needed for fee calculations).
-    /// @param atTick The tick to check solvency at.
-    /// @param buffer The buffer to apply to the collateral requirement.
+    /// @notice Check whether an account is solvent at a given `atTick` with a collateral requirement of `buffer`/10_000 multiplied by the requirement of `positionIdList`.
+    /// @param account The account to check solvency for
+    /// @param positionIdList The list of positions to check solvency for
+    /// @param currentTick The current tick of the Uniswap pool (needed for fee calculations)
+    /// @param atTick The tick to check solvency at
+    /// @param buffer The buffer to apply to the collateral requirement
+    /// @return Whether the account is solvent at the given tick
     function _checkSolvencyAtTick(
         address account,
         TokenId[] calldata positionIdList,
@@ -1313,12 +1298,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
     }
 
-    /// @notice Get parameters related to the solvency state of the account associated with the incoming tokenData.
-    /// @param tokenData0 Leftright encoded word with balance of token0 in the right slot, and required balance in left slot.
-    /// @param tokenData1 Leftright encoded word with balance of token1 in the right slot, and required balance in left slot.
-    /// @param sqrtPriceX96 The current sqrt(price) of the AMM.
-    /// @return balanceCross The current cross-collateral balance of the option positions.
-    /// @return thresholdCross The cross-collateral threshold balance under which the account is insolvent.
+    /// @notice Get a cross-collateral balance and required threshold for a given set of token balances and collateral requirements.
+    /// @param tokenData0 LeftRight encoded word with balance of token0 in the right slot, and required balance in left slot
+    /// @param tokenData1 LeftRight encoded word with balance of token1 in the right slot, and required balance in left slot
+    /// @param sqrtPriceX96 The price at which to compute the collateral value and requirements
+    /// @return balanceCross The current cross-collateral balance of the option positions
+    /// @return thresholdCross The cross-collateral threshold balance under which the account is insolvent
     function _getSolvencyBalances(
         LeftRightUnsigned tokenData0,
         LeftRightUnsigned tokenData1,
@@ -1343,10 +1328,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Makes sure that the positions in the incoming user's list match the existing active option positions.
-    /// @dev Check whether the list of positionId 1) has duplicates and 2) matches the length stored in the positionsHash.
-    /// @param account The owner of the incoming list of positions.
-    /// @param positionIdList The existing list of active options for the owner.
-    /// @param offset Changes depending on whether this is a new mint or a liquidation (=1 if new mint, 0 if liquidation).
+    /// @param account The owner of the incoming list of positions
+    /// @param positionIdList The existing list of active options for the owner
+    /// @param offset The amount of positions from the end of the list to exclude from validation
     function _validatePositionList(
         address account,
         TokenId[] calldata positionIdList,
@@ -1358,8 +1342,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         unchecked {
             pLength = positionIdList.length - offset;
         }
-        // note that if pLength == 0 even if a user has existing position(s) the below will fail b/c the fingerprints will mismatch
-        // Check that position hash (the fingerprint of option positions) matches the one stored for the '_account'
+
         uint256 fingerprintIncomingList;
 
         for (uint256 i = 0; i < pLength; ) {
@@ -1381,10 +1364,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @dev The outcome of this function will be to update the hash of positions.
     /// This is done as a duplicate/validation check of the incoming list O(N).
     /// @dev The positions hash is stored as the XOR of the keccak256 of each tokenId. Updating will XOR the existing hash with the new tokenId.
-    /// The same update can either add a new tokenId (when minting an option), or remove an existing one (when burning it) - this happens through the XOR.
-    /// @param account The owner of the options.
-    /// @param tokenId The option position.
-    /// @param addFlag Pass addFlag=true when this is adding a position, needed to ensure the number of positions increases or decreases.
+    /// The same update can either add a new tokenId (when minting an option), or remove an existing one (when burning it).
+    /// @param account The owner of `tokenId`
+    /// @param tokenId The option position
+    /// @param addFlag Whether to add `tokenId` to the hash (true) or remove it (false)
     function _updatePositionsHash(address account, TokenId tokenId, bool addFlag) internal {
         // Get the current position hash value (fingerprint of all pre-existing positions created by '_account')
         // Add the current tokenId to the positionsHash as XOR'd
@@ -1404,32 +1387,32 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Get the address of the AMM pool connected to this Panoptic pool.
-    /// @return univ3pool AMM pool corresponding to this Panoptic pool.
+    /// @return univ3pool AMM pool corresponding to this Panoptic pool
     function univ3pool() external view returns (IUniswapV3Pool) {
         return s_univ3pool;
     }
 
     /// @notice Get the collateral token corresponding to token0 of the AMM pool.
-    /// @return collateralToken Collateral token corresponding to token0 in the AMM.
+    /// @return collateralToken Collateral token corresponding to token0 in the AMM
     function collateralToken0() external view returns (CollateralTracker collateralToken) {
         return s_collateralToken0;
     }
 
     /// @notice Get the collateral token corresponding to token1 of the AMM pool.
-    /// @return collateralToken collateral token corresponding to token1 in the AMM.
+    /// @return collateralToken collateral token corresponding to token1 in the AMM
     function collateralToken1() external view returns (CollateralTracker) {
         return s_collateralToken1;
     }
 
-    /// @notice get the number of positions for an account
-    /// @param user the account to get the positions hash of
-    /// @return _numberOfPositions number of positions in the account
+    /// @notice Get the current number of open positions for an account
+    /// @param user The account to query
+    /// @return _numberOfPositions Number of open positions for `user`
     function numberOfPositions(address user) public view returns (uint256 _numberOfPositions) {
         _numberOfPositions = (s_positionsHash[user] >> 248);
     }
 
-    /// @notice Compute the TWAP price from the last 600s = 10mins.
-    /// @return twapTick The TWAP price in ticks.
+    /// @notice Get the oracle price used to check solvency in liquidations.
+    /// @return twapTick The current oracle price used to check solvency in liquidations
     function getUniV3TWAP() internal view returns (int24 twapTick) {
         twapTick = PanopticMath.twapFilter(s_univ3pool, TWAP_WINDOW);
     }
@@ -1439,12 +1422,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Ensure the effective liquidity in a given chunk is above a certain threshold.
-    /// @param tokenId The id of the option position.
-    /// @param leg The leg of the option position (used to check if long or short).
-    /// @param tickLower The lower tick of the chunk.
-    /// @param tickUpper The upper tick of the chunk.
+    /// @param tokenId An option position
+    /// @param leg A leg index of `tokenId` corresponding to a tickLower-tickUpper chunk
+    /// @param tickLower The lower tick of the chunk
+    /// @param tickUpper The upper tick of the chunk
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as removedLiquidity/netLiquidity for a new position
-    /// denominated as X32 = (ratioLimit * 2**32). Set to 0 for no limit / only short options.
+    /// denominated as X32 = (ratioLimit * 2**32)
     function _checkLiquiditySpread(
         TokenId tokenId,
         uint256 leg,
@@ -1477,12 +1460,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Compute the premia collected for a single option position 'tokenId'.
-    /// @param tokenId The option position.
-    /// @param positionSize The number of contracts (size) of the option position.
-    /// @param owner The holder of the tokenId option.
-    /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false).
+    /// @param tokenId The option position
+    /// @param positionSize The number of contracts (size) of the option position
+    /// @param owner The holder of the tokenId option
+    /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false)
     /// @param atTick The tick at which the premia is calculated -> use (atTick < type(int24).max) to compute it
-    /// up to current block. atTick = type(int24).max will only consider fees as of the last on-chain transaction.
+    /// up to current block. atTick = type(int24).max will only consider fees as of the last on-chain transaction
+    /// @return premiaByLeg The amount of premia owed to the user for each leg of the position
+    /// @return premiumAccumulatorsByLeg The amount of premia accumulated for each leg of the position
     function _getPremia(
         TokenId tokenId,
         uint128 positionSize,
@@ -1522,9 +1507,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 unchecked {
                     LeftRightUnsigned premiumAccumulatorLast = s_options[owner][tokenId][leg];
 
-                    // if the premium accumulatorLast is higher than current, it means the premium accumulator has overflowed and rolled over at least once
-                    // we can account for one rollover by doing (acc_cur + (acc_max - acc_last))
-                    // if there are multiple rollovers or the rollover goes past the last accumulator, rolled over fees will just remain unclaimed
                     premiaByLeg[leg] = LeftRightSigned
                         .wrap(0)
                         .toRightSlot(
@@ -1561,12 +1543,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         AVAILABLE PREMIUM LOGIC
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Settle all unpaid premium for long legs of chunk `chunkIdentity` on `tokenIds` of `owners`.
+    /// @notice Settle unpaid premium for one `legIndex` on a position owned by `owner`.
     /// @dev Called by sellers on buyers of their chunk to increase the available premium for withdrawal (before closing their position).
-    /// @dev This feature is only available when all `owners` is solvent at the current tick
-    /// @param positionIdList Exhaustive list of open positions for the `owners` used for solvency checks where the tokenId to be settled is the last element.
-    /// @param owner The owner of the option position to make premium payments on.
-    /// @param legIndex the index of the leg in tokenId that is to be collected on (must be isLong=1).
+    /// @dev This feature is only available when `owner` is solvent and has the requisite tokens to settle the premium.
+    /// @param positionIdList Exhaustive list of open positions for `owner` used for solvency checks where the tokenId to settle is placed at the last index
+    /// @param owner The owner of the option position to make premium payments on
+    /// @param legIndex the index of the leg in tokenId that is to be collected on (must be isLong=1)
     function settleLongPremium(
         TokenId[] calldata positionIdList,
         address owner,
@@ -1641,11 +1623,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _validateSolvency(owner, positionIdList, NO_BUFFER);
     }
 
-    /// @notice Adds collected tokens to settled accumulator and adjusts grossPremiumLast for any liquidity added
-    /// @dev Always called after `mintTokenizedPosition`
-    /// @param tokenId The option position that was minted.
-    /// @param collectedByLeg The amount of tokens collected in the corresponding chunk for each leg of the position.
-    /// @param positionSize The size of the position, expressed in terms of the asset.
+    /// @notice Adds collected tokens to settled accumulator and adjusts grossPremiumLast for any liquidity added.
+    /// @param tokenId The option position that was minted
+    /// @param collectedByLeg The amount of tokens collected in the corresponding chunk for each leg of the position
+    /// @param positionSize The size of the position, expressed in terms of the asset
     function _updateSettlementPostMint(
         TokenId tokenId,
         LeftRightUnsigned[4] memory collectedByLeg,
@@ -1728,9 +1709,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
     }
 
-    /// @notice Query the amount of premium available for withdrawal given a certain `premiumOwed` for a chunk
-    /// @dev Based on the ratio between `settledTokens` and the total premium owed to sellers in a chunk
-    /// @dev The ratio is capped at 1 (it can be greater than one if some seller forfeits enough premium)
+    /// @notice Query the amount of premium available for withdrawal given a certain `premiumOwed` for a chunk.
+    /// @dev Based on the ratio between `settledTokens` and the total premium owed to sellers in a chunk.
+    /// @dev The ratio is capped at 1 (as the base ratio can be greater than one if some seller forfeits enough premium).
     /// @param totalLiquidity The updated total liquidity amount for the chunk
     /// @param settledTokens LeftRight accumulator for the amount of tokens that have been settled (collected or paid)
     /// @param grossPremiumLast The `last` values used with `premiumAccumulators` to compute the total premium owed to sellers
@@ -1778,10 +1759,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
     }
 
-    /// @notice Query the total amount of liquidity sold in the corresponding chunk for a position leg
-    /// @dev totalLiquidity (total sold) = removedLiquidity + netLiquidity (in AMM)
+    /// @notice Query the total amount of liquidity sold in the corresponding chunk for a position leg.
+    /// @dev totalLiquidity (total sold) = removedLiquidity + netLiquidity (in AMM).
     /// @param tokenId The option position
-    /// @param leg The leg of the option position to get `totalLiquidity for
+    /// @param leg The leg of the option position to get `totalLiquidity` for
+    /// @return totalLiquidity The total amount of liquidity sold in the corresponding chunk for a position leg
     function _getTotalLiquidity(
         TokenId tokenId,
         uint256 leg
@@ -1804,8 +1786,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
     }
 
-    /// @notice Updates settled tokens and grossPremiumLast for a chunk after a burn and returns premium info
-    /// @dev Always called after `burnTokenizedPosition`
+    /// @notice Updates settled tokens and grossPremiumLast for a chunk after a burn and returns premium info.
     /// @param owner The owner of the option position that was burnt
     /// @param tokenId The option position that was burnt
     /// @param collectedByLeg The amount of tokens collected in the corresponding chunk for each leg of the position

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -268,7 +268,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Store the address of the canonical SemiFungiblePositionManager (SFPM) contract.
-    /// @param _sfpm The address of the SemiFungiblePositionManager (SFPM) contract
+    /// @param _sfpm The address of the SFPM
     constructor(SemiFungiblePositionManager _sfpm) {
         SFPM = _sfpm;
     }
@@ -381,7 +381,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
     /// @return premium0 Premium for token0 (negative = amount is owed)
     /// @return premium1 Premium for token1 (negative = amount is owed)
-    /// @return balances A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
+    /// @return A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
     function calculateAccumulatedFeesBatch(
         address user,
         bool includePendingPremium,
@@ -625,7 +625,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _addUserOption(tokenId, effectiveLiquidityLimitX32);
 
         // update the users options balance of position 'tokenId'
-        // note: user can't mint same position multiple times, so set the positionSize instead of adding
+        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
         s_positionBalance[msg.sender][tokenId] = LeftRightUnsigned
             .wrap(0)
             .toLeftSlot(poolUtilizations)
@@ -646,7 +646,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
-    /// @return poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool) at the time of minting,
+    /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool) at the time of minting,
     /// right 64bits for token0 and left 64bits for token1
     function _mintInSFPMAndUpdateCollateral(
         TokenId tokenId,
@@ -668,7 +668,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tokenId The option position
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param totalSwapped The amount of tokens moved during creation of the option position
-    /// @return poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
+    /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets()
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
     function _payCommissionAndWriteData(
@@ -1050,7 +1050,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
             // Do not commit any settled long premium to storage - we will do this after we determine if any long premium must be revoked
             // This is to prevent any short positions the liquidatee has being settled with tokens that will later be revoked
-            // Note: tick limits are not applied here since it is not the liquidator's position being liquidated
+            // NOTE: tick limits are not applied here since it is not the liquidator's position being liquidated
             (netExchanged, premiasByLeg) = _burnAllOptionsFrom(
                 liquidatee,
                 MIN_SWAP_TICK,
@@ -1387,7 +1387,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Get the address of the AMM pool connected to this Panoptic pool.
-    /// @return univ3pool AMM pool corresponding to this Panoptic pool
+    /// @return AMM pool corresponding to this Panoptic pool
     function univ3pool() external view returns (IUniswapV3Pool) {
         return s_univ3pool;
     }
@@ -1399,7 +1399,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Get the collateral token corresponding to token1 of the AMM pool.
-    /// @return collateralToken collateral token corresponding to token1 in the AMM
+    /// @return Collateral token corresponding to token1 in the AMM
     function collateralToken1() external view returns (CollateralTracker) {
         return s_collateralToken1;
     }
@@ -1717,7 +1717,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param grossPremiumLast The `last` values used with `premiumAccumulators` to compute the total premium owed to sellers
     /// @param premiumOwed The amount of premium owed to sellers in the chunk
     /// @param premiumAccumulators The current values of the premium accumulators for the chunk
-    /// @return availablePremium The amount of premium available for withdrawal
+    /// @return The amount of token0/token1 premium available for withdrawal
     function _getAvailablePremium(
         uint256 totalLiquidity,
         LeftRightUnsigned settledTokens,

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -376,7 +376,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
 
         // store the poolId => UniswapV3Pool information in a mapping
         // `locked` being initialized to false is gas-efficient because the pool address makes the slot nonzero
-        // note: we preserve the state of `locked` to prevent reentering a pool by initializing it during the reentrant call
+        // NOTE: we preserve the state of `locked` to prevent reentering a pool by initializing it during the reentrant call
         s_poolContext[poolId] = PoolAddressAndLock({
             pool: IUniswapV3Pool(univ3pool),
             locked: s_poolContext[poolId].locked
@@ -780,14 +780,14 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                 })
             );
 
-            // note: upstream users of this function such as the Panoptic Pool should ensure users always compensate for the ITM amount delta
+            // NOTE: upstream users of this function such as the Panoptic Pool should ensure users always compensate for the ITM amount delta
             // the netting swap is not perfectly accurate, and it is possible for swaps to run out of liquidity, so we do not want to rely on it
             // this is simply a convenience feature, and should be treated as such
             if ((itm0 != 0) && (itm1 != 0)) {
                 (uint160 sqrtPriceX96, , , , , , ) = _univ3pool.slot0();
 
                 // implement a single "netting" swap. Thank you @danrobinson for this puzzle/idea
-                // note: negative ITM amounts denote a surplus of tokens (burning liquidity), while positive amounts denote a shortage of tokens (minting liquidity)
+                // NOTE: negative ITM amounts denote a surplus of tokens (burning liquidity), while positive amounts denote a shortage of tokens (minting liquidity)
                 // compute the approximate delta of token0 that should be resolved in the swap at the current tick
                 // we do this by flipping the signs on the token1 ITM amount converting+deducting it against the token0 ITM amount
                 // couple examples (price = 2 1/0):
@@ -827,12 +827,12 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                 swapAmount = -itm1;
             }
 
-            // note - can occur if itm0 and itm1 have the same value
+            // NOTE: can occur if itm0 and itm1 have the same value
             // in that case, swapping would be pointless so skip
             if (swapAmount == 0) return LeftRightSigned.wrap(0);
 
             // swap tokens in the Uniswap pool
-            // note: this triggers our swap callback function
+            // NOTE: this triggers our swap callback function
             (int256 swap0, int256 swap1) = _univ3pool.swap(
                 msg.sender,
                 zeroForOne,
@@ -1435,8 +1435,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     /// @param tickUpper The upper end of the tick range for the position (int24)
     /// @param atTick The current tick. Set atTick < type(int24).max = 8388608 to get latest premium up to the current block
     /// @param isLong Whether the position is long (=1) or short (=0)
-    /// @return premiumToken0 The amount of premium (per liquidity X64) for token0 = sum (feeGrowthLast0X128) over every block where the position has been touched
-    /// @return premiumToken1 The amount of premium (per liquidity X64) for token1 = sum (feeGrowthLast0X128) over every block where the position has been touched
+    /// @return The amount of premium (per liquidity X64) for token0 = sum (feeGrowthLast0X128) over every block where the position has been touched
+    /// @return The amount of premium (per liquidity X64) for token1 = sum (feeGrowthLast0X128) over every block where the position has been touched
     function getAccountPremium(
         address univ3pool,
         address owner,

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -68,19 +68,18 @@ import {TokenId} from "@types/TokenId.sol";
 /// @author Axicon Labs Limited
 /// @title Semi-Fungible Position Manager (ERC1155) - a gas-efficient Uniswap V3 position manager.
 /// @notice Wraps Uniswap V3 positions with up to 4 legs behind an ERC1155 token.
-/// @dev Replaces the NonfungiblePositionManager.sol (ERC721) from Uniswap Labs
+/// @dev Replaces the NonfungiblePositionManager.sol (ERC721) from Uniswap Labs.
 contract SemiFungiblePositionManager is ERC1155, Multicall {
     /*//////////////////////////////////////////////////////////////
                                  EVENTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Emitted when a UniswapV3Pool is initialized.
+    /// @notice Emitted when a UniswapV3Pool is initialized in the SFPM.
     /// @param uniswapPool Address of the underlying Uniswap v3 pool
     /// @param poolId The SFPM's pool identifier for the pool, including the 16-bit tick spacing and 48-bit pool pattern
     event PoolInitialized(address indexed uniswapPool, uint64 poolId);
 
-    /// @notice Emitted when a position is destroyed/burned
-    /// @dev Recipient is used to track whether it was burned directly by the user or through an option contract
+    /// @notice Emitted when a position is destroyed/burned.
     /// @param recipient The address of the user who burned the position
     /// @param tokenId The tokenId of the burned position
     /// @param positionSize The number of contracts burnt, expressed in terms of the asset
@@ -90,9 +89,9 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         uint128 positionSize
     );
 
-    /// @notice Emitted when a position is created/minted
-    /// @dev Recipient is used to track whether it was minted directly by the user or through an option contract
-    /// @param caller the caller who created the position. In 99% of cases `caller` == `recipient`.
+    /// @notice Emitted when a position is created/minted.
+    /// @dev `recipient` is used to track whether it was minted directly by the user or through an option contract.
+    /// @param caller The address of the user who minted the position
     /// @param tokenId The tokenId of the minted position
     /// @param positionSize The number of contracts minted, expressed in terms of the asset
     event TokenizedPositionMinted(
@@ -105,13 +104,12 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                                  TYPES
     //////////////////////////////////////////////////////////////*/
 
-    // Used for safecasting
     using Math for uint256;
     using Math for int256;
 
-    // Packs the pool address and reentrancy lock into a single slot
-    // `locked` can be initialized to false because the pool address makes the slot nonzero
-    // false = unlocked, true = locked
+    /// @notice Packs the Uniswap pool address and reentrancy lock into a single slot.
+    /// @dev `locked` can be initialized to false with no gas consequences because the pool address makes the slot nonzero.
+    /// @dev false = unlocked, true = locked
     struct PoolAddressAndLock {
         IUniswapV3Pool pool;
         bool locked;
@@ -121,10 +119,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                             IMMUTABLES 
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev flag for mint/burn
+    /// @notice Flag used to indicate a regular position mint.
     bool internal constant MINT = false;
+
+    /// @notice Flag used to indicate that a position burn (with a burnTokenId) is occuring.
     bool internal constant BURN = true;
 
+    /// @notice Parameter used to modify the [equation](https://www.desmos.com/calculator/mdeqob2m04) of the utilization-based multiplier for long premium.
     // ν = 1/2**VEGOID = multiplicative factor for long premium (Eqns 1-5)
     // Similar to vega in options because the liquidity utilization is somewhat reflective of the implied volatility (IV),
     // and vegoid modifies the sensitivity of the streamia to changes in that utilization,
@@ -132,24 +133,24 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     // The effect of vegoid on the long premium multiplier can be explored here: https://www.desmos.com/calculator/mdeqob2m04
     uint128 private constant VEGOID = 2;
 
-    /// @dev Uniswap V3 Factory address. Initialized in the constructor.
-    /// @dev used to verify callbacks and to query for the pool address
+    /// @notice Canonical Uniswap V3 Factory address.
+    /// @dev Used to verify callbacks and initialize pools.
     IUniswapV3Factory internal immutable FACTORY;
 
     /*//////////////////////////////////////////////////////////////
                             STORAGE 
     //////////////////////////////////////////////////////////////*/
 
-    /// Store the mapping between the poolId and the Uniswap v3 pool - intent is to be 1:1 for all pools
+    /// @notice Retrieve the corresponding poolId for a given Uniswap V3 pool address.
     /// @dev pool address => pool id + 2 ** 255 (initialization bit for `poolId == 0`, set if the pool exists)
     mapping(address univ3pool => uint256 poolIdData) internal s_AddrToPoolIdData;
 
-    /// @dev also contains a boolean which is used for the reentrancy lock - saves gas since this slot is often warmed
+    /// @notice Retrieve the Uniswap V3 pool address corresponding to a given poolId.
     // pool ids are used instead of addresses to save bits in the token id
     // (there will never be a collision because it's infeasible to mine an address with 8 consecutive bytes)
     mapping(uint64 poolId => PoolAddressAndLock contextData) internal s_poolContext;
 
-    /** 
+    /*
         We're tracking the amount of net and removed liquidity for the specific region:
 
              net amount    
@@ -169,15 +170,15 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
      * |<------- 128 bits ------->|<------- 128 bits ------->|
      * |<---------------------- 256 bits ------------------->|
      */
-    ///
-    /// @dev mapping that stores the liquidity data of keccak256(abi.encodePacked(address poolAddress, address owner, int24 tickLower, int24 tickUpper))
-    // liquidityData is a LeftRight. The right slot represents the liquidity currently sold (added) in the AMM owned by the user
-    // the left slot represents the amount of liquidity currently bought (removed) that has been removed from the AMM - the user owes it to a seller
-    // the reason why it is called "removedLiquidity" is because long options are created by removed liquidity -ie. short selling LP positions
+
+    /// @notice Retrieve the current liquidity state in a chunk for a given user.
+    /// @dev `removedAndNetLiquidity` is a LeftRight. The right slot represents the liquidity currently sold (added) in the AMM owned by the user and
+    // the left slot represents the amount of liquidity currently bought (removed) that has been removed from the AMM - the user owes it to a seller.
+    // The reason why it is called "removedLiquidity" is because long options are created by removed liquidity - ie. short selling LP positions.
     mapping(bytes32 positionKey => LeftRightUnsigned removedAndNetLiquidity)
         internal s_accountLiquidity;
 
-    /**
+    /*
         Any liquidity that has been deposited in the AMM using the SFPM will collect fees over 
         time, we call this the gross premia. If that liquidity has been removed, we also need to
         keep track of the amount of fees that *would have been collected*, we call this the owed
@@ -283,24 +284,25 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         to zero would get rid of the "spread logic".
     */
 
-    // tracking account premia for the added liquidity (isLong=0 legs) and removed liquidity (isLong=1 legs) separately
+    /// @notice Per-liquidity accumulator for the premium owed by buyers on a given chunk, tokenType and account.
     mapping(bytes32 positionKey => LeftRightUnsigned accountPremium) private s_accountPremiumOwed;
 
+    /// @notice Per-liquidity accumulator for the premium earned by sellers on a given chunk, tokenType and account.
     mapping(bytes32 positionKey => LeftRightUnsigned accountPremium) private s_accountPremiumGross;
 
-    /// @dev mapping that stores a LeftRight packing of feesBase of  keccak256(abi.encodePacked(address poolAddress, address owner, int24 tickLower, int24 tickUpper))
-    /// @dev Base fees is stored as int128((feeGrowthInside0LastX128 * liquidity) / 2**128), which allows us to store the accumulated fees as int128 instead of uint256
+    /// @notice Per-liquidity accumulator for the fees collected on an account for a given chunk.
+    /// @dev Base fees is stored as int128((feeGrowthInside0LastX128 * liquidity) / 2**128), which allows us to store the accumulated fees as int128 instead of uint256.
     /// @dev Right slot: int128 token0 base fees, Left slot: int128 token1 base fees.
-    /// feesBase represents the baseline fees collected by the position last time it was updated - this is recalculated every time the position is collected from with the new value
+    /// @dev feesBase represents the baseline fees collected by the position last time it was updated - this is recalculated every time the position is collected from with the new value.
     mapping(bytes32 positionKey => LeftRightSigned baseFees0And1) internal s_accountFeesBase;
 
     /*//////////////////////////////////////////////////////////////
                            REENTRANCY LOCK
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Modifier that prohibits reentrant calls for a specific pool
-    /// @dev We piggyback the reentrancy lock on the (pool id => pool) mapping to save gas
-    /// @dev (there's an extra 96 bits of storage available in the mapping slot and it's almost always warm)
+    /// @notice Modifier that prohibits reentrant calls for a specific pool.
+    /// @dev We piggyback the reentrancy lock on the (pool id => pool) mapping to save gas.
+    /// @dev (there's an extra 96 bits of storage available in the mapping slot and it's almost always warm).
     /// @param poolId The poolId of the pool to activate the reentrancy lock on
     modifier ReentrancyLock(uint64 poolId) {
         // check if the pool is already locked
@@ -314,8 +316,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         endReentrancyLock(poolId);
     }
 
-    /// @notice Add reentrancy lock on pool
-    /// @dev reverts if the pool is already locked
+    /// @notice Add reentrancy lock on pool.
+    /// @dev reverts if the pool is already locked.
     /// @param poolId The poolId of the pool to add the reentrancy lock to
     function beginReentrancyLock(uint64 poolId) internal {
         // check if the pool is already locked, if so, revert
@@ -325,7 +327,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         s_poolContext[poolId].locked = true;
     }
 
-    /// @notice Remove reentrancy lock on pool
+    /// @notice Remove reentrancy lock on pool.
     /// @param poolId The poolId of the pool to remove the reentrancy lock from
     function endReentrancyLock(uint64 poolId) internal {
         // gas refund is triggered here by returning the slot to its original value
@@ -336,13 +338,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                              INITIALIZATION
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Construct the Semi-Fungible Position Manager (SFPM)
-    /// @param _factory the Uniswap v3 Factory used to retrieve registered Uniswap pools
+    /// @notice Set the canonical Uniswap V3 Factory address.
+    /// @param _factory The canonical Uniswap V3 Factory address
     constructor(IUniswapV3Factory _factory) {
         FACTORY = _factory;
     }
 
-    /// @notice Initialize a Uniswap v3 pool in the SemifungiblePositionManager contract
+    /// @notice Initialize a Uniswap v3 pool in the SFPM.
     /// @dev Revert if already initialized.
     /// @param token0 The contract address of token0 of the pool
     /// @param token1 The contract address of token1 of the pool
@@ -355,9 +357,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         if (univ3pool == address(0)) revert Errors.UniswapPoolNotInitialized();
 
         // return if the pool has already been initialized in SFPM
-        // @dev pools can be initialized from a Panoptic pool or by calling initializeAMMPool directly, reverting
-        // would prevent any PanopticPool from being deployed
-        // @dev some pools may not be deployable if the poolId has a collision (since we take only 8 bytes)
+        // pools can be initialized from the Panoptic Factory or by calling initializeAMMPool directly, so reverting
+        // could prevent a PanopticPool from being deployed on a previously initialized but otherwise valid pools
         // if poolId == 0, we have a bit on the left set if it was initialized, so this will still return properly
         if (s_AddrToPoolIdData[univ3pool] != 0) return;
 
@@ -387,6 +388,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         unchecked {
             s_AddrToPoolIdData[univ3pool] = uint256(poolId) + 2 ** 255;
         }
+
         emit PoolInitialized(univ3pool, poolId);
     }
 
@@ -394,8 +396,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                            CALLBACK HANDLERS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Called after minting liquidity to a position
-    /// @dev Pays the pool tokens owed for the minted liquidity from the payer (always the caller)
+    /// @notice Called after minting liquidity to a position.
+    /// @dev Pays the pool tokens owed for the minted liquidity from the payer (always the caller).
     /// @param amount0Owed The amount of token0 due to the pool for the minted liquidity
     /// @param amount1Owed The amount of token1 due to the pool for the minted liquidity
     /// @param data Contains the payer address and the pool features required to validate the callback
@@ -426,11 +428,11 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     }
 
     /// @notice Called by the pool after executing a swap during an ITM option mint/burn.
-    /// @dev Pays the pool tokens owed for the swap from the payer (always the caller)
+    /// @dev Pays the pool tokens owed for the swap from the payer (always the caller).
     /// @param amount0Delta The amount of token0 that was sent (negative) or must be received (positive) by the pool by
-    /// the end of the swap. If positive, the callback must send that amount of token0 to the pool.
+    /// the end of the swap. If positive, the callback must send that amount of token0 to the pool
     /// @param amount1Delta The amount of token1 that was sent (negative) or must be received (positive) by the pool by
-    /// the end of the swap. If positive, the callback must send that amount of token1 to the pool.
+    /// the end of the swap. If positive, the callback must send that amount of token1 to the pool
     /// @param data Contains the payer address and the pool features required to validate the callback
     function uniswapV3SwapCallback(
         int256 amount0Delta,
@@ -464,8 +466,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     /// @dev Auto-collect all accumulated fees.
     /// @param tokenId The tokenId of the minted position, which encodes information about up to 4 legs
     /// @param positionSize The number of contracts minted, expressed in terms of the asset
-    /// @param slippageTickLimitLow The lower price slippage limit when minting an ITM position (set to larger than slippageTickLimitHigh for swapping when minting)
-    /// @param slippageTickLimitHigh The higher slippage limit when minting an ITM position (set to lower than slippageTickLimitLow for swapping when minting)
+    /// @param slippageTickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param slippageTickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @return collectedByLeg An array of LeftRight encoded words containing the amount of token0 and token1 collected as fees for each leg
     /// @return totalSwapped A LeftRight encoded word containing the total amount of token0 and token1 swapped if minting ITM
     function burnTokenizedPosition(
@@ -497,8 +499,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     /// @notice Create a new position `tokenId` containing up to 4 legs.
     /// @param tokenId The tokenId of the minted position, which encodes information for up to 4 legs
     /// @param positionSize The number of contracts minted, expressed in terms of the asset
-    /// @param slippageTickLimitLow The lower price slippage limit when minting an ITM position (set to larger than slippageTickLimitHigh for swapping when minting)
-    /// @param slippageTickLimitHigh The higher slippage limit when minting an ITM position (set to lower than slippageTickLimitLow for swapping when minting)
+    /// @param slippageTickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param slippageTickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @return collectedByLeg An array of LeftRight encoded words containing the amount of token0 and token1 collected as fees for each leg
     /// @return totalSwapped A LeftRight encoded word containing the total amount of token0 and token1 swapped if minting ITM
     function mintTokenizedPosition(
@@ -530,13 +532,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                      TRANSFER HOOK IMPLEMENTATIONS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Transfer a single token from one user to another
-    /// @dev supports token approvals
-    /// @param from the user to transfer tokens from
-    /// @param to the user to transfer tokens to
-    /// @param id the ERC1155 token id to transfer
-    /// @param amount the amount of tokens to transfer
-    /// @param data optional data to include in the receive hook
+    /// @notice Transfer a single token from one user to another.
+    /// @dev Supports token approvals.
+    /// @param from The user to transfer tokens from
+    /// @param to The user to transfer tokens to
+    /// @param id The ERC1155 token id to transfer
+    /// @param amount The amount of tokens to transfer
+    /// @param data Optional data to include in the receive hook
     function safeTransferFrom(
         address from,
         address to,
@@ -555,14 +557,14 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         super.safeTransferFrom(from, to, id, amount, data);
     }
 
-    /// @notice Transfer multiple tokens from one user to another
-    /// @dev supports token approvals
-    /// @dev ids and amounts must be of equal length
-    /// @param from the user to transfer tokens from
-    /// @param to the user to transfer tokens to
-    /// @param ids the ERC1155 token ids to transfer
-    /// @param amounts the amounts of tokens to transfer
-    /// @param data optional data to include in the receive hook
+    /// @notice Transfer multiple tokens from one user to another.
+    /// @dev Supports token approvals.
+    /// @dev `ids` and `amounts` must be of equal length.
+    /// @param from The user to transfer tokens from
+    /// @param to The user to transfer tokens to
+    /// @param ids The ERC1155 token ids to transfer
+    /// @param amounts The amounts of tokens to transfer
+    /// @param data Optional data to include in the receive hook
     function safeBatchTransferFrom(
         address from,
         address to,
@@ -584,14 +586,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         super.safeBatchTransferFrom(from, to, ids, amounts, data);
     }
 
-    /// @notice update user position data following a token transfer
-    /// @dev token transfers are only allowed if you transfer your entire liquidity of a given chunk and the recipient has none
+    /// @notice Update user position data following a token transfer.
+    /// @dev Token transfers are only allowed if you transfer your entire liquidity of a given chunk and the recipient has none.
     /// @param from The address of the sender
     /// @param to The address of the recipient
-    /// @param id The tokenId being transferred'
+    /// @param id The tokenId being transferred
     /// @param amount The amount of the token being transferred
     function registerTokenTransfer(address from, address to, TokenId id, uint256 amount) internal {
-        // Validate tokenId
         id.validate();
 
         // Extract univ3pool from the poolId map to Uniswap Pool
@@ -599,15 +600,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
 
         uint256 numLegs = id.countLegs();
         for (uint256 leg = 0; leg < numLegs; ) {
-            // for this leg index: extract the liquidity chunk: a 256bit word containing the liquidity amount and upper/lower tick
-            // @dev see `contracts/types/LiquidityChunk.sol`
             LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
                 id,
                 leg,
                 uint128(amount)
             );
 
-            //construct the positionKey for the from and to addresses
+            // construct the positionKey for the from and to addresses
             bytes32 positionKey_from = keccak256(
                 abi.encodePacked(
                     address(univ3pool),
@@ -640,12 +639,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
 
             LeftRightSigned fromBase = s_accountFeesBase[positionKey_from];
 
-            //update+store liquidity and fee values between accounts
+            // update+store liquidity and fee values between accounts
             s_accountLiquidity[positionKey_to] = fromLiq;
             s_accountLiquidity[positionKey_from] = LeftRightUnsigned.wrap(0);
 
             s_accountFeesBase[positionKey_to] = fromBase;
             s_accountFeesBase[positionKey_from] = LeftRightSigned.wrap(0);
+
             unchecked {
                 ++leg;
             }
@@ -661,22 +661,21 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     /// @notice  - that the `tokenId` is valid
     /// @notice  - confirms that the Uniswap pool exists
     /// @notice  - retrieves Uniswap pool info
-    /// @notice and then forwards the minting/burning/swapping to another internal helper functions which perform the AMM pool actions.
-    ///   ┌───────────────────────┐
-    ///   │mintTokenizedPosition()├───┐
-    ///   └───────────────────────┘   │
-    ///                               │
-    ///   ┌───────────────────────┐   │   ┌───────────────────────────────┐
-    ///   │burnTokenizedPosition()├───────► _validateAndForwardToAMM(...) ├─ (...) --> (mint/burn in AMM)
-    ///   └───────────────────────┘       └───────────────────────────────┘
-
-    /// @param tokenId the option position
-    /// @param positionSize the size of the position to create
-    /// @param tickLimitLow lower limits on potential slippage
-    /// @param tickLimitHigh upper limits on potential slippage
-    /// @param isBurn is equal to false for mints and true for burns
+    /// @notice Then, forwards the minting/burning/swapping to another internal helper function that performs the AMM pool actions.
+    //   ┌───────────────────────┐
+    //   │mintTokenizedPosition()├───┐
+    //   └───────────────────────┘   │
+    //                               │
+    //   ┌───────────────────────┐   │   ┌───────────────────────────────┐
+    //   │burnTokenizedPosition()├───────► _validateAndForwardToAMM(...) ├─ (...) --> (mint/burn in AMM)
+    //   └───────────────────────┘       └───────────────────────────────┘
+    /// @param tokenId The option position
+    /// @param positionSize The size of the position to create
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param isBurn Whether a position is being minted (true) or burned (false)
     /// @return collectedByLeg An array of LeftRight encoded words containing the amount of token0 and token1 collected as fees for each leg
-    /// @return totalMoved the total amount of funds swapped in Uniswap as part of building potential ITM positions
+    /// @return totalMoved The net amount of funds moved to/from Uniswap
     function _validateAndForwardToAMM(
         TokenId tokenId,
         uint128 positionSize,
@@ -728,36 +727,36 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
             revert Errors.PriceBoundFail();
     }
 
-    /// @notice When a position is minted or burnt in-the-money (ITM) we are *not* 100% token0 or 100% token1: we have a mix of both tokens.
-    /// @notice The swapping for ITM options is needed because only one of the tokens are "borrowed" by a user to create the position.
-    /// @notice This is an ITM situation below (price within the range of the chunk):
-    ///
-    ///        AMM       strike
-    ///     liquidity   price tick
-    ///        ▲           │
-    ///        │       ┌───▼───┐
-    ///        │       │       │liquidity chunk
-    ///        │ ┌─────┴─▲─────┴─────┐
-    ///        │ │       │           │
-    ///        │ │       :           │
-    ///        │ │       :           │
-    ///        │ │       :           │
-    ///        └─┴───────▲───────────┴─► price
-    ///                  │
-    ///             current price
-    ///             in-the-money: mix of tokens 0 and 1 within the chunk
-    ///
-    ///   If we take token0 as an example, we deploy it to the AMM pool and *then* swap to get the right mix of token0 and token1
-    ///   to be correctly in the money at that strike.
-    ///   It that position is burnt, then we remove a mix of the two tokens and swap one of them so that the user receives only one.
-    /// @param univ3pool the uniswap pool in which to swap.
-    /// @param itmAmounts how much to swap - how much is ITM
-    /// @return totalSwapped the amount swapped in the AMM
+    /// @notice Called to perform an ITM swap in the Uniswap pool to resolve any non-tokenType token deltas.
+    /// @dev When a position is minted or burnt in-the-money (ITM) we are *not* 100% token0 or 100% token1: we have a mix of both tokens.
+    /// @dev The swapping for ITM options is needed because only one of the tokens are "borrowed" by a user to create the position.
+    // This is an ITM situation below (price within the range of the chunk):
+    //
+    //        AMM       strike
+    //     liquidity   price tick
+    //        ▲           │
+    //        │       ┌───▼───┐
+    //        │       │       │liquidity chunk
+    //        │ ┌─────┴─▲─────┴─────┐
+    //        │ │       │           │
+    //        │ │       :           │
+    //        │ │       :           │
+    //        │ │       :           │
+    //        └─┴───────▲───────────┴─► price
+    //                  │
+    //            current price
+    //             in-the-money: mix of tokens 0 and 1 within the chunk
+    //
+    //   If we take token0 as an example, we deploy it to the AMM pool and *then* swap to get the right mix of token0 and token1
+    //   to be correctly in the money at that strike.
+    //   It that position is burnt, then we remove a mix of the two tokens and swap one of them so that the user receives only one.
+    /// @param univ3pool The uniswap pool in which to swap.
+    /// @param itmAmounts How much to swap - how much is ITM
+    /// @return totalSwapped The token deltas swapped in the AMM
     function swapInAMM(
         IUniswapV3Pool univ3pool,
         LeftRightSigned itmAmounts
     ) internal returns (LeftRightSigned totalSwapped) {
-        // Initialize variables
         bool zeroForOne; // The direction of the swap, true for token0 to token1, false for token1 to token0
         int256 swapAmount; // The amount of token0 or token1 to swap
         bytes memory data;
@@ -833,7 +832,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
             if (swapAmount == 0) return LeftRightSigned.wrap(0);
 
             // swap tokens in the Uniswap pool
-            // @dev note this triggers our swap callback function
+            // note: this triggers our swap callback function
             (int256 swap0, int256 swap1) = _univ3pool.swap(
                 msg.sender,
                 zeroForOne,
@@ -853,13 +852,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
 
     /// @notice Create the position in the AMM given in the tokenId.
     /// @dev Loops over each leg in the tokenId and calls _createLegInAMM for each, which does the mint/burn in the AMM.
-    /// @param univ3pool the Uniswap pool.
-    /// @param tokenId the option position
-    /// @param positionSize the size of the option position
-    /// @param isBurn is true if the position is burnt
-    /// @return totalMoved the total amount of liquidity moved from the msg.sender to Uniswap
+    /// @param univ3pool The Uniswap pool
+    /// @param tokenId The option position
+    /// @param positionSize The size of the option position
+    /// @param isBurn Whether a position is being minted (true) or burned (false)
+    /// @return totalMoved The net amount of funds moved to/from Uniswap
     /// @return collectedByLeg An array of LeftRight encoded words containing the amount of token0 and token1 collected as fees for each leg
-    /// @return itmAmounts the amount of tokens swapped due to legs being in-the-money
+    /// @return itmAmounts The amount of tokens swapped due to legs being in-the-money
     function _createPositionInAMM(
         IUniswapV3Pool univ3pool,
         TokenId tokenId,
@@ -899,8 +898,6 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                     _leg = _isBurn ? numLegs - leg - 1 : leg;
                 }
 
-                // for this _leg index: extract the liquidity chunk: a 256bit word containing the liquidity amount and upper/lower tick
-                // @dev see `contracts/types/LiquidityChunk.sol`
                 LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
                     _tokenId,
                     _leg,
@@ -945,15 +942,15 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     /// @dev  - mints any new liquidity in the AMM needed (via _mintLiquidity)
     /// @dev  - burns any new liquidity in the AMM needed (via _burnLiquidity)
     /// @dev  - tracks all amounts minted and burned
-    /// @dev to burn a position, the opposing position is "created" through this function
+    /// @dev To burn a position, the opposing position is "created" through this function,
     /// but we need to pass in a flag to indicate that so the removedLiquidity is updated.
-    /// @param univ3pool the Uniswap pool.
-    /// @param tokenId the option position
-    /// @param leg the leg index that needs to be modified
-    /// @param liquidityChunk has lower tick, upper tick, and liquidity amount to mint
-    /// @param isBurn is true if the position is burnt
-    /// @return moved the total amount of liquidity moved from the msg.sender to Uniswap
-    /// @return itmAmounts the amount of tokens swapped due to legs being in-the-money
+    /// @param univ3pool The Uniswap pool
+    /// @param tokenId The option position
+    /// @param leg The leg index that needs to be modified
+    /// @param liquidityChunk The liquidity chunk in Uniswap represented by the leg
+    /// @param isBurn Whether a position is being minted (true) or burned (false)
+    /// @return moved The net amount of funds moved to/from Uniswap
+    /// @return itmAmounts The amount of tokens to swap due to legs being in-the-money
     /// @return collectedSingleLeg LeftRight encoded words containing the amount of token0 and token1 collected as fees
     function _createLegInAMM(
         IUniswapV3Pool univ3pool,
@@ -1041,7 +1038,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         // track how much liquidity we need to collect from uniswap
         // add the fees that accumulated in uniswap within the liquidityChunk:
         {
-            /** if the position is NOT long (selling a put or a call), then _mintLiquidity to move liquidity
+            /* if the position is NOT long (selling a put or a call), then _mintLiquidity to move liquidity
                 from the msg.sender to the uniswap v3 pool:
                 Selling(isLong=0): Mint chunk of liquidity in Uniswap (defined by upper tick, lower tick, and amount)
                        ┌─────────────────────────────────┐
@@ -1100,10 +1097,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         );
     }
 
-    /// @notice caches/stores the accumulated premia values for the specified postion.
-    /// @param positionKey the hashed data which represents the underlying position in the Uniswap pool
-    /// @param currentLiquidity the total amount of liquidity in the AMM for the specific position
-    /// @param collectedAmounts amount of tokens (token0 and token1) collected from Uniswap
+    /// @notice Updates the premium accumulators for a chunk with the latest collected tokens.
+    /// @param positionKey A key representing a liquidity chunk/range in Uniswap
+    /// @param currentLiquidity The total amount of liquidity in the AMM for the specified chunk
+    /// @param collectedAmounts The amount of tokens (token0 and token1) collected from Uniswap
     function _updateStoredPremia(
         bytes32 positionKey,
         LeftRightUnsigned currentLiquidity,
@@ -1126,21 +1123,18 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
             );
     }
 
-    /// @notice Compute the feesGrowth * liquidity / 2**128 by reading feeGrowthInside0LastX128 and feeGrowthInside1LastX128 from univ3pool.positions.
-    /// @param univ3pool the Uniswap pool.
-    /// @param liquidity the total amount of liquidity in the AMM for the specific position
-    /// @param liquidityChunk has lower tick, upper tick, and liquidity amount to mint
-    /// @param roundUp if true, round up the feesBase, otherwise round down
-    /// @dev stored fees base is rounded up and the current fees base is rounded down to minimize the amount of fees collected (Δfeesbase) in favor of the protocol
+    /// @notice Compute an up-to-date feeGrowth value without a poke.
+    /// @dev Stored fees base is rounded up and the current fees base is rounded down to minimize the amount of fees collected (Δfeesbase) in favor of the protocol.
+    /// @param univ3pool The Uniswap pool
+    /// @param liquidity The total amount of liquidity in the AMM for the specific position
+    /// @param liquidityChunk The liquidity chunk in Uniswap to compute the feesBase for
+    /// @param roundUp If true, round up the feesBase, otherwise round down
     function _getFeesBase(
         IUniswapV3Pool univ3pool,
         uint128 liquidity,
         LiquidityChunk liquidityChunk,
         bool roundUp
     ) private view returns (LeftRightSigned feesBase) {
-        // now collect fee growth within the liquidity chunk in `liquidityChunk`
-        // this is the fee accumulated in Uniswap for this chunk of liquidity
-
         // read the latest feeGrowth directly from the Uniswap pool
         (, uint256 feeGrowthInside0LastX128, uint256 feeGrowthInside1LastX128, , ) = univ3pool
             .positions(
@@ -1154,11 +1148,11 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
             );
 
         // (feegrowth * liquidity) / 2 ** 128
-        /// @dev here we're converting the value to an int128 even though all values (feeGrowth, liquidity, Q128) are strictly positive.
-        /// That's because of the way feeGrowthInside works in Uniswap v3, where it can underflow when stored for the first time.
-        /// This is not a problem in Uniswap v3 because the fees are always calculated by taking the difference of the feeGrowths,
-        /// so that the net different is always positive.
-        /// So by using int128 instead of uint128, we remove the need to handle extremely large underflows and simply allow it to be negative
+        // here we're converting the value to an int128 even though all values (feeGrowth, liquidity, Q128) are strictly positive.
+        // That's because of the way feeGrowthInside works in Uniswap v3, where it can underflow when stored for the first time.
+        // This is not a problem in Uniswap v3 because the fees are always calculated by taking the difference of the feeGrowths,
+        // so that the net different is always positive.
+        // So by using int128 instead of uint128, we remove the need to handle extremely large underflows and simply allow it to be negative
         feesBase = roundUp
             ? LeftRightSigned
                 .wrap(0)
@@ -1175,10 +1169,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     }
 
     /// @notice Mint a chunk of liquidity (`liquidityChunk`) in the Uniswap v3 pool; return the amount moved.
-    /// @dev note that "moved" means: mint in Uniswap and move tokens from msg.sender.
-    /// @param liquidityChunk the chunk of liquidity to mint given by tick upper, tick lower, and its size
-    /// @param univ3pool the Uniswap v3 pool to mint liquidity in/to
-    /// @return movedAmounts how many tokens were moved from msg.sender to Uniswap
+    /// @dev Note that "moved" means: mint in Uniswap and move tokens from msg.sender.
+    /// @param liquidityChunk The liquidity chunk in Uniswap to mint
+    /// @param univ3pool The Uniswap v3 pool to mint liquidity in/to
+    /// @return movedAmounts How many tokens were moved from msg.sender to Uniswap
     function _mintLiquidity(
         LiquidityChunk liquidityChunk,
         IUniswapV3Pool univ3pool
@@ -1214,10 +1208,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     }
 
     /// @notice Burn a chunk of liquidity (`liquidityChunk`) in the Uniswap v3 pool and send to msg.sender; return the amount moved.
-    /// @dev note that "moved" means: burn position in Uniswap and send tokens to msg.sender.
-    /// @param liquidityChunk the chunk of liquidity to burn given by tick upper, tick lower, and its size
-    /// @param univ3pool the Uniswap v3 pool to burn liquidity in/from
-    /// @return movedAmounts how many tokens were moved from Uniswap to msg.sender
+    /// @dev Note that "moved" means: burn position in Uniswap and send tokens to msg.sender.
+    /// @param liquidityChunk The liquidity chunk in Uniswap to burn
+    /// @param univ3pool The Uniswap v3 pool to burn liquidity in/from
+    /// @return movedAmounts How many tokens were moved from Uniswap to msg.sender
     function _burnLiquidity(
         LiquidityChunk liquidityChunk,
         IUniswapV3Pool univ3pool
@@ -1242,13 +1236,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     }
 
     /// @notice Helper to collect amounts between msg.sender and Uniswap and also to update the Uniswap fees collected to date from the AMM.
-    /// @param liquidityChunk the liquidity chunk representing the option position/leg
-    /// @param univ3pool the Uniswap pool where the position is deployed
-    /// @param currentLiquidity the existing liquidity msg.sender owns in the AMM for this chunk before the SFPM was called
-    /// @param positionKey the unique key to identify the liquidity chunk/tokenType pairing in this uniswap pool
-    /// @param movedInLeg how much liquidity has been moved between msg.sender and Uniswap before this function call
-    /// @param isLong whether the leg in question is long (=1) or short (=0)
-    /// @return collectedChunk the incoming amount collected with potentially whatever is collected in this function added to it
+    /// @param liquidityChunk The liquidity chunk in Uniswap to collect from
+    /// @param univ3pool The Uniswap pool where the position is deployed
+    /// @param currentLiquidity The existing liquidity msg.sender owns in the AMM for this chunk before the SFPM was called
+    /// @param positionKey The unique key to identify the liquidity chunk/tokenType pairing in this uniswap pool
+    /// @param movedInLeg How much liquidity has been moved between msg.sender and Uniswap before this function call
+    /// @param isLong Whether the leg in question is long (=1) or short (=0)
+    /// @return collectedChunk The amount of tokens collected from Uniswap
     function _collectAndWritePositionData(
         LiquidityChunk liquidityChunk,
         IUniswapV3Pool univ3pool,
@@ -1309,10 +1303,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         }
     }
 
-    /// @notice Function that updates the Owed and Gross account liquidities.
+    /// @notice Compute deltas for Owed/Gross premium given quantities of tokens collected from Uniswap.
     /// @dev Returned accumulators are capped at the max value (2**128 - 1) for each token if they overflow.
-    /// @param currentLiquidity netLiquidity (right) and removedLiquidity (left) at the start of the transaction
-    /// @param collectedAmounts total amount of tokens (token0 and token1) collected from Uniswap.
+    /// @param currentLiquidity NetLiquidity (right) and removedLiquidity (left) at the start of the transaction
+    /// @param collectedAmounts Total amount of tokens (token0 and token1) collected from Uniswap
     /// @return deltaPremiumOwed The extra premium (per liquidity X64) to be added to the owed accumulator for token0 (right) and token1 (left)
     /// @return deltaPremiumGross The extra premium (per liquidity X64) to be added to the gross accumulator for token0 (right) and token1 (left)
     function _getPremiaDeltas(
@@ -1407,11 +1401,11 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
                             SFPM PROPERTIES
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Return the liquidity associated with a given position.
-    /// @dev Computes accountLiquidity[keccak256(abi.encodePacked(univ3pool, owner, tokenType, tickLower, tickUpper))]
+    /// @notice Return the liquidity associated with a given liquidity chunk/tokenType.
+    /// @dev Computes accountLiquidity[keccak256(abi.encodePacked(univ3pool, owner, tokenType, tickLower, tickUpper))].
     /// @param univ3pool The address of the Uniswap v3 Pool
     /// @param owner The address of the account that is queried
-    /// @param tokenType The tokenType of the position (the token it started as)
+    /// @param tokenType The tokenType of the position
     /// @param tickLower The lower end of the tick range for the position (int24)
     /// @param tickUpper The upper end of the tick range for the position (int24)
     /// @return accountLiquidities The amount of liquidity that has been shorted/added to the Uniswap contract (netLiquidity:removedLiquidity -> rightSlot:leftSlot)
@@ -1422,25 +1416,25 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         int24 tickLower,
         int24 tickUpper
     ) external view returns (LeftRightUnsigned accountLiquidities) {
-        /// Extract the account liquidity for a given uniswap pool, owner, token type, and ticks
-        /// @dev tokenType input here is the asset of the positions minted, this avoids put liquidity to be used for call, and vice-versa
+        // Extract the account liquidity for a given uniswap pool, owner, token type, and ticks
+        // tokenType input here is the asset of the positions minted, this avoids put liquidity to be used for call, and vice-versa
         accountLiquidities = s_accountLiquidity[
             keccak256(abi.encodePacked(univ3pool, owner, tokenType, tickLower, tickUpper))
         ];
     }
 
-    /// @notice Return the premium associated with a given position, where Premium is an accumulator of feeGrowth for the touched position.
-    /// @dev Computes s_accountPremium{isLong ? Owed : Gross}[keccak256(abi.encodePacked(univ3pool, owner, tokenType, tickLower, tickUpper))]
-    /// @dev if an atTick parameter is provided that is different from type(int24).max, then it will update the premium up to the current
-    /// @dev block at the provided atTick value. We do this because this may be called immediately after the Uni v3 pool has been touched
-    /// @dev so no need to read the feeGrowths from the Uni v3 pool.
+    /// @notice Return the premium associated with a given position, where premium is an accumulator of feeGrowth for the touched position.
+    /// @dev Computes s_accountPremium{isLong ? Owed : Gross}[keccak256(abi.encodePacked(univ3pool, owner, tokenType, tickLower, tickUpper))].
+    /// @dev If an atTick parameter is provided that is different from type(int24).max, then it will update the premium up to the current
+    /// block at the provided atTick value. We do this because this may be called immediately after the Uni v3 pool has been touched,
+    /// so no need to read the feeGrowths from the Uni v3 pool.
     /// @param univ3pool The address of the Uniswap v3 Pool
     /// @param owner The address of the account that is queried
-    /// @param tokenType The tokenType of the position (the token it started as)
+    /// @param tokenType The tokenType of the position
     /// @param tickLower The lower end of the tick range for the position (int24)
     /// @param tickUpper The upper end of the tick range for the position (int24)
     /// @param atTick The current tick. Set atTick < type(int24).max = 8388608 to get latest premium up to the current block
-    /// @param isLong whether the position is long (=1) or short (=0)
+    /// @param isLong Whether the position is long (=1) or short (=0)
     /// @return premiumToken0 The amount of premium (per liquidity X64) for token0 = sum (feeGrowthLast0X128) over every block where the position has been touched
     /// @return premiumToken1 The amount of premium (per liquidity X64) for token1 = sum (feeGrowthLast0X128) over every block where the position has been touched
     function getAccountPremium(
@@ -1519,9 +1513,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         return (acctPremia.rightSlot(), acctPremia.leftSlot());
     }
 
-    /// @notice Return the feesBase associated with a given position.
-    /// @dev Computes accountFeesBase[keccak256(abi.encodePacked(univ3pool, owner, tickLower, tickUpper))]
-    /// @dev feesBase0 is computed as Math.mulDiv128(feeGrowthInside0X128, legLiquidity)
+    /// @notice Return the feesBase associated with a given liquidity chunk.
+    /// @dev Computes accountFeesBase[keccak256(abi.encodePacked(univ3pool, owner, tickLower, tickUpper))].
     /// @param univ3pool The address of the Uniswap v3 Pool
     /// @param owner The address of the account that is queried
     /// @param tokenType The tokenType of the position (the token it started as)
@@ -1545,8 +1538,6 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     }
 
     /// @notice Returns the Uniswap v3 pool for a given poolId.
-    /// @dev poolId is typically the first 8 bytes of the uni v3 pool address
-    /// @dev But poolId can be different for first 8 bytes if there is a collision between Uni v3 pool addresses
     /// @param poolId The poolId for a Uni v3 pool
     /// @return UniswapV3Pool The unique poolId for that Uni v3 pool
     function getUniswapV3PoolFromId(
@@ -1556,8 +1547,6 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
     }
 
     /// @notice Returns the poolId for a given Uniswap v3 pool.
-    /// @dev poolId is typically the first 8 bytes of the uni v3 pool address
-    /// @dev But poolId can be different for first 8 bytes if there is a collision between Uni v3 pool addresses
     /// @param univ3pool The address of the Uniswap v3 Pool
     /// @return poolId The unique poolId for that Uni v3 pool
     function getPoolId(address univ3pool) external view returns (uint64 poolId) {

--- a/contracts/base/FactoryNFT.sol
+++ b/contracts/base/FactoryNFT.sol
@@ -318,7 +318,7 @@ contract FactoryNFT is MetadataStore, ERC721 {
         }
     }
 
-    /// @notice Get the maximum SVG unit width for the strategy name label in the center for a given rarity (frame)
+    /// @notice Get the maximum SVG unit width for the strategy name label in the center for a given rarity (frame).
     /// @dev This is to ensure the text fits within its section on the frame. There are 6 frames, and each rarity is assigned one of the six.
     /// @param rarity The rarity of the NFT
     /// @return width The maximum SVG unit width for the strategy name label

--- a/contracts/base/MetadataStore.sol
+++ b/contracts/base/MetadataStore.sol
@@ -8,12 +8,12 @@ import {Pointer} from "@types/Pointer.sol";
 /// @notice Base contract that can store two-deep objects with large value sizes at deployment time.
 /// @author Axicon Labs Limited
 contract MetadataStore {
-    /// @notice Stores metadata pointers for future retrieval
-    /// @dev Can hold 2-deep object structures
-    /// @dev Examples include ``{"A": ["B", "C"]}` and ``{"A": {"B": "C"}}`
-    /// @dev The first and second keys can be up-to-32-char strings (or array indices
-    /// @dev Values are pointers to a certain section of contract code: [address, start, length]
-    /// @dev The maximum size of a value is theoretically unlimited, but depends on the effective contract size limit for a given chain
+    /// @notice Stores metadata pointers for future retrieval.
+    /// @dev Can hold 2-deep object structures.
+    /// @dev Examples include `{"A": ["B", "C"]}` and `{"A": {"B": "C"}}`.
+    /// @dev The first and second keys can be up-to-32-char strings (or array indices.
+    /// @dev Values are pointers to a certain section of contract code: [address, start, length].
+    /// @dev The maximum size of a value is theoretically unlimited, but depends on the effective contract size limit for a given chain.
     mapping(bytes32 property => mapping(uint256 index => Pointer pointer)) internal metadata;
 
     /// @notice Stores provided metadata pointers for future retrieval.

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -16,7 +16,7 @@ library Errors {
     error DepositTooLarge();
 
     /// @notice PanopticPool: the effective liquidity (X32) is greater than min(`MAX_SPREAD`, `USER_PROVIDED_THRESHOLD`) during a long mint or short burn
-    /// Effective liquidity measures how much new liquidity is minted relative to how much is already in the pool
+    /// @dev Effective liquidity measures how much new liquidity is minted relative to how much is already in the pool
     error EffectiveLiquidityAboveThreshold();
 
     /// @notice CollateralTracker: attempted to withdraw/redeem more than available liquidity, owned shares, or open positions would allow for
@@ -28,7 +28,7 @@ library Errors {
     /// @notice PanopticPool: the provided list of option positions is incorrect or invalid
     error InputListFail();
 
-    /// @notice PanopticFactory: irst 20 bytes of provided salt does not match caller address
+    /// @notice PanopticFactory: first 20 bytes of provided salt does not match caller address
     error InvalidSalt();
 
     /// @notice Tick is not between `MIN_TICK` and `MAX_TICK`
@@ -38,13 +38,13 @@ library Errors {
     error InvalidNotionalValue();
 
     /// @notice Invalid TokenId parameter detected
-    /// @param parameterType poolId=0, ratio=1, tokenType=2, risk_partner=3 , strike=4, width=5, two identical strike/width/tokenType chunks=6
+    /// @param parameterType poolId=0, ratio=1, tokenType=2, risk_partner=3, strike=4, width=5, two identical strike/width/tokenType chunks=6
     error InvalidTokenIdParameter(uint256 parameterType);
 
     /// @notice A mint or swap callback was attempted from an address that did not match the canonical Uniswap V3 pool with the claimed features
     error InvalidUniswapCallback();
 
-    /// @notice Invalid input in LeftRight library.
+    /// @notice Invalid input in LeftRight library
     error LeftRightInputError();
 
     /// @notice PanopticPool: one of the legs in a position are force-exercisable (they are all either short or ITM long)

--- a/contracts/libraries/FeesCalc.sol
+++ b/contracts/libraries/FeesCalc.sol
@@ -102,7 +102,7 @@ library FeesCalc {
         uint128 liquidity
     ) public view returns (LeftRightSigned) {
         // extract the amount of AMM fees collected within the liquidity chunk`
-        // note: the fee variables are *per unit of liquidity*; so more "rate" variables
+        // NOTE: the fee variables are *per unit of liquidity*; so more "rate" variables
         (
             uint256 ammFeesPerLiqToken0X128,
             uint256 ammFeesPerLiqToken1X128
@@ -125,8 +125,8 @@ library FeesCalc {
     /// @param currentTick The current price tick in the AMM
     /// @param tickLower The lower tick of the option position leg (a liquidity chunk)
     /// @param tickUpper The upper tick of the option position leg (a liquidity chunk)
-    /// @return feeGrowthInside0X128 the fee growth in the AMM of token0
-    /// @return feeGrowthInside1X128 the fee growth in the AMM of token1
+    /// @return feeGrowthInside0X128 The fee growth in the AMM of token0
+    /// @return feeGrowthInside1X128 The fee growth in the AMM of token1
     function _getAMMSwapFeesPerLiquidityCollected(
         IUniswapV3Pool univ3pool,
         int24 currentTick,

--- a/contracts/libraries/InteractionHelper.sol
+++ b/contracts/libraries/InteractionHelper.sol
@@ -14,7 +14,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 /// @title InteractionHelper - contains helper functions for external interactions such as approvals.
 /// @notice Used to delegate logic with multiple external calls.
 /// @dev Generally employed when there is a need to save or reuse bytecode size
-// on a core contract (calls take a significant amount of logic).
+/// on a core contract (calls take a significant amount of logic).
 /// @author Axicon Labs Limited
 library InteractionHelper {
     /// @notice Function that performs approvals on behalf of the PanopticPool for CollateralTracker and SemiFungiblePositionManager.

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -17,13 +17,12 @@ import {TokenId} from "@types/TokenId.sol";
 /// @title Compute general math quantities relevant to Panoptic and AMM pool management.
 /// @author Axicon Labs Limited
 library PanopticMath {
-    // Used for safecasting
     using Math for uint256;
 
     /// @notice This is equivalent to type(uint256).max — used in assembly blocks as a replacement.
     uint256 internal constant MAX_UINT256 = 2 ** 256 - 1;
 
-    /// @notice masks 16-bit tickSpacing out of 64-bit [16-bit tickspacing][48-bit poolPattern] format poolId
+    /// @notice Masks 16-bit tickSpacing out of 64-bit [16-bit tickspacing][48-bit poolPattern] format poolId
     uint64 internal constant TICKSPACING_MASK = 0xFFFF000000000000;
 
     /*//////////////////////////////////////////////////////////////
@@ -31,18 +30,18 @@ library PanopticMath {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Given an address to a Uniswap v3 pool, return its 64-bit ID as used in the `TokenId` of Panoptic.
-    /// @dev Example:
-    ///      the 64 bits are the 48 *last* (most significant) bits - and thus corresponds to the *first* 12 hex characters (reading left to right)
-    ///      of the Uniswap v3 pool address, with the tickSpacing written in the highest 16 bits (i.e, max tickSpacing is 32768)
-    ///      e.g.:
-    ///        univ3pool   = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8
-    ///        tickSpacing = 60
-    ///      the returned id is then:
-    ///        poolPattern = 0x00008ad599c3A0ff
-    ///        tickSpacing = 0x003c000000000000    +
-    ///        --------------------------------------------
-    ///        poolId      = 0x003c8ad599c3A0ff
-    ///
+    // Example:
+    //      the 64 bits are the 48 *last* (most significant) bits - and thus corresponds to the *first* 12 hex characters (reading left to right)
+    //      of the Uniswap v3 pool address, with the tickSpacing written in the highest 16 bits (i.e, max tickSpacing is 32768)
+    //      e.g.:
+    //        univ3pool   = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8
+    //        tickSpacing = 60
+    //      the returned id is then:
+    //        poolPattern = 0x00008ad599c3A0ff
+    //        tickSpacing = 0x003c000000000000    +
+    //        --------------------------------------------
+    //        poolId      = 0x003c8ad599c3A0ff
+    //
     /// @param univ3pool The address of the Uniswap v3 pool to get the ID of
     /// @return A uint64 representing a fingerprint of the uniswap v3 pool address
     function getPoolId(address univ3pool) internal view returns (uint64) {
@@ -59,18 +58,17 @@ library PanopticMath {
     /// @return The provided `poolId` with its pool pattern slot incremented by 1
     function incrementPoolPattern(uint64 poolId) internal pure returns (uint64) {
         unchecked {
-            // increment
             return (poolId & TICKSPACING_MASK) + (uint48(poolId) + 1);
         }
     }
 
     /// @notice Get the number of leading hex characters in an address.
-    ///     0x0000bababaab...     0xababababab...
-    ///          ▲                 ▲
-    ///          │                 │
-    ///     4 leading hex      0 leading hex
-    ///    character zeros    character zeros
-    ///
+    //     0x0000bababaab...     0xababababab...
+    //          ▲                 ▲
+    //          │                 │
+    //     4 leading hex      0 leading hex
+    //    character zeros    character zeros
+    //
     /// @param addr The address to get the number of leading zero hex characters for
     /// @return The number of leading zero hex characters in the address
     function numberOfLeadingHexZeros(address addr) external pure returns (uint256) {
@@ -135,7 +133,7 @@ library PanopticMath {
     /// @param univ3pool The Uniswap pool to get the median observation from
     /// @param observationIndex The index of the last observation in the pool
     /// @param observationCardinality The number of observations in the pool
-    /// @param cardinality The number of `periods` to in the median price array, should be odd.
+    /// @param cardinality The number of `periods` to in the median price array, should be odd
     /// @param period The number of observations to average to compute one entry in the median price array
     /// @return The median of `cardinality` observations spaced by `period` in the Uniswap pool
     function computeMedianObservedPrice(
@@ -167,7 +165,7 @@ library PanopticMath {
                     int256(timestamps[i] - timestamps[i + 1]);
             }
 
-            // get the median of the 3 calculated ticks
+            // get the median of the `ticks` array (assuming `cardinality` is odd)
             return int24(Math.sort(ticks)[cardinality / 2]);
         }
     }
@@ -251,9 +249,9 @@ library PanopticMath {
     /// @notice Computes the twap of a Uniswap V3 pool using data from its oracle.
     /// @dev Note that our definition of TWAP differs from a typical mean of prices over a time window.
     /// @dev We instead observe the average price over a series of time intervals, and define the TWAP as the median of those averages.
-    /// @param univ3pool The Uniswap pool from which to compute the TWAP.
-    /// @param twapWindow The time window to compute the TWAP over.
-    /// @return The final calculated TWAP tick.
+    /// @param univ3pool The Uniswap pool from which to compute the TWAP
+    /// @param twapWindow The time window to compute the TWAP over
+    /// @return The final calculated TWAP tick
     function twapFilter(IUniswapV3Pool univ3pool, uint32 twapWindow) external view returns (int24) {
         uint32[] memory secondsAgos = new uint32[](20);
 
@@ -279,7 +277,7 @@ library PanopticMath {
             int256[] memory sortedTicks = Math.sort(twapMeasurement);
 
             // Get the median value
-            return int24(sortedTicks[10]);
+            return int24(sortedTicks[9]);
         }
     }
 
@@ -289,15 +287,15 @@ library PanopticMath {
 
     /// @notice For a given option position (`tokenId`), leg index within that position (`legIndex`), and `positionSize` get the tick range spanned and its
     /// liquidity (share ownership) in the Univ3 pool; this is a liquidity chunk.
-    ///          Liquidity chunk  (defined by tick upper, tick lower, and its size/amount: the liquidity)
-    ///   liquidity    │
-    ///         ▲      │
-    ///         │     ┌▼┐
-    ///         │  ┌──┴─┴──┐
-    ///         │  │       │
-    ///         │  │       │
-    ///         └──┴───────┴────► price
-    ///         Uniswap v3 Pool
+    //          Liquidity chunk  (defined by tick upper, tick lower, and its size/amount: the liquidity)
+    //   liquidity    │
+    //         ▲      │
+    //         │     ┌▼┐
+    //         │  ┌──┴─┴──┐
+    //         │  │       │
+    //         │  │       │
+    //         └──┴───────┴────► price
+    //         Uniswap v3 Pool
     /// @param tokenId The option position id
     /// @param legIndex The leg index of the option position, can be {0,1,2,3}
     /// @param positionSize The number of contracts held by this leg
@@ -380,8 +378,8 @@ library PanopticMath {
 
     /// @notice Returns the distances of the upper and lower ticks from the strike for a position with the given width and tickSpacing.
     /// @dev Given `r = (width * tickSpacing) / 2`, `tickLower = strike - floor(r)` and `tickUpper = strike + ceil(r)`.
-    /// @param width The width of the leg.
-    /// @param tickSpacing The tick spacing of the underlying pool.
+    /// @param width The width of the leg
+    /// @param tickSpacing The tick spacing of the underlying pool
     /// @return The lower tick of the range
     /// @return The upper tick of the range
     function getRangesFromStrike(
@@ -401,8 +399,8 @@ library PanopticMath {
     /// @notice Compute the amount of funds that are underlying this option position. This is useful when exercising a position.
     /// @param tokenId The option position id
     /// @param positionSize The number of contracts of this option
-    /// @return longAmounts Left-right packed word where the right contains the total contract size and the left total notional
-    /// @return shortAmounts Left-right packed word where the right contains the total contract size and the left total notional
+    /// @return longAmounts Left-right packed word where rightSlot = token0 and leftSlot = token1 held against borrowed Uniswap liquidity for long legs
+    /// @return shortAmounts Left-right packed word where where rightSlot = token0 and leftSlot = token1 borrowed to create short legs
     function computeExercisedAmounts(
         TokenId tokenId,
         uint128 positionSize
@@ -469,7 +467,7 @@ library PanopticMath {
     }
 
     /// @notice Convert an amount of token0 into an amount of token1 given the sqrtPriceX96 in a Uniswap pool defined as sqrt(1/0)*2^96.
-    /// @dev Uses reduced precision after tick 443636 in order to accomodate the full range of tick.s
+    /// @dev Uses reduced precision after tick 443636 in order to accomodate the full range of ticks
     /// @param amount The amount of token0 to convert into token1
     /// @param sqrtPriceX96 The square root of the price at which to convert `amount` of token0 into token1
     /// @return The converted `amount` of token0 represented in terms of token1
@@ -901,7 +899,7 @@ library PanopticMath {
     /// @param atTick Tick to convert values at. This can be the current tick or some TWAP/median tick
     /// @param collateral0 CollateralTracker for token0
     /// @param collateral1 CollateralTracker for token1
-    /// @return The LeftRight-packed amount of token0/token1 to refund to the user.
+    /// @return The LeftRight-packed amount of token0/token1 to refund to the user
     function getRefundAmounts(
         address refunder,
         LeftRightSigned refundValues,

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -910,7 +910,7 @@ library PanopticMath {
         uint160 sqrtPriceX96 = Math.getSqrtRatioAtTick(atTick);
         unchecked {
             // if the refunder lacks sufficient token0 to pay back the refundee, have them pay back the equivalent value in token1
-            // note: it is possible for refunds to be negative when the exercise fee is higher than the delegated amounts. This is expected behavior
+            // NOTE: it is possible for refunds to be negative when the exercise fee is higher than the delegated amounts. This is expected behavior
             int256 balanceShortage = refundValues.rightSlot() -
                 int256(collateral0.convertToAssets(collateral0.balanceOf(refunder)));
 

--- a/contracts/tokens/ERC1155Minimal.sol
+++ b/contracts/tokens/ERC1155Minimal.sol
@@ -171,7 +171,7 @@ abstract contract ERC1155 {
     }
 
     /// @notice Query balances for multiple users and tokens at once.
-    /// @dev `owners` and `ids` should be of equal length
+    /// @dev `owners` and `ids` should be of equal length.
     /// @param owners The list of users to query balances for
     /// @param ids The list of ERC1155 token ids to query
     /// @return balances The balances for each owner-id pair in the same order as the input arrays

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -15,18 +15,17 @@ using LeftRightLibrary for LeftRightSigned global;
 /// @author Axicon Labs Limited
 /// @notice Simple data type that divides a 256-bit word into two 128-bit slots.
 library LeftRightLibrary {
-    // Used for safecasting
     using Math for uint256;
 
-    /// @notice AND bitmask to isolate the right half of a uint256
+    /// @notice AND bitmask to isolate the left half of a uint256.
     uint256 internal constant LEFT_HALF_BIT_MASK =
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000;
 
-    /// @notice AND bitmask to isolate the left half of an int256
+    /// @notice AND bitmask to isolate the left half of an int256.
     int256 internal constant LEFT_HALF_BIT_MASK_INT =
         int256(uint256(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000));
 
-    /// @notice AND bitmask to isolate the left half of an int256
+    /// @notice AND bitmask to isolate the right half of an int256.
     int256 internal constant RIGHT_HALF_BIT_MASK = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/types/LiquidityChunk.sol
+++ b/contracts/types/LiquidityChunk.sol
@@ -11,7 +11,7 @@ using LiquidityChunkLibrary for LiquidityChunk global;
 /// @author Axicon Labs Limited
 ///
 /// @notice A liquidity chunk is an amount of `liquidity` (an amount of WETH, e.g.) deployed between two ticks: `tickLower` and `tickUpper`
-/// into a concentrated liquidity AMM .
+/// into a concentrated liquidity AMM.
 //
 //                liquidity
 //                    ▲      liquidity chunk
@@ -50,11 +50,11 @@ using LiquidityChunkLibrary for LiquidityChunk global;
 //        <--- most significant bit        least significant bit --->
 //
 library LiquidityChunkLibrary {
-    /// @notice AND mask to strip the `tickLower` value from a packed LiquidityChunk
+    /// @notice AND mask to strip the `tickLower` value from a packed LiquidityChunk.
     uint256 internal constant CLEAR_TL_MASK =
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
-    /// @notice AND mask to strip the `tickUpper` value from a packed LiquidityChunk
+    /// @notice AND mask to strip the `tickUpper` value from a packed LiquidityChunk.
     uint256 internal constant CLEAR_TU_MASK =
         0xFFFFFF000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -58,23 +58,23 @@ using TokenIdLibrary for TokenId global;
 //  - the Uniswap v3 pool id starts at bit index 0 and ends at bit index 63 (and thus takes up 64 bits).
 //  - the width of the 3rd leg in this option position starts at bit index 64+36+48*2=196
 library TokenIdLibrary {
-    /// @notice AND mask to extract all `isLong` bits for each leg from a TokenId
+    /// @notice AND mask to extract all `isLong` bits for each leg from a TokenId.
     uint256 internal constant LONG_MASK =
         0x100_000000000100_000000000100_000000000100_0000000000000000;
 
-    /// @notice AND mask to clear `poolId` from a TokenId
+    /// @notice AND mask to clear `poolId` from a TokenId.
     uint256 internal constant CLEAR_POOLID_MASK =
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF_0000000000000000;
 
-    /// @notice AND mask to clear all bits except for the option ratios of the legs
+    /// @notice AND mask to clear all bits except for the option ratios of the legs.
     uint256 internal constant OPTION_RATIO_MASK =
         0x0000000000FE_0000000000FE_0000000000FE_0000000000FE_0000000000000000;
 
-    /// @notice AND mask to clear all bits except for the components of the chunk key (strike, width, tokenType) for each leg
+    /// @notice AND mask to clear all bits except for the components of the chunk key (strike, width, tokenType) for each leg.
     uint256 internal constant CHUNK_MASK =
         0xFFFFFFFFF200_FFFFFFFFF200_FFFFFFFFF200_FFFFFFFFF200_0000000000000000;
 
-    /// @notice AND mask to cut a sign-extended int256 back to an int24
+    /// @notice AND mask to cut a sign-extended int256 back to an int24.
     int256 internal constant BITMASK_INT24 = 0xFFFFFF;
 
     /*//////////////////////////////////////////////////////////////
@@ -189,7 +189,7 @@ library TokenIdLibrary {
     /// @notice Add the `tickSpacing` to the PoolID for `self`.
     /// @param self The TokenId to add `_tickSpacing` to
     /// @param _tickSpacing The tickSpacing to add to `self`
-    /// @return `self` with `_tickSpacing` added to the TickSpacing slot in the PoolID.
+    /// @return `self` with `_tickSpacing` added to the TickSpacing slot in the PoolID
     function addTickSpacing(TokenId self, int24 _tickSpacing) internal pure returns (TokenId) {
         unchecked {
             return TokenId.wrap(TokenId.unwrap(self) + (uint256(uint24(_tickSpacing)) << 48));
@@ -323,7 +323,7 @@ library TokenIdLibrary {
     }
 
     /// @notice Add a leg to a TokenId.
-    /// @param self The tokenId in the SFPM representing an option position.
+    /// @param self The tokenId in the SFPM representing an option position
     /// @param legIndex The leg index of this position (in {0,1,2,3}) to add
     /// @param _optionRatio The relative size of the leg
     /// @param _asset The asset of the leg
@@ -400,7 +400,7 @@ library TokenIdLibrary {
     /// @notice Get the number of longs in this option position.
     /// @notice Count the number of legs (out of a maximum of 4) that are long positions.
     /// @param self The TokenId to count longs for
-    /// @return The number of long positions in `self` (in the range {0,...,4}).
+    /// @return The number of long positions in `self` (in the range {0,...,4})
     function countLongs(TokenId self) internal pure returns (uint256) {
         unchecked {
             return self.isLong(0) + self.isLong(1) + self.isLong(2) + self.isLong(3);
@@ -450,7 +450,7 @@ library TokenIdLibrary {
 
     /// @notice Clear a leg in an option position with index `i`.
     /// @dev set bits of the leg to zero. Also sets the optionRatio and asset to zero of that leg.
-    /// @dev NOTE it's important that the caller fills in the leg details after.
+    /// @dev NOTE: it's important that the caller fills in the leg details after.
     //  - optionRatio is zeroed
     //  - asset is zeroed
     //  - width is zeroed

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -660,7 +660,7 @@ contract PanopticMathTest is Test, PositionUtils {
         int256[] memory sortedTicks = Math.sort(twapMeasurement);
 
         // Get the median value
-        int256 twapTick = sortedTicks[10];
+        int256 twapTick = sortedTicks[9];
 
         assertEq(twapTick, harness.twapFilter(selectedPool, twapWindow));
     }


### PR DESCRIPTION
This *should* be the last change before we start the C4 audit. Includes:
- `twapFilter` should return the *actual* median and not the 10th index
- NatSpec formatting should be based on what we want the md-docs to look like -- can be previewed with `forge doc`
- fixes for other significant errors/anachronisms in our documentation/comments

The first point is the only logical change, so review that and also let me know if there's any egregious documentation errors I missed that stick out. I'm sending out the diff today, but we have until Tuesday to make last-minute changes if absolutely necessary.

If anyone wants to review the overall [diff](https://github.com/panoptic-labs/panoptic-v1-core-private/compare/f59ed0f71d70729fb4331de336bc7cdca91abffe..feat/mit-review-diff) between the version that went out to C4 and this commit, I have a gist with a preliminary version of the [audit report](https://gist.github.com/dyedm1/49389c9e94754a5df213d410609eb3cd) to reference.