### PR TITLE
Lower max utilization from `90%` to `X%`

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -160,7 +160,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @dev The maximum allowed ratio for a single chunk, defined as: removedLiquidity / netLiquidity
     /// The long premium spread multiplier that corresponds with the MAX_SPREAD value depends on VEGOID,
     /// which can be explored in this calculator: https://www.desmos.com/calculator/mdeqob2m04
-    uint64 internal constant MAX_SPREAD = 9 * (2 ** 32);
+    uint64 internal constant MAX_SPREAD = 4 * (2 ** 32);
 
     /// @dev The maximum allowed number of opened positions
     uint64 internal constant MAX_POSITIONS = 32;


### PR DESCRIPTION
This is a draft pull request, the proposed change is very minimal (one parameter), but more research may be needed to identify the best parameter.

### SETUP
The way Panoptic works is by allowing anyone to sell options by depositing liquidity in Uniswap v3 through the Panoptic smart contracts. Once an options has been sold, it will start earning a streaming premium (“streamia”) that is equal to the amount of fees collected by that position in the Uniswap pool.

If another user wants to buy that option, they can “short” or remove part of that liquidity from Uniswap v4 and put it back at a later time. The streamia paid by the buyer is going to be equal to the amount of fees that would have been collected by that position in Uniswap v3 _plus a spread term_. That spread term is given by

`Spread = nu * removedLiquidity / (totalLiquidity - removedLiquidity)`

Correspondingly, the seller will also receive an extra amount of streamia. The extra amount received by the seller is

`extra revenue = nu * removedLiquidity^2 / (totalLiquidity * (totalLiquidity - removedLiquidity))`


### PROBLEM
: There could be a scenario where a seller could look at the amount removedLiquidity and decrease their position size so that the spread multiplier increases their overall revenue _even though their position size is smaller_

Basically, we want to solve for the amount of removedLiquidity for which this expression is true (assuming 90% is the maximum strike utilization):

![image](https://github.com/panoptic-labs/panoptic-v1-core-private/assets/83659385/9ff2e6d4-8210-4e80-b0a6-dccb4d888956)

Solving for this, we find that if the amount of `removedLiquidity` is initially larger than 30.7% of the amount of options sold, then it is profitable (and the optimal strategy) to reduce the size of the seller’s position to just 1.1 times the amount of options purchased. 

In other words, the seller could reduce their size by close to 3x and earn the same amount of streamia due to the 3.25x spread multiplier (ie. same reward, 3x smaller risk). **That might be a problem.**

This figure shows the region in red where it is optimal to reduce the position size to 90% strike utilization given a strike utilization limit (in this case 90%):

![image](https://github.com/panoptic-labs/panoptic-v1-core-private/assets/83659385/bf887c9a-938d-4dbc-a0e9-28e055f5e0a6)

### SOLUTION

We may consider changing the max utilization to below the current value of 90%. Looking at different values, we obtain

* limit = 90% → removedLiquidity > 30%
* limit = 85% → removedLiquidity > 42%
* limit = 80% → removedLiquidity > 50%
* limit = 75% → removedLiquidity > 57% 
* limit = 66% → removedLiquidity > 67%  (never attainable)


A 80% max strike utilization seems reasonable. That would lead to a max spread of exactly 2x, and it would somewhat echo the 20% collateral requirement for selling options.

It does not get rid of the "automatically reduce size" window, but it does reduce it somewhat: 

![image](https://github.com/panoptic-labs/panoptic-v1-core-private/assets/83659385/6859fac2-7187-4ce2-aeb3-728c4328a8ab)

