### PR TITLE
[Draft] Hardened solvency checks

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1425,6 +1425,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         // position is in-the-money, collateral requirement = amountMoved*(1-SRC)*(scaleFactor-ratio)/(scaleFactor+1) + SCR*amountMoved
                         required += c3;
                     }
+                    // cannot require more than the notional value of that position
+                    required = Math.max(required, amountMoved);
                 }
             }
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1010,12 +1010,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
+    /// @param safeMode whether to mandate 100% collateralization
     /// @return utilization The final utilization of the collateral vault
     function takeCommissionAddData(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount
+        int128 swappedAmount,
+        bool safeMode
     ) external onlyPanopticPool returns (int256 utilization) {
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
@@ -1047,7 +1049,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_poolAssets = uint128(uint256(updatedAssets));
             s_inAMM = uint128(uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)));
 
-            utilization = _poolUtilization();
+            utilization = safeMode ? DECIMALS_128 : _poolUtilization();
         }
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1426,7 +1426,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         required += c3;
                     }
                     // cannot require more than the notional value of that position
-                    required = Math.max(required, amountMoved);
+                    required = Math.min(required, amountMoved);
                 }
             }
         }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1074,7 +1074,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         int256 liquidationBonus0;
         int256 liquidationBonus1;
-        int24 finalTick;
         {
             LeftRightSigned netExchanged;
             LeftRightSigned[4][] memory premiasByLeg;
@@ -1091,8 +1090,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 positionIdList
             );
 
-            (, finalTick, , , , , ) = s_univ3pool.slot0();
-
             LeftRightSigned collateralRemaining;
             // compute bonus amounts using latest tick data
             (liquidationBonus0, liquidationBonus1, collateralRemaining) = PanopticMath
@@ -1100,7 +1097,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     tokenData0,
                     tokenData1,
                     Math.getSqrtRatioAtTick(twapTick),
-                    Math.getSqrtRatioAtTick(finalTick),
+                    Math.getSqrtRatioAtTick(currentTick),
                     netExchanged,
                     premia
                 );
@@ -1116,7 +1113,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
             // reusing variables to save stack space; netExchanged = deltaBonus0, premia = deltaBonus1
             address _liquidatee = liquidatee;
             TokenId[] memory _positionIdList = positionIdList;
-            int24 _finalTick = finalTick;
             int256 deltaBonus0;
             int256 deltaBonus1;
             (deltaBonus0, deltaBonus1) = PanopticMath.haircutPremia(
@@ -1126,7 +1122,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 collateralRemaining,
                 s_collateralToken0,
                 s_collateralToken1,
-                Math.getSqrtRatioAtTick(_finalTick),
+                Math.getSqrtRatioAtTick(currentTick),
                 s_settledTokens
             );
 
@@ -1156,8 +1152,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
             !_checkSolvencyAtTick(
                 msg.sender,
                 positionIdListLiquidator,
-                finalTick,
-                finalTick,
+                currentTick,
+                currentTick,
                 BP_DECREASE_BUFFER
             )
         ) revert Errors.NotEnoughCollateral();

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1307,6 +1307,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
         return _checkCrossBalances(account, atTick, positionBalanceArray, portfolioPremium, buffer);
     }
 
+    /// @notice Check whether a the balances of an account is solvent at a given `atTick` with a collateral requirement of `buffer`/10_000 multiplied by the requirement of `positionBalanceArray`.
+    /// @param account The account to check solvency for
+    /// @param atTick The tick to check solvency at
+    /// @param positionBalanceArray A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
+    /// @param portfolioPremium The computed premia of the user's positions, where premia contains the accumulated premia for token0 in the right slot and for token1 in the left slot
+    /// @param buffer The buffer to apply to the collateral requirement
+    /// @return Whether the account is solvent at the given tick
     function _checkCrossBalances(
         address account,
         int24 atTick,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -654,6 +654,22 @@ contract PanopticPool is ERC1155Holder, Multicall {
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (uint128) {
+        // check if the price has deviated too much recently.
+        {
+            (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
+            uint256 medianData = s_miniMedian;
+            int24 medianTick = (int24(
+                uint24(medianData >> ((uint24(medianData >> (192 + 3 * 3)) % 8) * 24))
+            ) + int24(uint24(medianData >> ((uint24(medianData >> (192 + 3 * 4)) % 8) * 24)))) / 2;
+
+            // If ticks have recently deviated more than +/- 20%, enforce covered mints
+            if (Math.abs(currentTick - medianTick) > MAX_SLOW_FAST_DELTA) {
+                if (tickLimitLow > tickLimitHigh) {
+                    (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
+                }
+            }
+        }
+
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -654,22 +654,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (uint128) {
-        bool safeMode;
-        // check if the price has deviated too much recently.
-        {
-            (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-            uint256 medianData = s_miniMedian;
-            int24 medianTick = (int24(
-                uint24(medianData >> ((uint24(medianData >> (192 + 3 * 3)) % 8) * 24))
-            ) + int24(uint24(medianData >> ((uint24(medianData >> (192 + 3 * 4)) % 8) * 24)))) / 2;
-
-            // If ticks have recently deviated more than +/- 20%, enforce covered mints
-            if (Math.abs(currentTick - medianTick) > MAX_SLOW_FAST_DELTA) {
-                safeMode = true;
-                if (tickLimitLow > tickLimitHigh) {
-                    (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
-                }
-            }
+        bool safeMode = isSafeMode();
+        // if safeMode, enforce covered deployment
+        if (safeMode && (tickLimitLow > tickLimitHigh)) {
+            (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
         }
 
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
@@ -978,6 +966,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
             LeftRightSigned paidAmounts
         )
     {
+        {
+            bool safeMode = isSafeMode();
+            // if safeMode, enforce covered at assignment
+            if (safeMode && (tickLimitLow > tickLimitHigh)) {
+                (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
+            }
+        }
+
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .burnTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
@@ -1071,6 +1067,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // Perform the specified delegation from `msg.sender` to `liquidatee`
         // Works like a transfer, so the liquidator must possess all the tokens they are delegating, resulting in no net supply change
         // If not enough tokens are delegated for the positions of `liquidatee` to be closed, the liquidation will fail
+        // TODO: since all options are closed using the covered flag, we could compute the delegation amounts directly here.
         s_collateralToken0.delegate(msg.sender, liquidatee, delegations.rightSlot());
         s_collateralToken1.delegate(msg.sender, liquidatee, delegations.leftSlot());
 
@@ -1365,6 +1362,24 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 Math.mulDivRoundingUp(uint256(tokenData1.leftSlot()), 2 ** 96, sqrtPriceX96) +
                 Math.mulDiv96RoundingUp(tokenData0.leftSlot(), sqrtPriceX96);
         }
+    }
+
+    /// @notice Checks whether the current tick has deviated too much from the slow oracle media tick
+    /// @return safeMode a boolean flag, triggers safe more when true where all newly minted positions must be fully collateralized
+    function isSafeMode() internal returns (bool safeMode) {
+        // check if the price has deviated too much recently.
+        (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
+        uint256 medianData = s_miniMedian;
+        int24 medianTick = (int24(
+            uint24(medianData >> ((uint24(medianData >> (192 + 3 * 3)) % 8) * 24))
+        ) + int24(uint24(medianData >> ((uint24(medianData >> (192 + 3 * 4)) % 8) * 24)))) / 2;
+
+        // If ticks have recently deviated more than +/- 20%, enforce covered mints
+        if (Math.abs(currentTick - medianTick) > MAX_SLOW_FAST_DELTA) {
+            safeMode = true;
+        }
+
+        return (safeMode);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -654,6 +654,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (uint128) {
+        bool safeMode;
         // check if the price has deviated too much recently.
         {
             (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
@@ -664,6 +665,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
             // If ticks have recently deviated more than +/- 20%, enforce covered mints
             if (Math.abs(currentTick - medianTick) > MAX_SLOW_FAST_DELTA) {
+                safeMode = true;
                 if (tickLimitLow > tickLimitHigh) {
                     (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
                 }
@@ -675,7 +677,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         _updateSettlementPostMint(tokenId, collectedByLeg, positionSize);
 
-        uint128 poolUtilizations = _payCommissionAndWriteData(tokenId, positionSize, totalSwapped);
+        uint128 poolUtilizations = _payCommissionAndWriteData(
+            tokenId,
+            positionSize,
+            totalSwapped,
+            safeMode
+        );
 
         return poolUtilizations;
     }
@@ -684,13 +691,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tokenId The option position
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param totalSwapped The amount of tokens moved during creation of the option position
+    /// @param safeMode whether to mandate 100% collateralization
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as (inAMM * 10_000) / totalAssets()
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
-        LeftRightSigned totalSwapped
+        LeftRightSigned totalSwapped,
+        bool safeMode
     ) internal returns (uint128) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
@@ -700,13 +709,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
             msg.sender,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
-            totalSwapped.rightSlot()
+            totalSwapped.rightSlot(),
+            safeMode
         );
         int256 utilization1 = s_collateralToken1.takeCommissionAddData(
             msg.sender,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
-            totalSwapped.leftSlot()
+            totalSwapped.leftSlot(),
+            safeMode
         );
 
         // return pool utilizations as a uint128 (pool Utilization is always < 10000)

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1049,14 +1049,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 currentTick
             );
 
-            if (!_checkCrossBalances(liquidatee, twapTick, positionBalanceArray, premia, NO_BUFFER))
+            if (_checkCrossBalances(liquidatee, twapTick, positionBalanceArray, premia, NO_BUFFER))
                 revert Errors.NotMarginCalled();
 
             // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
             // check with currentTick as well, do conservative collateral checks if outside
             if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
                 if (
-                    !_checkCrossBalances(
+                    _checkCrossBalances(
                         liquidatee,
                         currentTick,
                         positionBalanceArray,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1394,19 +1394,20 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
     /// @notice Checks whether the current tick has deviated too much from the slow oracle media tick
     /// @return safeMode a boolean flag, triggers safe more when true where all newly minted positions must be fully collateralized
-    function isSafeMode() internal returns (bool safeMode) {
+    function isSafeMode() internal view returns (bool safeMode) {
         // check if the price has deviated too much recently.
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-        uint256 medianData = s_miniMedian;
-        int24 medianTick = (int24(
-            uint24(medianData >> ((uint24(medianData >> (192 + 3 * 3)) % 8) * 24))
-        ) + int24(uint24(medianData >> ((uint24(medianData >> (192 + 3 * 4)) % 8) * 24)))) / 2;
+        unchecked {
+            uint256 medianData = s_miniMedian;
+            int24 medianTick = (int24(
+                uint24(medianData >> ((uint24(medianData >> (192 + 3 * 3)) % 8) * 24))
+            ) + int24(uint24(medianData >> ((uint24(medianData >> (192 + 3 * 4)) % 8) * 24)))) / 2;
 
-        // If ticks have recently deviated more than +/- 20%, enforce covered mints
-        if (Math.abs(currentTick - medianTick) > MAX_SLOW_FAST_DELTA) {
-            safeMode = true;
+            // If ticks have recently deviated more than +/- 20%, enforce covered mints
+            if (Math.abs(currentTick - medianTick) > MAX_SLOW_FAST_DELTA) {
+                safeMode = true;
+            }
         }
-
         return (safeMode);
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -872,17 +872,61 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // check that the provided positionIdList matches the positions in memory
         _validatePositionList(user, positionIdList, 0);
 
-        IUniswapV3Pool _univ3pool = s_univ3pool;
         (
-            ,
             int24 currentTick,
-            uint16 observationIndex,
-            uint16 observationCardinality,
-            ,
-            ,
+            int24 fastOracleTick,
+            int24 slowOracleTick,
+            uint256 _medianData
+        ) = _getOracleTicks();
 
-        ) = _univ3pool.slot0();
-        int24 fastOracleTick = PanopticMath.computeMedianObservedPrice(
+        medianData = _medianData;
+
+        uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
+        LeftRightSigned premia;
+        {
+            (premia, positionBalanceArray) = _calculateAccumulatedPremia(
+                user,
+                positionIdList,
+                COMPUTE_ALL_PREMIA,
+                ONLY_AVAILABLE_PREMIUM,
+                currentTick
+            );
+
+            bool solventAtFast = _checkCrossBalances(
+                user,
+                fastOracleTick,
+                positionBalanceArray,
+                premia,
+                buffer
+            );
+            if (!solventAtFast) revert Errors.NotEnoughCollateral();
+        }
+        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
+        // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
+        if (
+            Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA ||
+            Math.abs(int256(fastOracleTick) - currentTick) > MAX_SLOW_FAST_DELTA ||
+            Math.abs(currentTick - slowOracleTick) > MAX_SLOW_FAST_DELTA
+        )
+            if (
+                !_checkCrossBalances(user, currentTick, positionBalanceArray, premia, buffer) ||
+                !_checkCrossBalances(user, slowOracleTick, positionBalanceArray, premia, buffer) ||
+                !_checkCrossBalances(user, fastOracleTick, positionBalanceArray, premia, buffer)
+            ) revert Errors.NotEnoughCollateral();
+    }
+
+    function _getOracleTicks()
+        internal
+        view
+        returns (int24 currentTick, int24 fastOracleTick, int24 slowOracleTick, uint256 medianData)
+    {
+        IUniswapV3Pool _univ3pool = s_univ3pool;
+        uint16 observationIndex;
+        uint16 observationCardinality;
+
+        (, currentTick, observationIndex, observationCardinality, , , ) = _univ3pool.slot0();
+
+        fastOracleTick = PanopticMath.computeMedianObservedPrice(
             _univ3pool,
             observationIndex,
             observationCardinality,
@@ -890,7 +934,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
             FAST_ORACLE_PERIOD
         );
 
-        int24 slowOracleTick;
         if (SLOW_ORACLE_UNISWAP_MODE) {
             slowOracleTick = PanopticMath.computeMedianObservedPrice(
                 _univ3pool,
@@ -908,38 +951,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 _univ3pool
             );
         }
-
-        uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
-        LeftRightSigned premia;
-        (premia, positionBalanceArray) = _calculateAccumulatedPremia(
-            user,
-            positionIdList,
-            COMPUTE_ALL_PREMIA,
-            ONLY_AVAILABLE_PREMIUM,
-            currentTick
-        );
-
-        bool solventAtFast = _checkCrossBalances(
-            user,
-            fastOracleTick,
-            positionBalanceArray,
-            premia,
-            buffer
-        );
-        if (!solventAtFast) revert Errors.NotEnoughCollateral();
-
-        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
-        // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
-        if (
-            Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA ||
-            Math.abs(int256(fastOracleTick) - currentTick) > MAX_SLOW_FAST_DELTA ||
-            Math.abs(currentTick - slowOracleTick) > MAX_SLOW_FAST_DELTA
-        )
-            if (
-                !_checkCrossBalances(user, currentTick, positionBalanceArray, premia, buffer) ||
-                !_checkCrossBalances(user, slowOracleTick, positionBalanceArray, premia, buffer) ||
-                !_checkCrossBalances(user, fastOracleTick, positionBalanceArray, premia, buffer)
-            ) revert Errors.NotEnoughCollateral();
     }
 
     /// @notice Burns and handles the exercise of options.
@@ -1049,7 +1060,20 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 currentTick
             );
 
-            if (_checkCrossBalances(liquidatee, twapTick, positionBalanceArray, premia, NO_BUFFER))
+            tokenData0 = s_collateralToken0.getAccountMarginDetails(
+                liquidatee,
+                twapTick,
+                positionBalanceArray,
+                premia.rightSlot()
+            );
+            tokenData1 = s_collateralToken1.getAccountMarginDetails(
+                liquidatee,
+                twapTick,
+                positionBalanceArray,
+                premia.leftSlot()
+            );
+
+            if (_checkSolvencyCross(tokenData0, tokenData1, twapTick, NO_BUFFER))
                 revert Errors.NotMarginCalled();
 
             // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
@@ -1333,6 +1357,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
             portfolioPremium.leftSlot()
         );
 
+        return _checkSolvencyCross(tokenData0, tokenData1, atTick, buffer);
+    }
+
+    function _checkSolvencyCross(
+        LeftRightUnsigned tokenData0,
+        LeftRightUnsigned tokenData1,
+        int24 atTick,
+        uint256 buffer
+    ) internal view returns (bool) {
         (uint256 balanceCross, uint256 thresholdCross) = _getSolvencyBalances(
             tokenData0,
             tokenData1,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1036,8 +1036,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
         LeftRightSigned premia;
+        int24 currentTick;
         {
-            (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
+            (, currentTick, , , , , ) = s_univ3pool.slot0();
 
             uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
             (premia, positionBalanceArray) = _calculateAccumulatedPremia(
@@ -1112,6 +1113,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             // if premium is haircut from a token that is not in protocol loss, some of the liquidation bonus will be converted into that token
             // reusing variables to save stack space; netExchanged = deltaBonus0, premia = deltaBonus1
             address _liquidatee = liquidatee;
+            int24 _currentTick = currentTick;
             TokenId[] memory _positionIdList = positionIdList;
             int256 deltaBonus0;
             int256 deltaBonus1;
@@ -1122,7 +1124,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 collateralRemaining,
                 s_collateralToken0,
                 s_collateralToken1,
-                Math.getSqrtRatioAtTick(currentTick),
+                Math.getSqrtRatioAtTick(_currentTick),
                 s_settledTokens
             );
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -937,7 +937,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         )
             if (
                 !_checkCrossBalances(user, currentTick, positionBalanceArray, premia, buffer) ||
-                !_checkCrossBalances(user, slowOracleTick, positionBalanceArray, premia, buffer)
+                !_checkCrossBalances(user, slowOracleTick, positionBalanceArray, premia, buffer) ||
+                !_checkCrossBalances(user, fastOracleTick, positionBalanceArray, premia, buffer)
             ) revert Errors.NotEnoughCollateral();
     }
 
@@ -1051,7 +1052,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 revert Errors.NotMarginCalled();
 
             // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
-            // TODO check with currentTick as well, do conservative collateral checks if outside
+            // check with currentTick as well, do conservative collateral checks if outside
             if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
                 if (
                     !_checkCrossBalances(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -904,10 +904,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
         );
         if (!solventAtFast) revert Errors.NotEnoughCollateral();
 
-        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e, the user must be solvent at both the fast and slow oracle ticks.
-        if (Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA)
-            if (!_checkSolvencyAtTick(user, positionIdList, currentTick, slowOracleTick, buffer))
-                revert Errors.NotEnoughCollateral();
+        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e, the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
+        if (
+            Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA ||
+            Math.abs(int256(fastOracleTick) - currentTick) > MAX_SLOW_FAST_DELTA ||
+            Math.abs(currentTick - slowOracleTick) > MAX_SLOW_FAST_DELTA
+        )
+            if (
+                !_checkSolvencyAtTick(user, positionIdList, currentTick, slowOracleTick, buffer) ||
+                !_checkSolvencyAtTick(user, positionIdList, currentTick, currentTick, buffer)
+            ) revert Errors.NotEnoughCollateral();
     }
 
     /// @notice Burns and handles the exercise of options.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -894,25 +894,35 @@ contract PanopticPool is ERC1155Holder, Multicall {
             );
         }
 
-        // Check the user's solvency at the fast tick; revert if not solvent
-        bool solventAtFast = _checkSolvencyAtTick(
+        uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
+        LeftRightSigned premia;
+        (premia, positionBalanceArray) = _calculateAccumulatedPremia(
             user,
             positionIdList,
-            currentTick,
+            COMPUTE_ALL_PREMIA,
+            ONLY_AVAILABLE_PREMIUM,
+            currentTick
+        );
+
+        bool solventAtFast = _checkCrossBalances(
+            user,
             fastOracleTick,
+            positionBalanceArray,
+            premia,
             buffer
         );
         if (!solventAtFast) revert Errors.NotEnoughCollateral();
 
-        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e, the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
+        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
+        // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
         if (
             Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA ||
             Math.abs(int256(fastOracleTick) - currentTick) > MAX_SLOW_FAST_DELTA ||
             Math.abs(currentTick - slowOracleTick) > MAX_SLOW_FAST_DELTA
         )
             if (
-                !_checkSolvencyAtTick(user, positionIdList, currentTick, slowOracleTick, buffer) ||
-                !_checkSolvencyAtTick(user, positionIdList, currentTick, currentTick, buffer)
+                !_checkCrossBalances(user, currentTick, positionBalanceArray, premia, buffer) ||
+                !_checkCrossBalances(user, slowOracleTick, positionBalanceArray, premia, buffer)
             ) revert Errors.NotEnoughCollateral();
     }
 
@@ -1005,10 +1015,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
         {
             (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
 
-            // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
-            if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
-                revert Errors.StaleTWAP();
-
             uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
             (premia, positionBalanceArray) = _calculateAccumulatedPremia(
                 liquidatee,
@@ -1017,27 +1023,22 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 ONLY_AVAILABLE_PREMIUM,
                 currentTick
             );
-            tokenData0 = s_collateralToken0.getAccountMarginDetails(
-                liquidatee,
-                twapTick,
-                positionBalanceArray,
-                premia.rightSlot()
-            );
 
-            tokenData1 = s_collateralToken1.getAccountMarginDetails(
-                liquidatee,
-                twapTick,
-                positionBalanceArray,
-                premia.leftSlot()
-            );
+            if (!_checkCrossBalances(liquidatee, twapTick, positionBalanceArray, premia, NO_BUFFER))
+                revert Errors.NotMarginCalled();
 
-            (uint256 balanceCross, uint256 thresholdCross) = _getSolvencyBalances(
-                tokenData0,
-                tokenData1,
-                Math.getSqrtRatioAtTick(twapTick)
-            );
-
-            if (balanceCross >= thresholdCross) revert Errors.NotMarginCalled();
+            // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
+            // TODO check with currentTick as well, do conservative collateral checks if outside
+            if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
+                if (
+                    !_checkCrossBalances(
+                        liquidatee,
+                        currentTick,
+                        positionBalanceArray,
+                        premia,
+                        NO_BUFFER
+                    )
+                ) revert Errors.NotMarginCalled();
         }
 
         // Perform the specified delegation from `msg.sender` to `liquidatee`
@@ -1279,6 +1280,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 currentTick
             );
 
+        return _checkCrossBalances(account, atTick, positionBalanceArray, portfolioPremium, buffer);
+    }
+
+    function _checkCrossBalances(
+        address account,
+        int24 atTick,
+        uint256[2][] memory positionBalanceArray,
+        LeftRightSigned portfolioPremium,
+        uint256 buffer
+    ) internal view returns (bool) {
         LeftRightUnsigned tokenData0 = s_collateralToken0.getAccountMarginDetails(
             account,
             atTick,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -881,38 +881,25 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         medianData = _medianData;
 
-        uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
-        LeftRightSigned premia;
-        {
-            (premia, positionBalanceArray) = _calculateAccumulatedPremia(
-                user,
-                positionIdList,
-                COMPUTE_ALL_PREMIA,
-                ONLY_AVAILABLE_PREMIUM,
-                currentTick
-            );
-
-            bool solventAtFast = _checkCrossBalances(
-                user,
-                fastOracleTick,
-                positionBalanceArray,
-                premia,
-                buffer
-            );
-            if (!solventAtFast) revert Errors.NotEnoughCollateral();
-        }
+        int24[] memory atTicks;
         // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
         // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
         if (
             Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA ||
             Math.abs(int256(fastOracleTick) - currentTick) > MAX_SLOW_FAST_DELTA ||
             Math.abs(currentTick - slowOracleTick) > MAX_SLOW_FAST_DELTA
-        )
-            if (
-                !_checkCrossBalances(user, currentTick, positionBalanceArray, premia, buffer) ||
-                !_checkCrossBalances(user, slowOracleTick, positionBalanceArray, premia, buffer) ||
-                !_checkCrossBalances(user, fastOracleTick, positionBalanceArray, premia, buffer)
-            ) revert Errors.NotEnoughCollateral();
+        ) {
+            atTicks = new int24[](3);
+            atTicks[0] = fastOracleTick;
+            atTicks[1] = slowOracleTick;
+            atTicks[2] = currentTick;
+        } else {
+            atTicks = new int24[](1);
+            atTicks[0] = fastOracleTick;
+        }
+
+        bool solvent = _checkSolvencyAtTicks(user, positionIdList, currentTick, atTicks, buffer);
+        if (!solvent) revert Errors.NotEnoughCollateral();
     }
 
     function _getOracleTicks()
@@ -1047,10 +1034,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
         LeftRightSigned premia;
-        int24 currentTick;
+        (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
         {
-            (, currentTick, , , , , ) = s_univ3pool.slot0();
-
             uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
             (premia, positionBalanceArray) = _calculateAccumulatedPremia(
                 liquidatee,
@@ -1171,25 +1156,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
             uint256(int256(uint256(_delegations.leftSlot())) + liquidationBonus1)
         );
 
-        // check that the provided positionIdList matches the positions in memory
-        _validatePositionList(msg.sender, positionIdListLiquidator, 0);
+        // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
+        _validateSolvency(msg.sender, positionIdListLiquidator, BP_DECREASE_BUFFER);
 
-        if (
-            !_checkSolvencyAtTick(
-                msg.sender,
-                positionIdListLiquidator,
-                currentTick,
-                currentTick,
-                BP_DECREASE_BUFFER
-            )
-        ) revert Errors.NotEnoughCollateral();
-
-        LeftRightSigned bonusAmounts = LeftRightSigned
-            .wrap(0)
-            .toRightSlot(int128(liquidationBonus0))
-            .toLeftSlot(int128(liquidationBonus1));
-
-        emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
+        {
+            LeftRightSigned bonusAmounts = LeftRightSigned
+                .wrap(0)
+                .toRightSlot(int128(liquidationBonus0))
+                .toLeftSlot(int128(liquidationBonus1));
+            emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
+        }
     }
 
     /// @notice Force the exercise of a single position. Exercisor will have to pay a fee to the force exercisee.
@@ -1306,14 +1282,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param account The account to check solvency for
     /// @param positionIdList The list of positions to check solvency for
     /// @param currentTick The current tick of the Uniswap pool (needed for fee calculations)
-    /// @param atTick The tick to check solvency at
+    /// @param atTicks An attay of the ticks to check solvency at
     /// @param buffer The buffer to apply to the collateral requirement
     /// @return Whether the account is solvent at the given tick
-    function _checkSolvencyAtTick(
+    function _checkSolvencyAtTicks(
         address account,
         TokenId[] calldata positionIdList,
         int24 currentTick,
-        int24 atTick,
+        int24[] memory atTicks,
         uint256 buffer
     ) internal view returns (bool) {
         (
@@ -1327,7 +1303,20 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 currentTick
             );
 
-        return _checkCrossBalances(account, atTick, positionBalanceArray, portfolioPremium, buffer);
+        uint256 numberOfTicks = atTicks.length;
+        bool solvent = true;
+        for (uint256 i; i < numberOfTicks; ++i) {
+            solvent =
+                solvent &&
+                _checkCrossBalances(
+                    account,
+                    atTicks[i],
+                    positionBalanceArray,
+                    portfolioPremium,
+                    buffer
+                );
+        }
+        return solvent;
     }
 
     /// @notice Check whether a the balances of an account is solvent at a given `atTick` with a collateral requirement of `buffer`/10_000 multiplied by the requirement of `positionBalanceArray`.
@@ -1365,7 +1354,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightUnsigned tokenData1,
         int24 atTick,
         uint256 buffer
-    ) internal view returns (bool) {
+    ) internal pure returns (bool) {
         (uint256 balanceCross, uint256 thresholdCross) = _getSolvencyBalances(
             tokenData0,
             tokenData1,
@@ -1718,6 +1707,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
 
         // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
+
         _validateSolvency(owner, positionIdList, NO_BUFFER);
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1842,7 +1842,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             address(0),
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            false
         );
 
         vm.expectRevert(Errors.NotPanopticPool.selector);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -560,7 +560,13 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(address(pp));
-        CollateralTracker(collateralReference).takeCommissionAddData(Alice, 0, 0, 1_000_000_000);
+        CollateralTracker(collateralReference).takeCommissionAddData(
+            Alice,
+            0,
+            0,
+            1_000_000_000,
+            false
+        );
         assertEq(
             1_000_000_000_000_000 -
                 1 -


### PR DESCRIPTION
# Hardened Solvency Checks

This PR addresses one UX issue and another potential security issue.

## StaleTWAP()
First, we are currently performing a staleness check on the `twapTick` vs `currentTick` during liquidations and revert if those two diverge by more than 5%:

https://github.com/panoptic-labs/panoptic-v1-core-private/blob/53c45f1f18365069a21dde23b1bcd7a9c0b640da/contracts/PanopticPool.sol#L1003-L1004

This potentially impacts UX because an account could be unliquidatable under choppy price moves (ie. continuously up/down by 5% in a 10mins window), and liquidation would only proceed if the price happens to be within 5% of the TWAP, which could lead to execution at an arbitrary price and not the current one.

This PR solves this by ensuring that an additional solvency check at the `currentTick` is performed when the price diverges by more than 5%:

https://github.com/panoptic-labs/panoptic-v1-core-private/blob/357b46e139642649344efcdc98d3becee19df890/contracts/PanopticPool.sol#L1059-L1068

This ensure that accounts could still be liquidated even of there is a recent 5% price move AND it is also liquidatable at the TWAP tick and the current Tick

## Covered Position Mandate

This PR also address a potential issue where a rapid price move larger than 20% leads to users trading many options using the few blocks of "free" collateral.

That is, create positions when `fastOracleTick` hasn't quite caught up to `currentTick`. In this scenario, users could mint options with ITM amounts, receive tokens due to the intrinsic value, and then withdraw those funds because the collateral check is done at the `fastOracleTick` and those positions appear OTM

To solve this, we mandate that all newly minted options to be `covered` when the recent price deviated by more than 20%. This means selling and/or buying ITM options would require the user to own the itm amounts in their account.

This is implemented here, where the `tickLimit` order is changed to small-to-large if the price deviates too much from the `slowOracleTick`, hardcoded to be median tick.

https://github.com/panoptic-labs/panoptic-v1-core-private/blob/357b46e139642649344efcdc98d3becee19df890/contracts/PanopticPool.sol#L659-L673


## 100% Collateralization Mandate

This one is further hardening the solvency of the protocol after large/sudden price moves that exceed 20%. We do this by mandating that, in addition to the covered minting, we also change the collateral requirement of all short options to 100% collateralized. 

Increasing the collateral requirement to 100% does not change the funds required inside the account for the covered mint mandate --all transactions that have enough funds will still succeed.

The additional collateral requirement criteria (ie. `safeMode = true`) means that those positions will also be fully collateralized and will never lead to any protocol loss. 

This would mean users that want to capitalize on sudden price moves could still mint options, but those options would not add any extra risk to the protocol. If the price stabilizes at a later time, those users could close+redeploy their position at a lower collateral requirement provides that the >20% move condition is not satisfied.

This full collateralization requirement is implemented by passing a `safeMode=true` flag in `collateralTracker.takeCommissionAddData`:

https://github.com/panoptic-labs/panoptic-v1-core-private/blob/357b46e139642649344efcdc98d3becee19df890/contracts/CollateralTracker.sol#L1052

## Review conditions

This is changing the code after our intended code freeze... The additional checks should make the collateral requirements and options minting _safer_ by adding more checks + requirements, but that'd still need to be verified before merging into the frozen codebase. 

## Alternatives

An alternative check in `liquidate` for tick staleness could be based on the vector displacement instead of the individual deviations. Could be safer, but I haven't looked at it too deeply:

```        
if (
    ((int256(fastOracleTick) - slowOracleTick)**2 + 
    (int256(fastOracleTick) - currentTick)**2 + 
    (currentTick - slowOracleTick)**2) >  MAX_SLOW_FAST_DELTA**2
) {
```
