### PR TITLE
fix: reduce `CARDINALITY_INCREASE` to minimum for 10min on ETH mainnet

### DIFF
--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -80,7 +80,7 @@ contract PanopticFactory is FactoryNFT, Multicall {
     uint256 internal constant FULL_RANGE_LIQUIDITY_AMOUNT_TOKEN = 1e6;
 
     /// @notice The `observationCardinalityNext` to set on the Uniswap pool when a new PanopticPool is deployed.
-    uint16 internal constant CARDINALITY_INCREASE = 100;
+    uint16 internal constant CARDINALITY_INCREASE = 50;
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -80,7 +80,7 @@ contract PanopticFactory is FactoryNFT, Multicall {
     uint256 internal constant FULL_RANGE_LIQUIDITY_AMOUNT_TOKEN = 1e6;
 
     /// @notice The `observationCardinalityNext` to set on the Uniswap pool when a new PanopticPool is deployed.
-    uint16 internal constant CARDINALITY_INCREASE = 50;
+    uint16 internal constant CARDINALITY_INCREASE = 51;
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE


### PR DESCRIPTION
`CARDINALITY_INCREASE` was arbitrarily set to 100 when the `TWAPFilter` oracle was first introduced. I can't find any justification for this number, as in fact only `600s window / 12s ETH blocktime = 50 observation periods` (`observationCardinality = 51`) is required to guarantee that the oldest observation is `>= 600s` old on ETH mainnet.

(`TWAP_WINDOW`, at least on Ethereum mainnet, is the oracle that requires the greatest number of observations; `SLOW_ORACLE_CARDINALITY = 8` and `SLOW_ORACLE_PERIOD = 5` so only 46 observations are required for that one)

It is essential that there are enough observation slots to guarantee that none of the three oracles will revert if one is filled every block with the lowest possible blocktime. Otherwise, an actor could temporarily DoS mints, burns, force exercises, liquidations, and premium settlements by poking with a swap/mint/burn every block until the cardinality was increased. (somebody may even eke out a C4 medium by applying this to L2s)

Like `MAX_POSITIONS` (guaranteed liquidation within gas limit), and the slow/fast oracle parameters (blocktime = min time between each observation), this is a parameter that we will have to reconsider for each chain we deploy to. The criteria for filled observation slots on the frontend as a component of pool validity will need to be adjusted as well.

For example, Arbitrum has a block time of ~250ms. We would need to set `CARDINALITY_INCREASE` to at least 2401 to secure history for the 10 minute `TWAPFilter` oracle.

We'll add a test for each chain that simulates an observation being taken each block, advancing the blocktime by the minimum expected period and confirming that all oracles work as intended on the cardinality we select.