### PR TITLE
fix: `s_poolAssets` underflow in `withdraw(..., TokenId[])`

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -574,9 +574,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         _burn(owner, shares);
 
         // update tracked asset balance
-        unchecked {
-            s_poolAssets -= uint128(assets);
-        }
+        s_poolAssets -= uint128(assets);
 
         // reverts if account is not solvent/eligible to withdraw
         s_panopticPool.validateCollateralWithdrawable(owner, positionIdList);

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -853,6 +853,36 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.withdraw(maxAssets + 1, Bob, Bob, new TokenId[](0));
     }
 
+    function test_Fail_removeGtAvailableCollateral() public {
+        // initalize world state
+        _initWorld(0);
+
+        // Invoke all interactions with the Collateral Tracker from user Bob
+        vm.startPrank(Bob);
+
+        // give Bob the max amount of tokens
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+
+        collateralToken0.deposit(1000, Bob);
+
+        collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 500);
+        collateralToken0.setInAMM(500);
+
+        uint256 bal = collateralToken0.balanceOf(Bob);
+        uint256 assets = collateralToken0.convertToAssets(bal);
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.redeem(bal, Bob, Bob);
+
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.withdraw(assets, Bob, Bob);
+
+        // no erc4626 maxWithdraw check, so s_poolAssets math underflows instead
+        vm.expectRevert(stdError.arithmeticError);
+        collateralToken0.withdraw(assets, Bob, Bob, new TokenId[](0));
+    }
+
     function test_Success_withdraw_OnBehalf(uint256 x, uint104 assets) public {
         _initWorld(x);
 


### PR DESCRIPTION
An overload of the `withdraw` function was added in #64 that allows accounts to withdraw assets while they have positions open. The `maxWithdraw` check present in the ERC4626 version of that method had to be omitted from the overload because `maxWithdraw` returns 0 if the owner has open positions (which is accurate given that they are indeed not permitted to withdraw through the ERC4626 interface).

This omission leads to an unintended edge case: if `s_poolAssets` is less than both the token balance of the panoptic pool and the asset value of a given account's shares, that account can withdraw more than `s_poolAssets`. If that occurs, `s_poolAssets` will underflow in the following statement:
```
unchecked {
    s_poolAssets -= uint128(assets)
}
```

Fortunately, all math involving `s_poolAssets` is unchecked and self-consistent, so for all intents and purposes an overflowed `s_poolAssets` value behaves like a negative signed integer. `totalAssets()` remains correct (e.g. `uint128(type(uint128).max-10 + 100) = 90`) as well as `_poolUtilization()` (`s_inAMM * 10_000 / totalAssets()`).

While it is technically possible for the stored utilization values for a user's position to overflow (given a situation where most assets are withdrawn via token donations to the pool: s_poolAssets = -(2**64 - 1) and s_inAMM = 2^64), the most severe impact of that is a modified collateral requirement in a pool with sufficiently negligible outside deposits for a pool utilization >= 2^64 bps to be plausible.

Nevertheless, we should remove this capability to avoid confusing frontends with overflowed `availableAssets` values from `getPoolData` and keep things consistent with the ERC4626 overload of `withdraw`. If the `unchecked` block surrounding the aforementioned statement is removed, any `s_poolAssets` underflows will be prevented.

This should also be catchable with Echidna, cc @flanagansteve :
- Invariant 1: `getPoolData().poolUtilization <= 10_000 bps`
- Invariant 2: `if x > getPoolData().availableAssets then withdraw(x, addr, addr, []) should revert`