### PR TITLE
Hardening PR0: more solvency checks

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -332,7 +332,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         if (
             ct0.convertToAssets(ct0.balanceOf(msg.sender)) < minValue0 ||
             ct1.convertToAssets(ct1.balanceOf(msg.sender)) < minValue1
-        ) revert Errors.NotEnoughCollateral();
+        ) revert Errors.AccountInsolvent();
     }
 
     /// @notice Determines if account is eligible to withdraw or transfer collateral.
@@ -884,7 +884,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
 
         bool solvent = _checkSolvencyAtTicks(user, positionIdList, currentTick, atTicks, buffer);
-        if (!solvent) revert Errors.NotEnoughCollateral();
+        if (!solvent) revert Errors.AccountInsolvent();
     }
 
     function _getOracleTicks()

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -501,7 +501,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     function pokeMedian() external {
         (, , uint16 observationIndex, uint16 observationCardinality, , , ) = s_univ3pool.slot0();
 
-        (, , uint256 medianData) = PanopticMath.computeInternalMedian(
+        (, uint256 medianData) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             MEDIAN_PERIOD,
@@ -876,11 +876,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 int256(currentTick - slowOracleTick) ** 2 >
             MAX_SLOW_FAST_DELTA ** 2
         ) {
-            atTicks = new int24[](3);
+            atTicks = new int24[](4);
             atTicks[0] = fastOracleTick;
             atTicks[1] = slowOracleTick;
             atTicks[2] = lastObservedTick;
-            atTicks[4] = currentTick;
+            atTicks[3] = currentTick;
         } else {
             atTicks = new int24[](1);
             atTicks[0] = fastOracleTick;
@@ -890,6 +890,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         if (!solvent) revert Errors.AccountInsolvent();
     }
 
+    /// @notice Burns and handles the exercise of options.
+    /// @return currentTick The current tick in the Uniswap pool (as returned in slot0)
+    /// @return fastOracleTick The fast oracle tick computed as the median of the past N observations in the Uniswap Pool
+    /// @return slowOracleTick The slow oracle tick as tracked by `s_miniMedian`
+    /// @return latestObservation The latest observation from the Uniswap pool (price at the end of the last block)
+    /// @return medianData the updated value for `s_miniMedian` (returns 0 if not enough time has passed since last observation)
     function _getOracleTicks()
         internal
         view
@@ -907,7 +913,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         (, currentTick, observationIndex, observationCardinality, , , ) = _univ3pool.slot0();
 
-        (fastOracleTick, ) = PanopticMath.computeMedianObservedPrice(
+        (fastOracleTick, latestObservation) = PanopticMath.computeMedianObservedPrice(
             _univ3pool,
             observationIndex,
             observationCardinality,
@@ -916,7 +922,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         );
 
         if (SLOW_ORACLE_UNISWAP_MODE) {
-            (slowOracleTick, latestObservation) = PanopticMath.computeMedianObservedPrice(
+            (slowOracleTick, ) = PanopticMath.computeMedianObservedPrice(
                 _univ3pool,
                 observationIndex,
                 observationCardinality,
@@ -924,7 +930,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 SLOW_ORACLE_PERIOD
             );
         } else {
-            (slowOracleTick, latestObservation, medianData) = PanopticMath.computeInternalMedian(
+            (slowOracleTick, medianData) = PanopticMath.computeInternalMedian(
                 observationIndex,
                 observationCardinality,
                 MEDIAN_PERIOD,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1011,9 +1011,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
         LeftRightSigned premia;
+        (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
         {
-            (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-
             // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
             if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
                 revert Errors.StaleTWAP();
@@ -1057,7 +1056,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         int256 liquidationBonus0;
         int256 liquidationBonus1;
-        int24 finalTick;
         {
             LeftRightSigned netExchanged;
             LeftRightSigned[4][] memory premiasByLeg;
@@ -1074,8 +1072,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 positionIdList
             );
 
-            (, finalTick, , , , , ) = s_univ3pool.slot0();
-
             LeftRightSigned collateralRemaining;
             // compute bonus amounts using latest tick data
             (liquidationBonus0, liquidationBonus1, collateralRemaining) = PanopticMath
@@ -1083,7 +1079,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     tokenData0,
                     tokenData1,
                     Math.getSqrtRatioAtTick(twapTick),
-                    Math.getSqrtRatioAtTick(finalTick),
+                    Math.getSqrtRatioAtTick(currentTick),
                     netExchanged,
                     premia
                 );
@@ -1098,8 +1094,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
             // if premium is haircut from a token that is not in protocol loss, some of the liquidation bonus will be converted into that token
             // reusing variables to save stack space; netExchanged = deltaBonus0, premia = deltaBonus1
             address _liquidatee = liquidatee;
+            int24 _currentTick = currentTick;
             TokenId[] memory _positionIdList = positionIdList;
-            int24 _finalTick = finalTick;
             int256 deltaBonus0;
             int256 deltaBonus1;
             (deltaBonus0, deltaBonus1) = PanopticMath.haircutPremia(
@@ -1109,7 +1105,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 collateralRemaining,
                 s_collateralToken0,
                 s_collateralToken1,
-                Math.getSqrtRatioAtTick(_finalTick),
+                Math.getSqrtRatioAtTick(_currentTick),
                 s_settledTokens
             );
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -866,20 +866,25 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         medianData = _medianData;
 
-        // Check the user's solvency at the fast tick; revert if not solvent
-        bool solventAtFast = _checkSolvencyAtTick(
-            user,
-            positionIdList,
-            currentTick,
-            fastOracleTick,
-            buffer
-        );
-        if (!solventAtFast) revert Errors.NotEnoughCollateral();
+        int24[] memory atTicks;
+        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
+        // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
+        if (
+            Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA ||
+            Math.abs(int256(fastOracleTick) - currentTick) > MAX_SLOW_FAST_DELTA ||
+            Math.abs(currentTick - slowOracleTick) > MAX_SLOW_FAST_DELTA
+        ) {
+            atTicks = new int24[](3);
+            atTicks[0] = fastOracleTick;
+            atTicks[1] = slowOracleTick;
+            atTicks[2] = currentTick;
+        } else {
+            atTicks = new int24[](1);
+            atTicks[0] = fastOracleTick;
+        }
 
-        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e, the user must be solvent at both the fast and slow oracle ticks.
-        if (Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA)
-            if (!_checkSolvencyAtTick(user, positionIdList, currentTick, slowOracleTick, buffer))
-                revert Errors.NotEnoughCollateral();
+        bool solvent = _checkSolvencyAtTicks(user, positionIdList, currentTick, atTicks, buffer);
+        if (!solvent) revert Errors.NotEnoughCollateral();
     }
 
     function _getOracleTicks()
@@ -1126,26 +1131,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
             liquidatee,
             uint256(int256(uint256(_delegations.leftSlot())) + liquidationBonus1)
         );
+        // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
+        _validateSolvency(msg.sender, positionIdListLiquidator, BP_DECREASE_BUFFER);
 
-        // check that the provided positionIdList matches the positions in memory
-        _validatePositionList(msg.sender, positionIdListLiquidator, 0);
-
-        if (
-            !_checkSolvencyAtTick(
-                msg.sender,
-                positionIdListLiquidator,
-                finalTick,
-                finalTick,
-                BP_DECREASE_BUFFER
-            )
-        ) revert Errors.NotEnoughCollateral();
-
-        LeftRightSigned bonusAmounts = LeftRightSigned
-            .wrap(0)
-            .toRightSlot(int128(liquidationBonus0))
-            .toLeftSlot(int128(liquidationBonus1));
-
-        emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
+        {
+            LeftRightSigned bonusAmounts = LeftRightSigned
+                .wrap(0)
+                .toRightSlot(int128(liquidationBonus0))
+                .toLeftSlot(int128(liquidationBonus1));
+            emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
+        }
     }
 
     /// @notice Force the exercise of a single position. Exercisor will have to pay a fee to the force exercisee.
@@ -1262,14 +1257,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param account The account to check solvency for
     /// @param positionIdList The list of positions to check solvency for
     /// @param currentTick The current tick of the Uniswap pool (needed for fee calculations)
-    /// @param atTick The tick to check solvency at
+    /// @param atTicks An array of ticks to check solvency at
     /// @param buffer The buffer to apply to the collateral requirement
     /// @return Whether the account is solvent at the given tick
-    function _checkSolvencyAtTick(
+    function _checkSolvencyAtTicks(
         address account,
         TokenId[] calldata positionIdList,
         int24 currentTick,
-        int24 atTick,
+        int24[] memory atTicks,
         uint256 buffer
     ) internal view returns (bool) {
         (
@@ -1283,6 +1278,36 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 currentTick
             );
 
+        uint256 numberOfTicks = atTicks.length;
+        bool solvent = true;
+        for (uint256 i; i < numberOfTicks; ++i) {
+            solvent =
+                solvent &&
+                _checkCrossBalances(
+                    account,
+                    atTicks[i],
+                    positionBalanceArray,
+                    portfolioPremium,
+                    buffer
+                );
+        }
+        return solvent;
+    }
+
+    /// @notice Check whether a the balances of an account is solvent at a given `atTick` with a collateral requirement of `buffer`/10_000 multiplied by the requirement of `positionBalanceArray`.
+    /// @param account The account to check solvency for
+    /// @param atTick The tick to check solvency at
+    /// @param positionBalanceArray A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
+    /// @param portfolioPremium The computed premia of the user's positions, where premia contains the accumulated premia for token0 in the right slot and for token1 in the left slot
+    /// @param buffer The buffer to apply to the collateral requirement
+    /// @return Whether the account is solvent at the given tick
+    function _checkCrossBalances(
+        address account,
+        int24 atTick,
+        uint256[2][] memory positionBalanceArray,
+        LeftRightSigned portfolioPremium,
+        uint256 buffer
+    ) internal view returns (bool) {
         LeftRightUnsigned tokenData0 = s_collateralToken0.getAccountMarginDetails(
             account,
             atTick,
@@ -1296,12 +1321,20 @@ contract PanopticPool is ERC1155Holder, Multicall {
             portfolioPremium.leftSlot()
         );
 
+        return _checkSolvencyCross(tokenData0, tokenData1, atTick, buffer);
+    }
+
+    function _checkSolvencyCross(
+        LeftRightUnsigned tokenData0,
+        LeftRightUnsigned tokenData1,
+        int24 atTick,
+        uint256 buffer
+    ) internal pure returns (bool) {
         (uint256 balanceCross, uint256 thresholdCross) = _getSolvencyBalances(
             tokenData0,
             tokenData1,
             Math.getSqrtRatioAtTick(atTick)
         );
-
         // compare balance and required tokens, can use unsafe div because denominator is always nonzero
         unchecked {
             return balanceCross >= Math.unsafeDivRoundingUp(thresholdCross * buffer, 10_000);

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -861,7 +861,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             int24 currentTick,
             int24 fastOracleTick,
             int24 slowOracleTick,
-            int24 latestTick,
+            int24 lastObservedTick,
             uint256 _medianData
         ) = _getOracleTicks();
 
@@ -872,14 +872,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
         if (
             int256(fastOracleTick - slowOracleTick) ** 2 +
-                int256(fastOracleTick - currentTick) ** 2 +
+                int256(lastObservedTick - slowOracleTick) ** 2 +
                 int256(currentTick - slowOracleTick) ** 2 >
             MAX_SLOW_FAST_DELTA ** 2
         ) {
             atTicks = new int24[](3);
             atTicks[0] = fastOracleTick;
             atTicks[1] = slowOracleTick;
-            atTicks[2] = currentTick;
+            atTicks[2] = lastObservedTick;
+            atTicks[4] = currentTick;
         } else {
             atTicks = new int24[](1);
             atTicks[0] = fastOracleTick;

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -501,7 +501,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     function pokeMedian() external {
         (, , uint16 observationIndex, uint16 observationCardinality, , , ) = s_univ3pool.slot0();
 
-        (, uint256 medianData) = PanopticMath.computeInternalMedian(
+        (, , uint256 medianData) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             MEDIAN_PERIOD,
@@ -861,6 +861,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             int24 currentTick,
             int24 fastOracleTick,
             int24 slowOracleTick,
+            int24 latestTick,
             uint256 _medianData
         ) = _getOracleTicks();
 
@@ -891,7 +892,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
     function _getOracleTicks()
         internal
         view
-        returns (int24 currentTick, int24 fastOracleTick, int24 slowOracleTick, uint256 medianData)
+        returns (
+            int24 currentTick,
+            int24 fastOracleTick,
+            int24 slowOracleTick,
+            int24 latestObservation,
+            uint256 medianData
+        )
     {
         IUniswapV3Pool _univ3pool = s_univ3pool;
         uint16 observationIndex;
@@ -899,7 +906,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         (, currentTick, observationIndex, observationCardinality, , , ) = _univ3pool.slot0();
 
-        fastOracleTick = PanopticMath.computeMedianObservedPrice(
+        (fastOracleTick, ) = PanopticMath.computeMedianObservedPrice(
             _univ3pool,
             observationIndex,
             observationCardinality,
@@ -908,7 +915,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         );
 
         if (SLOW_ORACLE_UNISWAP_MODE) {
-            slowOracleTick = PanopticMath.computeMedianObservedPrice(
+            (slowOracleTick, latestObservation) = PanopticMath.computeMedianObservedPrice(
                 _univ3pool,
                 observationIndex,
                 observationCardinality,
@@ -916,7 +923,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 SLOW_ORACLE_PERIOD
             );
         } else {
-            (slowOracleTick, medianData) = PanopticMath.computeInternalMedian(
+            (slowOracleTick, latestObservation, medianData) = PanopticMath.computeInternalMedian(
                 observationIndex,
                 observationCardinality,
                 MEDIAN_PERIOD,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -868,8 +868,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         medianData = _medianData;
 
         int24[] memory atTicks;
-        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
-        // the user must be solvent at the fast, slow oracle ticks as well as the currentTick and the last observed tick.
+        // Fall back to a conservative approach if there's high deviation between internal ticks:
+        // Check solvency at the slowOracleTick, currentTick, and lastObservedTick instead of just the fastOracleTick.
+        // Deviation is measured as the magnitude of a 3D vector:
+        // (fastOracleTick - slowOracleTick, lastObservedTick - slowOracleTick, currentTick - slowOracleTick)
+        // This approach is more conservative than checking each tick difference individually,
+        // as the Euclidean norm is always greater than or equal to the maximum of the individual differences.
         if (
             int256(fastOracleTick - slowOracleTick) ** 2 +
                 int256(lastObservedTick - slowOracleTick) ** 2 +
@@ -886,8 +890,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
             atTicks[0] = fastOracleTick;
         }
 
-        bool solvent = _checkSolvencyAtTicks(user, positionIdList, currentTick, atTicks, buffer);
-        if (!solvent) revert Errors.AccountInsolvent();
+        if (!_checkSolvencyAtTicks(user, positionIdList, currentTick, atTicks, buffer))
+            revert Errors.AccountInsolvent();
     }
 
     /// @notice Burns and handles the exercise of options.
@@ -1142,7 +1146,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
             liquidatee,
             uint256(int256(uint256(_delegations.leftSlot())) + liquidationBonus1)
         );
-        // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
+
+        // ensure the liquidator is still solvent after the liquidation
         _validateSolvency(msg.sender, positionIdListLiquidator, BP_DECREASE_BUFFER);
 
         {
@@ -1331,21 +1336,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
             positionBalanceArray,
             portfolioPremium.leftSlot()
         );
-
-        return _checkSolvencyCross(tokenData0, tokenData1, atTick, buffer);
-    }
-
-    function _checkSolvencyCross(
-        LeftRightUnsigned tokenData0,
-        LeftRightUnsigned tokenData1,
-        int24 atTick,
-        uint256 buffer
-    ) internal pure returns (bool) {
         (uint256 balanceCross, uint256 thresholdCross) = _getSolvencyBalances(
             tokenData0,
             tokenData1,
             Math.getSqrtRatioAtTick(atTick)
         );
+
         // compare balance and required tokens, can use unsafe div because denominator is always nonzero
         unchecked {
             return balanceCross >= Math.unsafeDivRoundingUp(thresholdCross * buffer, 10_000);

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1150,13 +1150,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // ensure the liquidator is still solvent after the liquidation
         _validateSolvency(msg.sender, positionIdListLiquidator, BP_DECREASE_BUFFER);
 
-        {
-            LeftRightSigned bonusAmounts = LeftRightSigned
-                .wrap(0)
-                .toRightSlot(int128(liquidationBonus0))
-                .toLeftSlot(int128(liquidationBonus1));
-            emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
-        }
+        LeftRightSigned bonusAmounts = LeftRightSigned
+            .wrap(0)
+            .toRightSlot(int128(liquidationBonus0))
+            .toLeftSlot(int128(liquidationBonus1));
+        emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
     }
 
     /// @notice Force the exercise of a single position. Exercisor will have to pay a fee to the force exercisee.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -870,9 +870,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
         // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
         if (
-            Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA ||
-            Math.abs(int256(fastOracleTick) - currentTick) > MAX_SLOW_FAST_DELTA ||
-            Math.abs(currentTick - slowOracleTick) > MAX_SLOW_FAST_DELTA
+            int256(fastOracleTick - slowOracleTick) ** 2 +
+                int256(fastOracleTick - currentTick) ** 2 +
+                int256(currentTick - slowOracleTick) ** 2 >
+            MAX_SLOW_FAST_DELTA ** 2
         ) {
             atTicks = new int24[](3);
             atTicks[0] = fastOracleTick;

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -857,17 +857,43 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // check that the provided positionIdList matches the positions in memory
         _validatePositionList(user, positionIdList, 0);
 
-        IUniswapV3Pool _univ3pool = s_univ3pool;
         (
-            ,
             int24 currentTick,
-            uint16 observationIndex,
-            uint16 observationCardinality,
-            ,
-            ,
+            int24 fastOracleTick,
+            int24 slowOracleTick,
+            uint256 _medianData
+        ) = _getOracleTicks();
 
-        ) = _univ3pool.slot0();
-        int24 fastOracleTick = PanopticMath.computeMedianObservedPrice(
+        medianData = _medianData;
+
+        // Check the user's solvency at the fast tick; revert if not solvent
+        bool solventAtFast = _checkSolvencyAtTick(
+            user,
+            positionIdList,
+            currentTick,
+            fastOracleTick,
+            buffer
+        );
+        if (!solventAtFast) revert Errors.NotEnoughCollateral();
+
+        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e, the user must be solvent at both the fast and slow oracle ticks.
+        if (Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA)
+            if (!_checkSolvencyAtTick(user, positionIdList, currentTick, slowOracleTick, buffer))
+                revert Errors.NotEnoughCollateral();
+    }
+
+    function _getOracleTicks()
+        internal
+        view
+        returns (int24 currentTick, int24 fastOracleTick, int24 slowOracleTick, uint256 medianData)
+    {
+        IUniswapV3Pool _univ3pool = s_univ3pool;
+        uint16 observationIndex;
+        uint16 observationCardinality;
+
+        (, currentTick, observationIndex, observationCardinality, , , ) = _univ3pool.slot0();
+
+        fastOracleTick = PanopticMath.computeMedianObservedPrice(
             _univ3pool,
             observationIndex,
             observationCardinality,
@@ -875,7 +901,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
             FAST_ORACLE_PERIOD
         );
 
-        int24 slowOracleTick;
         if (SLOW_ORACLE_UNISWAP_MODE) {
             slowOracleTick = PanopticMath.computeMedianObservedPrice(
                 _univ3pool,
@@ -893,21 +918,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 _univ3pool
             );
         }
-
-        // Check the user's solvency at the fast tick; revert if not solvent
-        bool solventAtFast = _checkSolvencyAtTick(
-            user,
-            positionIdList,
-            currentTick,
-            fastOracleTick,
-            buffer
-        );
-        if (!solventAtFast) revert Errors.NotEnoughCollateral();
-
-        // If one of the ticks is too stale, we fall back to the more conservative tick, i.e, the user must be solvent at both the fast and slow oracle ticks.
-        if (Math.abs(int256(fastOracleTick) - slowOracleTick) > MAX_SLOW_FAST_DELTA)
-            if (!_checkSolvencyAtTick(user, positionIdList, currentTick, slowOracleTick, buffer))
-                revert Errors.NotEnoughCollateral();
     }
 
     /// @notice Burns and handles the exercise of options.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -146,9 +146,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @dev Mitigates manipulation of the currentTick that causes positions to be liquidated at a less favorable price.
     int256 internal constant MAX_TWAP_DELTA_LIQUIDATION = 513;
 
-    /// @notice The maximum allowed delta between the fast and slow oracle ticks before solvency is evaluated at the more oracle ticks (slow, current, and latest).
+    /// @notice The maximum allowed cumulative delta between: the fast & slow oracle tick, the current & slow oracle tick, and the last-observed & slow oracle tick.
     /// @dev Falls back on the more conservative (less solvent) tick during times of extreme volatility, where the price moves ~10% in <4 minutes.
-    int256 internal constant MAX_SLOW_FAST_DELTA = 953;
+    int256 internal constant MAX_TICKS_DELTA = 953;
 
     /// @notice The maximum allowed ratio for a single chunk, defined as: removedLiquidity / netLiquidity.
     /// @dev The long premium spread multiplier that corresponds with the MAX_SPREAD value depends on VEGOID,
@@ -843,7 +843,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Validates the solvency of `user`.
-    /// @dev Falls back to the more conservative tick if the delta between the fast and slow oracle exceeds `MAX_SLOW_FAST_DELTA`.
+    /// @dev Falls back to the more conservative tick if the delta between the fast and slow oracle exceeds `MAX_TICKS_DELTA`.
     /// @dev Effectively, this means that the users must be solvent at both the fast and slow oracle ticks if one of them is stale to mint or burn options.
     /// @param user The account to validate
     /// @param positionIdList The list of positions to validate solvency for
@@ -878,7 +878,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             int256(fastOracleTick - slowOracleTick) ** 2 +
                 int256(lastObservedTick - slowOracleTick) ** 2 +
                 int256(currentTick - slowOracleTick) ** 2 >
-            MAX_SLOW_FAST_DELTA ** 2
+            MAX_TICKS_DELTA ** 2
         ) {
             atTicks = new int24[](4);
             atTicks[0] = fastOracleTick;
@@ -894,7 +894,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             revert Errors.AccountInsolvent();
     }
 
-    /// @notice Burns and handles the exercise of options.
+    /// @notice Gets several ticks from Uniswap regarding the underlying pair.
     /// @return currentTick The current tick in the Uniswap pool (as returned in slot0)
     /// @return fastOracleTick The fast oracle tick computed as the median of the past N observations in the Uniswap Pool
     /// @return slowOracleTick The slow oracle tick as tracked by `s_miniMedian`
@@ -1294,7 +1294,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         uint256 numberOfTicks = atTicks.length;
         bool solvent = true;
-        for (uint256 i; i < numberOfTicks; ++i) {
+        for (uint256 i; i < numberOfTicks; ) {
             solvent =
                 solvent &&
                 _checkCrossBalances(
@@ -1304,6 +1304,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     portfolioPremium,
                     buffer
                 );
+            unchecked {
+                ++i;
+            }
         }
         return solvent;
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -146,9 +146,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @dev Mitigates manipulation of the currentTick that causes positions to be liquidated at a less favorable price.
     int256 internal constant MAX_TWAP_DELTA_LIQUIDATION = 513;
 
-    /// @notice The maximum allowed delta between the fast and slow oracle ticks before solvency is evaluated at the slow oracle tick.
-    /// @dev Falls back on the more conservative (less solvent) tick during times of extreme volatility.
-    int256 internal constant MAX_SLOW_FAST_DELTA = 1800;
+    /// @notice The maximum allowed delta between the fast and slow oracle ticks before solvency is evaluated at the more oracle ticks (slow, current, and latest).
+    /// @dev Falls back on the more conservative (less solvent) tick during times of extreme volatility, where the price moves ~10% in <4 minutes.
+    int256 internal constant MAX_SLOW_FAST_DELTA = 953;
 
     /// @notice The maximum allowed ratio for a single chunk, defined as: removedLiquidity / netLiquidity.
     /// @dev The long premium spread multiplier that corresponds with the MAX_SPREAD value depends on VEGOID,
@@ -869,7 +869,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         int24[] memory atTicks;
         // If one of the ticks is too stale, we fall back to the more conservative tick, i.e,
-        // the user must be solvent at the fast and slow oracle ticks as well as the currentTick.
+        // the user must be solvent at the fast, slow oracle ticks as well as the currentTick and the last observed tick.
         if (
             int256(fastOracleTick - slowOracleTick) ** 2 +
                 int256(lastObservedTick - slowOracleTick) ** 2 +

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -51,7 +51,7 @@ library Errors {
     error NoLegsExercisable();
 
     /// @notice PanopticPool: the account is not solvent enough to perform the desired action
-    error NotEnoughCollateral();
+    error AccountInsolvent();
 
     /// @notice SFPM: maximum token amounts for a position exceed 128 bits
     error PositionTooLarge();

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -200,7 +200,6 @@ library PanopticMath {
     /// @param medianData The packed structure representing the sorted 8-slot queue of ticks
     /// @param univ3pool The Uniswap pool to retrieve observations from
     /// @return medianTick The median of the provided 8-slot queue of ticks in `medianData`
-    /// @return lastObservedTick The latest observation in the Uniswap pool
     /// @return updatedMedianData The updated 8-slot queue of ticks with the latest observation inserted if the last entry is at least `period` seconds old (returns 0 otherwise)
     function computeInternalMedian(
         uint256 observationIndex,
@@ -208,7 +207,7 @@ library PanopticMath {
         uint256 period,
         uint256 medianData,
         IUniswapV3Pool univ3pool
-    ) external view returns (int24 medianTick, int24 lastObservedTick, uint256 updatedMedianData) {
+    ) external view returns (int24 medianTick, uint256 updatedMedianData) {
         unchecked {
             // return the average of the rank 3 and 4 values
             medianTick =
@@ -218,6 +217,7 @@ library PanopticMath {
 
             // only proceed if last entry is at least MEDIAN_PERIOD seconds old
             if (block.timestamp >= uint256(uint40(medianData >> 216)) + period) {
+                int24 lastObservedTick;
                 {
                     (uint256 timestamp_old, int56 tickCumulative_old, , ) = univ3pool.observations(
                         uint256(

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -169,7 +169,7 @@ library PanopticMath {
             int256[] memory tickCumulatives = new int256[](cardinality + 1);
 
             uint256[] memory timestamps = new uint256[](cardinality + 1);
-            // get the last 4 timestamps/tickCumulatives (if observationIndex < cardinality, the index will wrap back from observationCardinality)
+            // get the last "cardinality" timestamps/tickCumulatives (if observationIndex < cardinality, the index will wrap back from observationCardinality)
             for (uint256 i = 0; i < cardinality + 1; ++i) {
                 (timestamps[i], tickCumulatives[i], , ) = univ3pool.observations(
                     uint256(

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -157,13 +157,14 @@ library PanopticMath {
     /// @param cardinality The number of `periods` to in the median price array, should be odd
     /// @param period The number of observations to average to compute one entry in the median price array
     /// @return The median of `cardinality` observations spaced by `period` in the Uniswap pool
+    /// @return The latest observation in the Uniswap pool
     function computeMedianObservedPrice(
         IUniswapV3Pool univ3pool,
         uint256 observationIndex,
         uint256 observationCardinality,
         uint256 cardinality,
         uint256 period
-    ) external view returns (int24) {
+    ) external view returns (int24, int24) {
         unchecked {
             int256[] memory tickCumulatives = new int256[](cardinality + 1);
 
@@ -187,7 +188,7 @@ library PanopticMath {
             }
 
             // get the median of the `ticks` array (assuming `cardinality` is odd)
-            return int24(Math.sort(ticks)[cardinality / 2]);
+            return (int24(Math.sort(ticks)[cardinality / 2]), int24(ticks[0]));
         }
     }
 
@@ -199,6 +200,7 @@ library PanopticMath {
     /// @param medianData The packed structure representing the sorted 8-slot queue of ticks
     /// @param univ3pool The Uniswap pool to retrieve observations from
     /// @return medianTick The median of the provided 8-slot queue of ticks in `medianData`
+    /// @return lastObservedTick The latest observation in the Uniswap pool
     /// @return updatedMedianData The updated 8-slot queue of ticks with the latest observation inserted if the last entry is at least `period` seconds old (returns 0 otherwise)
     function computeInternalMedian(
         uint256 observationIndex,
@@ -206,7 +208,7 @@ library PanopticMath {
         uint256 period,
         uint256 medianData,
         IUniswapV3Pool univ3pool
-    ) external view returns (int24 medianTick, uint256 updatedMedianData) {
+    ) external view returns (int24 medianTick, int24 lastObservedTick, uint256 updatedMedianData) {
         unchecked {
             // return the average of the rank 3 and 4 values
             medianTick =
@@ -216,7 +218,6 @@ library PanopticMath {
 
             // only proceed if last entry is at least MEDIAN_PERIOD seconds old
             if (block.timestamp >= uint256(uint40(medianData >> 216)) + period) {
-                int24 lastObservedTick;
                 {
                     (uint256 timestamp_old, int56 tickCumulative_old, , ) = univ3pool.observations(
                         uint256(

--- a/periphery/PanopticHelper.sol
+++ b/periphery/PanopticHelper.sol
@@ -119,7 +119,7 @@ contract PanopticHelper {
     ) external view returns (int24, uint256) {
         (, , uint16 observationIndex, uint16 observationCardinality, , , ) = univ3pool.slot0();
 
-        (int24 _medianTick, , uint256 _medianData) = PanopticMath.computeInternalMedian(
+        (int24 _medianTick, uint256 _medianData) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             period,

--- a/periphery/PanopticHelper.sol
+++ b/periphery/PanopticHelper.sol
@@ -95,14 +95,14 @@ contract PanopticHelper {
     ) external view returns (int24) {
         (, , uint16 observationIndex, uint16 observationCardinality, , , ) = univ3pool.slot0();
 
-        return
-            PanopticMath.computeMedianObservedPrice(
-                univ3pool,
-                observationIndex,
-                observationCardinality,
-                cardinality,
-                period
-            );
+        (int24 medianTick, ) = PanopticMath.computeMedianObservedPrice(
+            univ3pool,
+            observationIndex,
+            observationCardinality,
+            cardinality,
+            period
+        );
+        return medianTick;
     }
 
     /// @notice Takes a packed structure representing a sorted 8-slot queue of ticks and returns the median of those values.
@@ -119,14 +119,14 @@ contract PanopticHelper {
     ) external view returns (int24, uint256) {
         (, , uint16 observationIndex, uint16 observationCardinality, , , ) = univ3pool.slot0();
 
-        return
-            PanopticMath.computeInternalMedian(
-                observationIndex,
-                observationCardinality,
-                period,
-                medianData,
-                univ3pool
-            );
+        (int24 _medianTick, , uint256 _medianData) = PanopticMath.computeInternalMedian(
+            observationIndex,
+            observationCardinality,
+            period,
+            medianData,
+            univ3pool
+        );
+        return (_medianTick, _medianData);
     }
 
     /// @notice Computes the twap of a Uniswap V3 pool using data from its oracle.

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -127,7 +127,7 @@ contract PanopticPoolHarness is PanopticPool {
 
         (, , uint16 observationIndex, uint16 observationCardinality, , , ) = uniswapPool.slot0();
 
-        int24 slowOracleTick = PanopticMath.computeMedianObservedPrice(
+        (int24 slowOracleTick, ) = PanopticMath.computeMedianObservedPrice(
             uniswapPool,
             observationIndex,
             observationCardinality,

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1651,7 +1651,7 @@ contract Misctest is Test, PositionUtils {
 
             deal(address(ct0), Buyers[i], i ** 15);
             deal(address(ct1), Buyers[i], i ** 15);
-            vm.expectRevert(Errors.NotEnoughCollateral.selector);
+            vm.expectRevert(Errors.AccountInsolvent.selector);
             pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0);
             vm.revertTo(snap);
         }
@@ -2008,11 +2008,11 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct0, Bob, ct0.convertToShares(266262));
         editCollateral(ct1, Bob, 0);
 
-        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         pp.validateCollateralWithdrawable(Bob, $posIdList);
     }
 
-    function test_Fail_WithdrawWithOpenPositions_NotEnoughCollateral() public {
+    function test_Fail_WithdrawWithOpenPositions_AccountInsolvent() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -2047,11 +2047,11 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
 
-        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         ct0.withdraw(1_000_000 - 266262, Bob, Bob, $posIdList);
     }
 
-    function test_Fail_WithdrawWithOpenPositions_SolventReceiver_NotEnoughCollateral() public {
+    function test_Fail_WithdrawWithOpenPositions_SolventReceiver_AccountInsolvent() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -2086,7 +2086,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
 
-        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         ct0.withdraw(1_000_000 - 266262, Alice, Bob, $posIdList);
     }
 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -2094,6 +2094,154 @@ contract Misctest is Test, PositionUtils {
         ct0.withdraw(1_000_000 - 266262, Bob, Bob, $posIdList);
     }
 
+    function test_Success_InsolventAtCurrentTick_down() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // setup mini-median price array
+        for (uint256 i = 0; i < 10; ++i) {
+            swapperc.mint(uniPool, -10, 10, 10 ** 18);
+            vm.warp(block.timestamp + 120);
+            vm.roll(block.number + 1);
+            pp.pokeMedian();
+            swapperc.burn(uniPool, -10, 10, 10 ** 18);
+        }
+        swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
+
+        int24 tickSpacing = uniPool.tickSpacing();
+        // mint ITM position
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                (0 / tickSpacing) * tickSpacing,
+                2
+            )
+        );
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(1800));
+
+        vm.startPrank(Bob);
+
+        ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+        ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+        token0.approve(address(ct0), 1_000_000);
+        ct0.deposit(0, Bob);
+        token1.approve(address(ct1), 1_000_000);
+        ct1.deposit(10_430, Bob);
+
+        uint256 snapshot = vm.snapshot();
+
+        // mint succeeds
+        pp.mintOptions(
+            $posIdList,
+            100_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        vm.revertTo(snapshot);
+
+        vm.startPrank(Swapper);
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(1801));
+
+        vm.startPrank(Bob);
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.mintOptions(
+            $posIdList,
+            100_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
+    function test_Success_InsolventAtCurrentTick_up() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // setup mini-median price array
+        for (uint256 i = 0; i < 10; ++i) {
+            swapperc.mint(uniPool, -10, 10, 10 ** 18);
+            vm.warp(block.timestamp + 120);
+            vm.roll(block.number + 1);
+            pp.pokeMedian();
+            swapperc.burn(uniPool, -10, 10, 10 ** 18);
+        }
+        swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
+
+        int24 tickSpacing = uniPool.tickSpacing();
+        // mint ITM position
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                1,
+                0,
+                (0 / tickSpacing) * tickSpacing,
+                2
+            )
+        );
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-1801));
+
+        vm.startPrank(Bob);
+
+        ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+        ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+        token0.approve(address(ct0), 1_000_000);
+        ct0.deposit(0, Bob);
+        token1.approve(address(ct1), 1_000_000);
+        ct1.deposit(10_430, Bob);
+
+        uint256 snapshot = vm.snapshot();
+
+        // mint succeeds
+        pp.mintOptions(
+            $posIdList,
+            100_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        vm.revertTo(snapshot);
+
+        vm.startPrank(Swapper);
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-1802));
+
+        vm.startPrank(Bob);
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.mintOptions(
+            $posIdList,
+            100_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
     function test_Fail_WithdrawWithOpenPositions_SolventReceiver_AccountInsolvent() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -2094,6 +2094,122 @@ contract Misctest is Test, PositionUtils {
         ct0.withdraw(1_000_000 - 266262, Bob, Bob, $posIdList);
     }
 
+    function test_Fail_InsolventAtCurrentTick_itmPut() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // setup mini-median price array
+        for (uint256 i = 0; i < 10; ++i) {
+            swapperc.mint(uniPool, -10, 10, 10 ** 18);
+            vm.warp(block.timestamp + 120);
+            vm.roll(block.number + 1);
+            pp.pokeMedian();
+            swapperc.burn(uniPool, -10, 10, 10 ** 18);
+        }
+        swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
+
+        int24 tickSpacing = uniPool.tickSpacing();
+        // mint ITM position
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                1,
+                0,
+                (0 / tickSpacing) * tickSpacing,
+                2
+            )
+        );
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-955));
+
+        vm.startPrank(Bob);
+
+        ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+        ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+        token0.approve(address(ct0), 1_000_000);
+        ct0.deposit(0, Bob);
+        token1.approve(address(ct1), 1_000_000);
+
+        // deposit bare minimum
+        ct1.deposit(17_817, Bob);
+
+        // mint fails
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.mintOptions(
+            $posIdList,
+            100_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
+    function test_Fail_InsolventAtCurrentTick_itmCall() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        // setup mini-median price array
+        for (uint256 i = 0; i < 10; ++i) {
+            swapperc.mint(uniPool, -10, 10, 10 ** 18);
+            vm.warp(block.timestamp + 120);
+            vm.roll(block.number + 1);
+            pp.pokeMedian();
+            swapperc.burn(uniPool, -10, 10, 10 ** 18);
+        }
+        swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
+
+        int24 tickSpacing = uniPool.tickSpacing();
+        // mint ITM position
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                (0 / tickSpacing) * tickSpacing,
+                2
+            )
+        );
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(954));
+
+        vm.startPrank(Bob);
+
+        ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
+        ct1.withdraw(ct1.maxWithdraw(Bob), Bob, Bob);
+
+        token0.approve(address(ct0), 1_000_000);
+        ct0.deposit(0, Bob);
+        token1.approve(address(ct1), 1_000_000);
+
+        // deposit bare minimum
+        ct1.deposit(17_811, Bob);
+
+        // mint fails
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.mintOptions(
+            $posIdList,
+            100_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
     function test_Success_InsolventAtCurrentTick_itmPut() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -2094,7 +2094,7 @@ contract Misctest is Test, PositionUtils {
         ct0.withdraw(1_000_000 - 266262, Bob, Bob, $posIdList);
     }
 
-    function test_Success_InsolventAtCurrentTick_down() public {
+    function test_Success_InsolventAtCurrentTick_itmPut() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -2120,14 +2120,16 @@ contract Misctest is Test, PositionUtils {
                 1,
                 1,
                 0,
-                0,
+                1,
                 0,
                 (0 / tickSpacing) * tickSpacing,
                 2
             )
         );
 
-        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(1800));
+        (, int24 staleTick, , , , , ) = uniPool.slot0();
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-954));
 
         vm.startPrank(Bob);
 
@@ -2137,7 +2139,9 @@ contract Misctest is Test, PositionUtils {
         token0.approve(address(ct0), 1_000_000);
         ct0.deposit(0, Bob);
         token1.approve(address(ct1), 1_000_000);
-        ct1.deposit(10_430, Bob);
+
+        // deposit bare minimum
+        ct1.deposit(17_817, Bob);
 
         uint256 snapshot = vm.snapshot();
 
@@ -2149,12 +2153,67 @@ contract Misctest is Test, PositionUtils {
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK
         );
+        (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(
+            pp,
+            Bob,
+            staleTick,
+            0,
+            $posIdList
+        );
+
+        assertTrue(totalCollateralBalance0 > totalCollateralRequired0, "Is solvent at stale tick!");
+
+        (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+        (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
+            pp,
+            Bob,
+            currentTick,
+            0,
+            $posIdList
+        );
+
+        assertTrue(
+            totalCollateralBalance0 <= totalCollateralRequired0,
+            "Is liquidatable at current tick!"
+        );
+
+        vm.startPrank(Swapper);
+
+        // setup mini-median price array
+        for (uint256 i = 0; i < 10; ++i) {
+            swapperc.mint(uniPool, -100000, 100000, 10 ** 18);
+            vm.warp(block.timestamp + 120);
+            vm.roll(block.number + 1);
+            pp.pokeMedian();
+            swapperc.burn(uniPool, -100000, 100000, 10 ** 18);
+        }
+
+        vm.startPrank(Alice);
+
+        // deal alice a bunch of collateral tokens without touching the supply
+        editCollateral(ct0, Alice, ct0.convertToShares(type(uint120).max));
+        editCollateral(ct1, Alice, ct1.convertToShares(type(uint120).max));
+
+        pp.liquidate(
+            new TokenId[](0),
+            Bob,
+            LeftRightUnsigned.wrap(type(uint120).max - 1).toLeftSlot(type(uint120).max - 1),
+            $posIdList
+        );
+
+        (uint256 after0, uint256 after1) = (
+            ct0.convertToAssets(ct0.balanceOf(Bob)),
+            ct1.convertToAssets(ct1.balanceOf(Bob))
+        );
+
+        assertTrue((after0 > 0) || (after1 > 0), "no protocol loss");
 
         vm.revertTo(snapshot);
 
         vm.startPrank(Swapper);
 
-        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(1801));
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-955));
 
         vm.startPrank(Bob);
 
@@ -2168,7 +2227,7 @@ contract Misctest is Test, PositionUtils {
         );
     }
 
-    function test_Success_InsolventAtCurrentTick_up() public {
+    function test_Success_InsolventAtCurrentTick_itmCall() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -2194,14 +2253,16 @@ contract Misctest is Test, PositionUtils {
                 1,
                 1,
                 0,
-                1,
+                0,
                 0,
                 (0 / tickSpacing) * tickSpacing,
                 2
             )
         );
 
-        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-1801));
+        (, int24 staleTick, , , , , ) = uniPool.slot0();
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(953));
 
         vm.startPrank(Bob);
 
@@ -2211,7 +2272,9 @@ contract Misctest is Test, PositionUtils {
         token0.approve(address(ct0), 1_000_000);
         ct0.deposit(0, Bob);
         token1.approve(address(ct1), 1_000_000);
-        ct1.deposit(10_430, Bob);
+
+        // deposit bare minimum
+        ct1.deposit(17_811, Bob);
 
         uint256 snapshot = vm.snapshot();
 
@@ -2223,12 +2286,67 @@ contract Misctest is Test, PositionUtils {
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK
         );
+        (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(
+            pp,
+            Bob,
+            staleTick,
+            0,
+            $posIdList
+        );
+
+        assertTrue(totalCollateralBalance0 > totalCollateralRequired0, "Is solvent at stale tick!");
+
+        (, int24 currentTick, , , , , ) = uniPool.slot0();
+
+        (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
+            pp,
+            Bob,
+            currentTick,
+            0,
+            $posIdList
+        );
+
+        assertTrue(
+            totalCollateralBalance0 <= totalCollateralRequired0,
+            "Is liquidatable at current tick!"
+        );
+
+        vm.startPrank(Swapper);
+
+        // setup mini-median price array
+        for (uint256 i = 0; i < 10; ++i) {
+            swapperc.mint(uniPool, -100000, 100000, 10 ** 18);
+            vm.warp(block.timestamp + 120);
+            vm.roll(block.number + 1);
+            pp.pokeMedian();
+            swapperc.burn(uniPool, -100000, 100000, 10 ** 18);
+        }
+
+        vm.startPrank(Alice);
+
+        // deal alice a bunch of collateral tokens without touching the supply
+        editCollateral(ct0, Alice, ct0.convertToShares(type(uint120).max));
+        editCollateral(ct1, Alice, ct1.convertToShares(type(uint120).max));
+
+        pp.liquidate(
+            new TokenId[](0),
+            Bob,
+            LeftRightUnsigned.wrap(type(uint120).max - 1).toLeftSlot(type(uint120).max - 1),
+            $posIdList
+        );
+
+        (uint256 after0, uint256 after1) = (
+            ct0.convertToAssets(ct0.balanceOf(Bob)),
+            ct1.convertToAssets(ct1.balanceOf(Bob))
+        );
+
+        assertTrue((after0 > 0) || (after1 > 0), "no protocol loss");
 
         vm.revertTo(snapshot);
 
         vm.startPrank(Swapper);
 
-        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-1802));
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(954));
 
         vm.startPrank(Bob);
 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -2358,6 +2358,14 @@ contract Misctest is Test, PositionUtils {
         token0.approve(address(swapperc), type(uint128).max);
         token1.approve(address(swapperc), type(uint128).max);
 
+        // setup mini-median price array
+        for (uint256 i = 0; i < 10; ++i) {
+            swapperc.mint(uniPool, -10, 10, 10 ** 18);
+            vm.warp(block.timestamp + 120);
+            vm.roll(block.number + 1);
+            pp.pokeMedian();
+            swapperc.burn(uniPool, -10, 10, 10 ** 18);
+        }
         swapperc.mint(uniPool, -10, 10, 10 ** 18);
 
         vm.startPrank(Seller);

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -2681,7 +2681,7 @@ contract PanopticPoolTest is PositionUtils {
         }
         (, currentTick, observationIndex, observationCardinality, , , ) = pool.slot0();
 
-        fastOracleTick = PanopticMath.computeMedianObservedPrice(
+        (fastOracleTick, ) = PanopticMath.computeMedianObservedPrice(
             pool,
             observationIndex,
             observationCardinality,
@@ -2689,7 +2689,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,
@@ -2834,7 +2834,7 @@ contract PanopticPoolTest is PositionUtils {
         }
         (, currentTick, observationIndex, observationCardinality, , , ) = pool.slot0();
 
-        fastOracleTick = PanopticMath.computeMedianObservedPrice(
+        (fastOracleTick, ) = PanopticMath.computeMedianObservedPrice(
             pool,
             observationIndex,
             observationCardinality,
@@ -2842,7 +2842,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,
@@ -2995,7 +2995,7 @@ contract PanopticPoolTest is PositionUtils {
         (currentSqrtPriceX96, currentTick, observationIndex, observationCardinality, , , ) = pool
             .slot0();
 
-        fastOracleTick = PanopticMath.computeMedianObservedPrice(
+        (fastOracleTick, ) = PanopticMath.computeMedianObservedPrice(
             pool,
             observationIndex,
             observationCardinality,
@@ -3003,7 +3003,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,
@@ -3210,7 +3210,7 @@ contract PanopticPoolTest is PositionUtils {
         (currentSqrtPriceX96, currentTick, observationIndex, observationCardinality, , , ) = pool
             .slot0();
 
-        fastOracleTick = PanopticMath.computeMedianObservedPrice(
+        (fastOracleTick, ) = PanopticMath.computeMedianObservedPrice(
             pool,
             observationIndex,
             observationCardinality,
@@ -3218,7 +3218,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,
@@ -4776,7 +4776,7 @@ contract PanopticPoolTest is PositionUtils {
             int256 balanceDelta1 = int256(ct1.balanceOf(Alice)) -
                 int256(lastCollateralBalance1[Alice]);
             (, , observationIndex, observationCardinality, , , ) = pool.slot0();
-            int24 _fastOracleTick = PanopticMath.computeMedianObservedPrice(
+            (int24 _fastOracleTick, ) = PanopticMath.computeMedianObservedPrice(
                 pool,
                 observationIndex,
                 observationCardinality,

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1527,7 +1527,7 @@ contract PanopticPoolTest is PositionUtils {
         uint256 assets0 = ct0.convertToAssets(ct0.balanceOf(Bob));
         uint256 assets1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
-        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         pp.assertMinCollateralValues(assets0 + 1, assets1);
     }
 
@@ -1539,7 +1539,7 @@ contract PanopticPoolTest is PositionUtils {
         uint256 assets0 = ct0.convertToAssets(ct0.balanceOf(Bob));
         uint256 assets1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
-        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         pp.assertMinCollateralValues(assets0, assets1 + 1);
     }
 
@@ -1551,7 +1551,7 @@ contract PanopticPoolTest is PositionUtils {
         uint256 assets0 = ct0.convertToAssets(ct0.balanceOf(Bob));
         uint256 assets1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
-        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         pp.assertMinCollateralValues(assets0 + 1, assets1 + 1);
     }
 
@@ -3599,7 +3599,7 @@ contract PanopticPoolTest is PositionUtils {
         );
     }
 
-    function test_Fail_mintOptions_OTMShortCall_NotEnoughCollateral(
+    function test_Fail_mintOptions_OTMShortCall_AccountInsolvent(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,
@@ -3644,7 +3644,7 @@ contract PanopticPoolTest is PositionUtils {
             Charlie
         );
 
-        vm.expectRevert(Errors.NotEnoughCollateral.selector);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         pp.mintOptions(
             posIdList,
             uint128(positionSize),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -2689,7 +2689,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,
@@ -2842,7 +2842,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,
@@ -3003,7 +3003,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,
@@ -3218,7 +3218,7 @@ contract PanopticPoolTest is PositionUtils {
             1
         );
 
-        (slowOracleTick, , ) = PanopticMath.computeInternalMedian(
+        (slowOracleTick, ) = PanopticMath.computeInternalMedian(
             observationIndex,
             observationCardinality,
             60,

--- a/test/foundry/libraries/harnesses/PanopticMathHarness.sol
+++ b/test/foundry/libraries/harnesses/PanopticMathHarness.sol
@@ -89,7 +89,7 @@ contract PanopticMathHarness is Test {
         uint256 cardinality,
         uint256 period
     ) public view returns (int24) {
-        int24 lastMedianObservation = PanopticMath.computeMedianObservedPrice(
+        (int24 lastMedianObservation, ) = PanopticMath.computeMedianObservedPrice(
             univ3pool,
             observationIndex,
             observationCardinality,


### PR DESCRIPTION
This splits PR https://github.com/panoptic-labs/panoptic-v1-core-private/pull/76 into smaller chunks.

This first PR checks that the account is solvent at the slow+fast oracle ticks if currentTick diverges too much from oracle ticks