### PR TITLE
fix: some typos in comments

### DIFF
--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -224,7 +224,6 @@ contract PanopticFactory is FactoryNFT, Multicall {
 
         // Mints the full-range initial deposit
         // which is why the deployer becomes also a "donor" of full-range liquidity
-        // The SFPM will `safeTransferFrom` tokens from the donor during the mint callback
         (uint256 amount0, uint256 amount1) = _mintFullRange(v3Pool, token0, token1, fee);
 
         if (amount0 > amount0Max || amount1 > amount1Max) revert Errors.PriceBoundFail();

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -168,7 +168,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     SemiFungiblePositionManager internal immutable SFPM;
 
     /*//////////////////////////////////////////////////////////////
-                                STORAGE 
+                                STORAGE
     //////////////////////////////////////////////////////////////*/
 
     /// @notice The Uniswap v3 pool that this instance of Panoptic is deployed on.
@@ -1316,7 +1316,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 Math.mulDiv(uint256(tokenData1.rightSlot()), 2 ** 96, sqrtPriceX96) +
                 Math.mulDiv96(tokenData0.rightSlot(), sqrtPriceX96);
             // the amount of cross-collateral balance needed for the account to be solvent, computed in terms of liquidity
-            // overstimate by rounding up
+            // overestimate by rounding up
             thresholdCross =
                 Math.mulDivRoundingUp(uint256(tokenData1.leftSlot()), 2 ** 96, sqrtPriceX96) +
                 Math.mulDiv96RoundingUp(tokenData0.leftSlot(), sqrtPriceX96);

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -243,7 +243,7 @@ library LeftRightLibrary {
     }
 
     /// @notice Subtract two LeftRight-encoded words; revert on overflow or underflow.
-    /// @notice FOr each slot, rectify difference `x - y` to 0 if negative.
+    /// @notice For each slot, rectify difference `x - y` to 0 if negative.
     /// @param x The minuend
     /// @param y The subtrahend
     /// @return z The difference `x - y`


### PR DESCRIPTION
- typo on overstimate in _getSolvencyBalances - Found this comment while tracing check solvency logic
- miscapitalisation of For in subRect - should be For not FOr
- (from Henry) remove claim in PanopticFactory about the SFPM that is no longer true 