### PR TITLE
fix: prevent `s_poolAssets` and `s_inAMM` underflowing during settlement

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1043,7 +1043,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // however, any intrinsic value is paid for by the users, so we only add the portion that comes from PLPs: the short/long amounts
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets).toUint128();
-            s_inAMM = uint128(uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)));
+            s_inAMM = uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)).toUint128();
 
             utilization = _poolUtilization();
         }
@@ -1089,7 +1089,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // any intrinsic value is paid for by the users, so we do not add it to s_inAMM
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
-            s_inAMM = uint128(uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)));
+            s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
 
             return (int128(tokenToPay));
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1042,7 +1042,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // the inflow or outflow of pool assets is defined by the swappedAmount: it includes both the ITM swap amounts and the short/long amounts used to create the position
             // however, any intrinsic value is paid for by the users, so we only add the portion that comes from PLPs: the short/long amounts
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
-            s_poolAssets = uint128(uint256(updatedAssets));
+            s_poolAssets = uint256(updatedAssets).toUint128();
             s_inAMM = uint128(uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)));
 
             utilization = _poolUtilization();

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1088,7 +1088,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // update stored asset balances with net moved amounts
             // any intrinsic value is paid for by the users, so we do not add it to s_inAMM
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
-            s_poolAssets = uint128(uint256(updatedAssets + realizedPremium));
+            s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
             s_inAMM = uint128(uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)));
 
             return (int128(tokenToPay));

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -873,7 +873,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.deposit(1000, Bob);
         collateralToken1.deposit(type(uint104).max, Bob);
 
-        collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 500);
+        collateralToken0.setPoolAssets(500);
         collateralToken0.setInAMM(500);
 
         (width, strike) = PositionUtils.getOTMSW(

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -897,7 +897,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
         );
     }
 
-    // mint a position with greater than s_poolAssets
     function test_Fail_burnGTAvailableAssets(uint256 widthSeed, int256 strikeSeed) public {
         // initalize world state
         _initWorld(0);
@@ -945,6 +944,104 @@ contract CollateralTrackerTest is Test, PositionUtils {
         );
 
         collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 300);
+
+        positionIdList.pop();
+
+        vm.expectRevert(Errors.CastingError.selector);
+        panopticPool.burnOptions(
+            tokenId,
+            positionIdList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
+    function test_Fail_mintGTInAMM(uint256 widthSeed, int256 strikeSeed) public {
+        // initalize world state
+        _initWorld(0);
+
+        // Invoke all interactions with the Collateral Tracker from user Bob
+        vm.startPrank(Bob);
+
+        // give Bob the max amount of tokens
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        IERC20Partial(token1).approve(address(collateralToken1), type(uint256).max);
+
+        collateralToken0.deposit(1000, Bob);
+        collateralToken1.deposit(type(uint104).max, Bob);
+
+        (width, strike) = PositionUtils.getOTMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        panopticPool.mintOptions(
+            positionIdList,
+            750,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        collateralToken0.setInAMM(450);
+
+        vm.expectRevert(Errors.CastingError.selector);
+        panopticPool.mintOptions(
+            positionIdList,
+            500,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
+    function test_Fail_burnGTInAMM(uint256 widthSeed, int256 strikeSeed) public {
+        // initalize world state
+        _initWorld(0);
+
+        // Invoke all interactions with the Collateral Tracker from user Bob
+        vm.startPrank(Bob);
+
+        // give Bob the max amount of tokens
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        IERC20Partial(token1).approve(address(collateralToken1), type(uint256).max);
+
+        collateralToken0.deposit(1000, Bob);
+        collateralToken1.deposit(type(uint104).max, Bob);
+
+        (width, strike) = PositionUtils.getOTMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        panopticPool.mintOptions(
+            positionIdList,
+            750,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        collateralToken0.setInAMM(500);
 
         positionIdList.pop();
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -3870,6 +3870,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
+            uint256 inAMMOffset = collateralToken0._inAMM();
+
             panopticPool.mintOptions(
                 positionIdList,
                 positionSize0,
@@ -3877,8 +3879,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK
             );
-
-            uint256 inAMMOffset = collateralToken0._inAMM();
 
             vm.revertTo(snapshot);
 
@@ -4036,6 +4036,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
+            uint256 inAMMOffset = collateralToken0._inAMM();
+
             panopticPool.mintOptions(
                 positionIdList,
                 positionSize0,
@@ -4043,8 +4045,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK
             );
-
-            uint256 inAMMOffset = collateralToken0._inAMM();
 
             vm.revertTo(snapshot);
 
@@ -4209,6 +4209,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
+            uint256 inAMMOffset = collateralToken0._inAMM();
+
             panopticPool.mintOptions(
                 positionIdList,
                 positionSize0,
@@ -4216,8 +4218,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK
             );
-
-            uint256 inAMMOffset = collateralToken0._inAMM();
 
             vm.revertTo(snapshot);
 
@@ -4371,6 +4371,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
+            uint256 inAMMOffset = collateralToken1._inAMM();
+
             panopticPool.mintOptions(
                 positionIdList,
                 positionSize0,
@@ -4378,8 +4380,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK
             );
-
-            uint256 inAMMOffset = collateralToken1._inAMM();
 
             vm.revertTo(snapshot);
 
@@ -4530,6 +4530,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
+            uint256 inAMMOffset = collateralToken0._inAMM();
+
             panopticPool.mintOptions(
                 positionIdList,
                 positionSize0,
@@ -4537,8 +4539,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK
             );
-
-            uint256 inAMMOffset = collateralToken0._inAMM();
 
             vm.revertTo(snapshot);
 
@@ -4687,6 +4687,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
+            uint256 inAMMOffset = collateralToken1._inAMM();
+
             panopticPool.mintOptions(
                 positionIdList,
                 positionSize0,
@@ -4694,8 +4696,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK
             );
-
-            uint256 inAMMOffset = collateralToken1._inAMM();
 
             vm.revertTo(snapshot);
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -853,6 +853,51 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.withdraw(maxAssets + 1, Bob, Bob, new TokenId[](0));
     }
 
+    // mint a position with greater than s_poolAssets
+    function test_Fail_mintGTAvailableCollateral(
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        // initalize world state
+        _initWorld(0);
+
+        // Invoke all interactions with the Collateral Tracker from user Bob
+        vm.startPrank(Bob);
+
+        // give Bob the max amount of tokens
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        IERC20Partial(token1).approve(address(collateralToken1), type(uint256).max);
+
+        collateralToken0.deposit(1000, Bob);
+        collateralToken1.deposit(type(uint104).max, Bob);
+
+        collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 500);
+        collateralToken0.setInAMM(500);
+
+        (width, strike) = PositionUtils.getOTMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        vm.expectRevert(Errors.CastingError.selector);
+        panopticPool.mintOptions(
+            positionIdList,
+            uint128(bound(positionSizeSeed, 501, 1000)),
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
     function test_Fail_removeGtAvailableCollateral() public {
         // initalize world state
         _initWorld(0);

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -994,7 +994,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
-        collateralToken0.setInAMM(450);
+        collateralToken0.setInAMM(-300);
 
         vm.expectRevert(Errors.CastingError.selector);
         panopticPool.mintOptions(
@@ -1041,7 +1041,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             Constants.MIN_V3POOL_TICK
         );
 
-        collateralToken0.setInAMM(500);
+        collateralToken0.setInAMM(-250);
 
         positionIdList.pop();
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -853,8 +853,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.withdraw(maxAssets + 1, Bob, Bob, new TokenId[](0));
     }
 
-    // mint a position with greater than s_poolAssets
-    function test_Fail_mintGTAvailableCollateral(
+    function test_Fail_mintGTAvailableAssets(
         uint256 widthSeed,
         int256 strikeSeed,
         uint256 positionSizeSeed
@@ -893,6 +892,66 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList,
             uint128(bound(positionSizeSeed, 501, 1000)),
             0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+    }
+
+    // mint a position with greater than s_poolAssets
+    function test_Fail_burnGTAvailableAssets(uint256 widthSeed, int256 strikeSeed) public {
+        // initalize world state
+        _initWorld(0);
+
+        // Invoke all interactions with the Collateral Tracker from user Bob
+        vm.startPrank(Bob);
+
+        // give Bob the max amount of tokens
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        IERC20Partial(token1).approve(address(collateralToken1), type(uint256).max);
+
+        collateralToken0.deposit(1000, Bob);
+        collateralToken1.deposit(type(uint104).max, Bob);
+
+        (width, strike) = PositionUtils.getOTMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        panopticPool.mintOptions(
+            positionIdList,
+            750,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        panopticPool.mintOptions(
+            positionIdList,
+            500,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 300);
+
+        positionIdList.pop();
+
+        vm.expectRevert(Errors.CastingError.selector);
+        panopticPool.burnOptions(
+            tokenId,
+            positionIdList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK
         );

--- a/test/foundry/testUtils/PositionUtils.sol
+++ b/test/foundry/testUtils/PositionUtils.sol
@@ -1438,7 +1438,7 @@ contract PositionUtils is Test {
                     LeftRightSigned.unwrap(
                         LeftRightSigned
                             .wrap(int256(uint256(vm.load(address(ct), bytes32(uint256(7))))))
-                            .add(LeftRightSigned.wrap(int128(assetDelta)))
+                            .add(LeftRightSigned.wrap(int256(uint256(uint128(int128(assetDelta))))))
                     )
                 )
             )

--- a/test/foundry/testUtils/PositionUtils.sol
+++ b/test/foundry/testUtils/PositionUtils.sol
@@ -1438,7 +1438,7 @@ contract PositionUtils is Test {
                     LeftRightSigned.unwrap(
                         LeftRightSigned
                             .wrap(int256(uint256(vm.load(address(ct), bytes32(uint256(7))))))
-                            .add(LeftRightSigned.wrap(assetDelta))
+                            .add(LeftRightSigned.wrap(int128(assetDelta)))
                     )
                 )
             )


### PR DESCRIPTION
In #78 we fixed a potential `s_poolAssets` underflow that could result in the collateral requirement scaling mechanism not working as intended due to inaccurate pool utilizations. It turns out that similar underflows (where assets are donated to the pool, allowing a call to go through that moves more tokens than are counted in the internal trackers) are also possible during settlement:

- `s_poolAssets` can underflow in `takeCommissionAddData` if a short position is minted with more tokens than counted in `s_poolAssets`
- `s_inAMM` can technically underflow in `takeCommissionAddData` if a long position is minted with `longAmount > s_inAMM` (i.e. opposing long/short positions use opposing `asset` values resulting in different `shortAmount`/`longAmount` corresponding to the same liquidity)
- `s_poolAssets` can underflow in `exercise` if a long position is closed with more assets than counted in `s_poolAssets`
- `s_inAMM` can technically underflow in `exercise` if a short position is closed with `shortAmount > s_inAMM` (again, due to potential discrepancies in movedAmounts/liquidity links between short/long positions)