### PR TITLE
test: raise gas limit back to 2**63 (default was lowered to ~1B)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,6 +8,7 @@ solc_version = '0.8.25'
 optimizer = true
 optimizer_runs = 1
 viaIR = false
+gas_limit = 9223372036854775807
 eth_rpc_url = "https://mainnet.infura.io/v3/901ff66ce2bd4fa89b01c5fd38f0ccc9"
 fs_permissions = [{ access = "read", path = "./"}]
 


### PR DESCRIPTION
https://github.com/foundry-rs/foundry/pull/8274

Paradigm run an open source project with an actual release schedule instead of nightly breaking changes: impossible edition

(We have a few very-high-gas-usage tests that require higher gas limits than ~1B, so this was breaking for us)