### PR TITLE
fix: prevent 0-liquidity positions from being created

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -988,7 +988,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
 
             // s_accountLiquidity is a LeftRight. The right slot represents the liquidity currently sold (added) in the AMM owned by the user
             // the left slot represents the amount of liquidity currently bought (removed) that has been removed from the AMM - the user owes it to a seller
-            // the reason why it is called "removedLiquidity" is because long options are created by removing -ie.short selling LP positions
+            // the reason why it is called "removedLiquidity" is because long options are created by removing - ie. short selling LP positions
             uint128 startingLiquidity = currentLiquidity.rightSlot();
             uint128 removedLiquidity = currentLiquidity.leftSlot();
             uint128 chunkLiquidity = liquidityChunk.liquidity();

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -993,6 +993,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
             uint128 removedLiquidity = currentLiquidity.leftSlot();
             uint128 chunkLiquidity = liquidityChunk.liquidity();
 
+            // 0-liquidity interactions are asymmetrical in Uniswap (burning 0 liquidity is permitted and functions as a poke, but minting is prohibited)
+            // thus, we prohibit all 0-liquidity chunks to prevent users from creating positions that cannot be closed
+            if (chunkLiquidity == 0) revert Errors.ZeroLiquidity();
+
             if (isLong == 0) {
                 // selling/short: so move from msg.sender *to* uniswap
                 // we're minting more liquidity in uniswap: so add the incoming liquidity chunk to the existing liquidity chunk

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -105,4 +105,7 @@ library Errors {
 
     /// @notice The Uniswap Pool has not been created, so it cannot be used in the SFPM or factory
     error UniswapPoolNotInitialized();
+
+    /// @notice SFPM: Mints/burns of 0-liquidity chunks in Uniswap are not supported
+    error ZeroLiquidity();
 }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -425,6 +425,49 @@ contract Misctest is Test, PositionUtils {
         );
     }
 
+    function test_fail_mint0liquidity_SFPM() public {
+        vm.startPrank(Seller);
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                -224040,
+                3540
+            )
+        );
+
+        vm.expectRevert(Errors.ZeroLiquidity.selector);
+        pp.mintOptions($posIdList, 537, 0, Constants.MIN_V3POOL_TICK, Constants.MAX_V3POOL_TICK);
+
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK
+        );
+
+        vm.startPrank(Alice);
+        $posIdList[0] = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+            0,
+            1,
+            0,
+            1,
+            0,
+            0,
+            -224040,
+            3540
+        );
+
+        vm.expectRevert(Errors.ZeroLiquidity.selector);
+        pp.mintOptions($posIdList, 537, 0, Constants.MIN_V3POOL_TICK, Constants.MAX_V3POOL_TICK);
+    }
+
     function test_success_MintBurnCallSpread() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);


### PR DESCRIPTION
This prevents a potential DoS found by our Echidna tests that could interfere with liquidations and other functionality. 

For some reason, Uniswap allows pokes to be executed via 0-liquidity burns, but reverts any 0-liquidity mints (despite the lack of any obvious technical barriers). The unfortunate consequence of this is that while Panoptic users are permitted to create 0-liquidity long positions (which is a valid `.burn(, , 0)` call), they cannot close those positions under any circumstances (SFPM users could increase their position size, but PanopticPool positions cannot be modified once created).

It is important that we prevent those positions from being created because they prevent any otherwise valid liquidations/force exercises from going through on a given account. While this PR prevents *all* 0-liquidity interactions with Uniswap, we could permit 0-liquidity mints in the SFPM to some degree (either by moving the check to the PanopticPool or skipping 0-liquidity mints), though I don't necessarily see any utility in that.