### PR TITLE
fix: reduce `positionTooLarge`  threshold in SFPM to account for rounding at mint

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -933,7 +933,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall {
         // Ensure upper bound on amount of tokens contained across all legs of the position on any given tick does not exceed a maximum of (2**127-1).
         // This is the maximum value of the `int128` type we frequently use to hold token amounts, so a given position's size should be guaranteed to
         // fit within that limit at all times.
-        if (amount0 > uint128(type(int128).max) || amount1 > uint128(type(int128).max))
+        if (amount0 > uint128(type(int128).max - 4) || amount1 > uint128(type(int128).max - 4))
             revert Errors.PositionTooLarge();
     }
 


### PR DESCRIPTION
Guillaume made the point that because Uniswap rounds up token amounts during liquidity adds, a position that passes the `positionTooLarge` check could in theory require 4 tokens more than the maximum int128 value to mint. 

While this check doesn't resolve all issues presented by very large amounts of tokens (and does not consider other quantities that could contribute to issues around these limits such as premium payments and swap deltas), I see no harm in reducing the threshold somewhat to a (still very large/reasonable) limit.