### PR TITLE
feat: fixed-size virtual delegation for force exercises

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -17,7 +17,6 @@ import {SafeTransferLib} from "@libraries/SafeTransferLib.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
-import "forge-std/Test.sol";
 
 /// @title Collateral Tracking System / Margin Accounting used in conjunction with a Panoptic Pool.
 /// @author Axicon Labs Limited
@@ -375,7 +374,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Returns the maximum deposit amount.
     /// @return maxAssets The maximum amount of assets that can be deposited
     function maxDeposit(address) external pure returns (uint256 maxAssets) {
-        return Constants.MAX_DEPOSIT_ASSETS;
+        return type(uint104).max;
     }
 
     /// @notice Returns shares received for depositing given amount of assets.
@@ -393,14 +392,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Deposit underlying tokens (assets) to the Panoptic pool from the LP and mint corresponding amount of shares.
-    /// @dev There is a maximum asset deposit limit of Constants.MAX_DEPOSIT_ASSETS.
+    /// @dev There is a maximum asset deposit limit of 2 ** 104 - 1.
     /// @dev An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP ('receiver').
     /// @param assets Amount of assets deposited
     /// @param receiver User to receive the shares
     /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        if (assets > Constants.MAX_DEPOSIT_ASSETS) revert Errors.DepositTooLarge();
+        if (assets > type(uint104).max) revert Errors.DepositTooLarge();
 
         shares = previewDeposit(assets);
 
@@ -428,9 +427,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return maxShares The maximum amount of shares that can be minted.
     function maxMint(address) external view returns (uint256 maxShares) {
         unchecked {
-            return
-                (convertToShares(Constants.MAX_DEPOSIT_ASSETS) * (DECIMALS - COMMISSION_FEE)) /
-                DECIMALS;
+            return (convertToShares(type(uint104).max) * (DECIMALS - COMMISSION_FEE)) / DECIMALS;
         }
     }
 
@@ -453,7 +450,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Deposit required amount of assets to receive specified amount of shares.
-    /// There is a maximum asset deposit limit of Constants.MAX_DEPOSIT_ASSETS.
+    /// There is a maximum asset deposit limit of 2**104 - 1.
     /// An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP ('receiver').
     /// @param shares Amount of shares to be minted.
@@ -462,7 +459,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
         assets = previewMint(shares);
 
-        if (assets > Constants.MAX_DEPOSIT_ASSETS) revert Errors.DepositTooLarge();
+        if (assets > type(uint104).max) revert Errors.DepositTooLarge();
 
         // transfer assets (underlying token funds) from the user/the LP to the PanopticPool
         // in return for the shares to be minted
@@ -1077,8 +1074,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             // add premium and token deltas not covered by swap to be paid/collected on position close
             int256 tokenToPay = swappedAmount - (longAmount - shortAmount) - realizedPremium;
-            console2.log("totalAssetsBefore", totalAssets());
-            console2.log("totalSupplyBefore", totalSupply);
+
             if (tokenToPay > 0) {
                 // if user must pay tokens, burn them from user balance (revert if balance too small)
                 uint256 sharesToBurn = Math.mulDivRoundingUp(
@@ -1086,30 +1082,18 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     totalSupply,
                     totalAssets()
                 );
-                console2.log("totalSharesDelta", -int256(sharesToBurn));
                 _burn(optionOwner, sharesToBurn);
             } else if (tokenToPay < 0) {
                 // if user must receive tokens, mint them
                 uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
-                console2.log("totalSharesDelta", sharesToMint);
                 _mint(optionOwner, sharesToMint);
             }
 
-            console2.log(
-                "totalAssetsDelta",
-                (updatedAssets +
-                    realizedPremium +
-                    int256(uint256(s_inAMM)) -
-                    (shortAmount - longAmount)) - int256(uint256(s_poolAssets) + s_inAMM)
-            );
             // update stored asset balances with net moved amounts
             // any intrinsic value is paid for by the users, so we do not add it to s_inAMM
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
             s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
-
-            console2.log("totalAssetsAfter", totalAssets());
-            console2.log("totalSupplyAfter", totalSupply);
 
             return (int128(tokenToPay));
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -17,6 +17,7 @@ import {SafeTransferLib} from "@libraries/SafeTransferLib.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
+import "forge-std/Test.sol";
 
 /// @title Collateral Tracking System / Margin Accounting used in conjunction with a Panoptic Pool.
 /// @author Axicon Labs Limited
@@ -905,22 +906,26 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         _transferFrom(delegator, delegatee, shares);
     }
 
-    /// @notice Delegate and transfer shares corresponding to the incoming assets from the protocol to `delegatee`.
+    /// @notice Increase the share balance of a user by shares worth `assets` without updating the total supply.
     /// @dev This is controlled by the Panoptic Pool - not individual users.
-    /// @dev Mints ghost shares so a position can be settled - the total supply is not affected.
-    /// @param delegatee The delegatee to send shares to - the recipient of the shares
-    /// @param assets The assets to which the shares delegated correspond
-    function delegate(address delegatee, uint256 assets) external onlyPanopticPool {
-        balanceOf[delegatee] += convertToShares(assets);
+    /// @param delegatee The account to increase the balance of
+    /// @param assets The amount of assets worth of shares to mint to `delegatee`
+    /// @return shares The amount of shares minted to `delegatee`
+    function delegate(
+        address delegatee,
+        uint256 assets
+    ) external onlyPanopticPool returns (uint256 shares) {
+        shares = convertToShares(assets);
+        balanceOf[delegatee] += shares;
     }
 
-    /// @notice Refunds delegated tokens back to the protocol.
-    /// @dev Assumes that `delegatee` has enough money to pay for the refund.
-    /// @dev Burns ghost shares after a position has been settled - the total supply is not affected.
-    /// @param delegatee The account refunding tokens to 'delegatee'
-    /// @param assets The amount of assets to which the shares to refund to the protocol correspond
-    function refund(address delegatee, uint256 assets) external onlyPanopticPool {
-        balanceOf[delegatee] -= convertToShares(assets);
+    /// @notice Decrease the share balance of a user without updating the total supply.
+    /// @dev Assumes that `delegatee` has enough money to pay for the refund, will revert otherwise.
+    /// @dev This is controlled by the Panoptic Pool - not individual users.
+    /// @param delegatee The account to decrease the balance of
+    /// @param shares The amount of shares to burn from `delegatee`
+    function revoke(address delegatee, uint256 shares) external onlyPanopticPool {
+        balanceOf[delegatee] -= shares;
     }
 
     /// @notice Revoke previously delegated shares. The opposite of 'delegate'.
@@ -1072,7 +1077,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             // add premium and token deltas not covered by swap to be paid/collected on position close
             int256 tokenToPay = swappedAmount - (longAmount - shortAmount) - realizedPremium;
-
+            console2.log("totalAssetsBefore", totalAssets());
+            console2.log("totalSupplyBefore", totalSupply);
             if (tokenToPay > 0) {
                 // if user must pay tokens, burn them from user balance (revert if balance too small)
                 uint256 sharesToBurn = Math.mulDivRoundingUp(
@@ -1080,18 +1086,30 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     totalSupply,
                     totalAssets()
                 );
+                console2.log("totalSharesDelta", -int256(sharesToBurn));
                 _burn(optionOwner, sharesToBurn);
             } else if (tokenToPay < 0) {
                 // if user must receive tokens, mint them
                 uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
+                console2.log("totalSharesDelta", sharesToMint);
                 _mint(optionOwner, sharesToMint);
             }
 
+            console2.log(
+                "totalAssetsDelta",
+                (updatedAssets +
+                    realizedPremium +
+                    int256(uint256(s_inAMM)) -
+                    (shortAmount - longAmount)) - int256(uint256(s_poolAssets) + s_inAMM)
+            );
             // update stored asset balances with net moved amounts
             // any intrinsic value is paid for by the users, so we do not add it to s_inAMM
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
             s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
+
+            console2.log("totalAssetsAfter", totalAssets());
+            console2.log("totalSupplyAfter", totalSupply);
 
             return (int128(tokenToPay));
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -392,7 +392,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Deposit underlying tokens (assets) to the Panoptic pool from the LP and mint corresponding amount of shares.
-    /// @dev There is a maximum asset deposit limit of 2 ** 104 - 1.
+    /// @dev There is a maximum asset deposit limit of (2 ** 104) - 1.
     /// @dev An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP ('receiver').
     /// @param assets Amount of assets deposited
@@ -450,7 +450,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Deposit required amount of assets to receive specified amount of shares.
-    /// There is a maximum asset deposit limit of 2**104 - 1.
+    /// @dev There is a maximum asset deposit limit of (2 ** 104) - 1.
     /// An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP ('receiver').
     /// @param shares Amount of shares to be minted.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -374,7 +374,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Returns the maximum deposit amount.
     /// @return maxAssets The maximum amount of assets that can be deposited
     function maxDeposit(address) external pure returns (uint256 maxAssets) {
-        return type(uint104).max;
+        return Constants.MAX_DEPOSIT_ASSETS;
     }
 
     /// @notice Returns shares received for depositing given amount of assets.
@@ -392,14 +392,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Deposit underlying tokens (assets) to the Panoptic pool from the LP and mint corresponding amount of shares.
-    /// @dev There is a maximum asset deposit limit of (2 ** 104) - 1.
+    /// @dev There is a maximum asset deposit limit of Constants.MAX_DEPOSIT_ASSETS.
     /// @dev An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP ('receiver').
     /// @param assets Amount of assets deposited
     /// @param receiver User to receive the shares
     /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        if (assets > type(uint104).max) revert Errors.DepositTooLarge();
+        if (assets > Constants.MAX_DEPOSIT_ASSETS) revert Errors.DepositTooLarge();
 
         shares = previewDeposit(assets);
 
@@ -427,7 +427,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return maxShares The maximum amount of shares that can be minted.
     function maxMint(address) external view returns (uint256 maxShares) {
         unchecked {
-            return (convertToShares(type(uint104).max) * (DECIMALS - COMMISSION_FEE)) / DECIMALS;
+            return
+                (convertToShares(Constants.MAX_DEPOSIT_ASSETS) * (DECIMALS - COMMISSION_FEE)) /
+                DECIMALS;
         }
     }
 
@@ -450,7 +452,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Deposit required amount of assets to receive specified amount of shares.
-    /// There is a maximum asset deposit limit of (2 ** 104) - 1.
+    /// There is a maximum asset deposit limit of Constants.MAX_DEPOSIT_ASSETS.
     /// An MEV tax is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP ('receiver').
     /// @param shares Amount of shares to be minted.
@@ -459,7 +461,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
         assets = previewMint(shares);
 
-        if (assets > type(uint104).max) revert Errors.DepositTooLarge();
+        if (assets > Constants.MAX_DEPOSIT_ASSETS) revert Errors.DepositTooLarge();
 
         // transfer assets (underlying token funds) from the user/the LP to the PanopticPool
         // in return for the shares to be minted

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -19,7 +19,6 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
-import "forge-std/Test.sol";
 
 /// @title The Panoptic Pool: Create permissionless options on a CLAMM.
 /// @author Axicon Labs Limited
@@ -1167,15 +1166,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightUnsigned delegatedShares = LeftRightUnsigned
             .wrap(0)
             .toRightSlot(
-                uint128(
-                    (s_collateralToken0.delegate(account, uint128(Constants.STANDARD_DELEGATION)))
-                )
+                uint128((s_collateralToken0.delegate(account, type(uint104).max * 10_000)))
             )
-            .toLeftSlot(
-                uint128(
-                    s_collateralToken1.delegate(account, uint128(Constants.STANDARD_DELEGATION))
-                )
-            );
+            .toLeftSlot(uint128(s_collateralToken1.delegate(account, type(uint104).max * 10_000)));
 
         uint128 positionBalance = s_positionBalance[account][touchedId[0]].rightSlot();
 
@@ -1211,9 +1204,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
             s_collateralToken0,
             s_collateralToken1
         );
-
-        console2.log("exerciseFees.rightSlot()", exerciseFees.rightSlot());
-        console2.log("refundAmounts.rightSlot()", refundAmounts.rightSlot());
 
         // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
         s_collateralToken0.refund(account, msg.sender, refundAmounts.rightSlot());

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -19,6 +19,7 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
+import "forge-std/Test.sol";
 
 /// @title The Panoptic Pool: Create permissionless options on a CLAMM.
 /// @author Axicon Labs Limited
@@ -1157,6 +1158,25 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
         _validatePositionList(msg.sender, positionIdListExercisor, 0);
 
+        int24 twapTick = getUniV3TWAP();
+
+        // on forced exercise, the price *must* be outside the position's range for at least 1 leg
+        touchedId[0].validateIsExercisable(twapTick);
+
+        // The protocol delegates some virtual shares to ensure the burn can be settled.
+        LeftRightUnsigned delegatedShares = LeftRightUnsigned
+            .wrap(0)
+            .toRightSlot(
+                uint128(
+                    (s_collateralToken0.delegate(account, uint128(Constants.STANDARD_DELEGATION)))
+                )
+            )
+            .toLeftSlot(
+                uint128(
+                    s_collateralToken1.delegate(account, uint128(Constants.STANDARD_DELEGATION))
+                )
+            );
+
         uint128 positionBalance = s_positionBalance[account][touchedId[0]].rightSlot();
 
         // compute the notional value of the short legs (the maximum amount of tokens required to exercise - premia)
@@ -1166,16 +1186,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             positionBalance
         );
 
-        int24 twapTick = getUniV3TWAP();
-
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-
-        // on forced exercise, the price *must* be outside the position's range for at least 1 leg
-        touchedId[0].validateIsExercisable(twapTick);
-
-        // The protocol delegates some virtual shares to ensure the burn can be settled.
-        s_collateralToken0.delegate(account, uint128(Constants.STANDARD_DELEGATION));
-        s_collateralToken1.delegate(account, uint128(Constants.STANDARD_DELEGATION));
 
         // Exercise the option
         // Turn off ITM swapping to prevent swap at potentially unfavorable price
@@ -1194,19 +1205,23 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
             account,
+            delegatedShares,
             exerciseFees,
             twapTick,
             s_collateralToken0,
             s_collateralToken1
         );
 
+        console2.log("exerciseFees.rightSlot()", exerciseFees.rightSlot());
+        console2.log("refundAmounts.rightSlot()", refundAmounts.rightSlot());
+
         // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
         s_collateralToken0.refund(account, msg.sender, refundAmounts.rightSlot());
         s_collateralToken1.refund(account, msg.sender, refundAmounts.leftSlot());
 
-        // refund the protocol any virtual shares after settling the difference with the exercisor
-        s_collateralToken0.refund(account, uint128(Constants.STANDARD_DELEGATION));
-        s_collateralToken1.refund(account, uint128(Constants.STANDARD_DELEGATION));
+        // revoke the virual shares that were delegated after settling the difference with the exercisor
+        s_collateralToken0.revoke(account, delegatedShares.rightSlot());
+        s_collateralToken1.revoke(account, delegatedShares.leftSlot());
 
         _validateSolvency(account, positionIdListExercisee, NO_BUFFER);
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1161,33 +1161,21 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // compute the notional value of the short legs (the maximum amount of tokens required to exercise - premia)
         // and the long legs (from which the exercise cost is computed)
-        (LeftRightSigned longAmounts, LeftRightSigned delegatedAmounts) = PanopticMath
-            .computeExercisedAmounts(touchedId[0], positionBalance);
+        (LeftRightSigned longAmounts, ) = PanopticMath.computeExercisedAmounts(
+            touchedId[0],
+            positionBalance
+        );
 
         int24 twapTick = getUniV3TWAP();
 
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
 
-        {
-            // add the premia to the delegated amounts to ensure the user has enough collateral to exercise
-            (LeftRightSigned positionPremia, ) = _calculateAccumulatedPremia(
-                account,
-                touchedId,
-                COMPUTE_LONG_PREMIA,
-                ONLY_AVAILABLE_PREMIUM,
-                currentTick
-            );
-
-            // long premia is represented as negative so subtract it to increase it for the delegated amounts
-            delegatedAmounts = delegatedAmounts.sub(positionPremia);
-        }
-
         // on forced exercise, the price *must* be outside the position's range for at least 1 leg
         touchedId[0].validateIsExercisable(twapTick);
 
         // The protocol delegates some virtual shares to ensure the burn can be settled.
-        s_collateralToken0.delegate(account, uint128(delegatedAmounts.rightSlot()));
-        s_collateralToken1.delegate(account, uint128(delegatedAmounts.leftSlot()));
+        s_collateralToken0.delegate(account, uint128(Constants.STANDARD_DELEGATION));
+        s_collateralToken1.delegate(account, uint128(Constants.STANDARD_DELEGATION));
 
         // Exercise the option
         // Turn off ITM swapping to prevent swap at potentially unfavorable price
@@ -1203,34 +1191,22 @@ contract PanopticPool is ERC1155Holder, Multicall {
             longAmounts
         );
 
-        LeftRightSigned refundAmounts = delegatedAmounts.add(exerciseFees);
-
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
-        refundAmounts = PanopticMath.getRefundAmounts(
+        LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
             account,
-            refundAmounts,
+            exerciseFees,
             twapTick,
             s_collateralToken0,
             s_collateralToken1
         );
 
-        unchecked {
-            // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
-            s_collateralToken0.refund(
-                account,
-                msg.sender,
-                refundAmounts.rightSlot() - delegatedAmounts.rightSlot()
-            );
-            s_collateralToken1.refund(
-                account,
-                msg.sender,
-                refundAmounts.leftSlot() - delegatedAmounts.leftSlot()
-            );
-        }
+        // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
+        s_collateralToken0.refund(account, msg.sender, refundAmounts.rightSlot());
+        s_collateralToken1.refund(account, msg.sender, refundAmounts.leftSlot());
 
         // refund the protocol any virtual shares after settling the difference with the exercisor
-        s_collateralToken0.refund(account, uint128(delegatedAmounts.rightSlot()));
-        s_collateralToken1.refund(account, uint128(delegatedAmounts.leftSlot()));
+        s_collateralToken0.refund(account, uint128(Constants.STANDARD_DELEGATION));
+        s_collateralToken1.refund(account, uint128(Constants.STANDARD_DELEGATION));
 
         _validateSolvency(account, positionIdListExercisee, NO_BUFFER);
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1166,9 +1166,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightUnsigned delegatedShares = LeftRightUnsigned
             .wrap(0)
             .toRightSlot(
-                uint128((s_collateralToken0.delegate(account, type(uint104).max * 10_000)))
+                uint128((s_collateralToken0.delegate(account, uint256(type(uint104).max) * 10_000)))
             )
-            .toLeftSlot(uint128(s_collateralToken1.delegate(account, type(uint104).max * 10_000)));
+            .toLeftSlot(
+                uint128(s_collateralToken1.delegate(account, uint256(type(uint104).max) * 10_000))
+            );
 
         uint128 positionBalance = s_positionBalance[account][touchedId[0]].rightSlot();
 

--- a/contracts/libraries/Constants.sol
+++ b/contracts/libraries/Constants.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
+import {LeftRightSigned} from "@types/LeftRight.sol";
+
 /// @title Library of Constants used in Panoptic.
 /// @author Axicon Labs Limited
 /// @notice This library provides constants used in Panoptic.
@@ -20,4 +22,11 @@ library Constants {
     /// @notice Maximum possible sqrtPriceX96 in a Uniswap V3 pool
     uint160 internal constant MAX_V3POOL_SQRT_RATIO =
         1461446703485210103287273052203988822378723970342;
+
+    /// @notice Maximum amount of assets permitted for a single collateral deposit
+    uint256 internal constant MAX_DEPOSIT_ASSETS = type(uint104).max;
+
+    /// @notice LeftRight-packed token0:token1 right:left quantities of virtual assets to delegate during liquidations/force exercises
+    /// @dev `LeftRightSigned.wrap(0).toRightSlot(MAX_DEPOSIT_ASSETS * 10_000).toLeftSlot(MAX_DEPOSIT_ASSETS * 10_000)`
+    int128 internal constant STANDARD_DELEGATION = MAX_DEPOSIT_ASSETS * 10_000;
 }

--- a/contracts/libraries/Constants.sol
+++ b/contracts/libraries/Constants.sol
@@ -28,5 +28,5 @@ library Constants {
 
     /// @notice LeftRight-packed token0:token1 right:left quantities of virtual assets to delegate during liquidations/force exercises
     /// @dev `LeftRightSigned.wrap(0).toRightSlot(MAX_DEPOSIT_ASSETS * 10_000).toLeftSlot(MAX_DEPOSIT_ASSETS * 10_000)`
-    int128 internal constant STANDARD_DELEGATION = MAX_DEPOSIT_ASSETS * 10_000;
+    int128 internal constant STANDARD_DELEGATION = int128(int256(MAX_DEPOSIT_ASSETS * 10_000));
 }

--- a/contracts/libraries/Constants.sol
+++ b/contracts/libraries/Constants.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import {LeftRightSigned} from "@types/LeftRight.sol";
-
 /// @title Library of Constants used in Panoptic.
 /// @author Axicon Labs Limited
 /// @notice This library provides constants used in Panoptic.
@@ -22,11 +20,4 @@ library Constants {
     /// @notice Maximum possible sqrtPriceX96 in a Uniswap V3 pool
     uint160 internal constant MAX_V3POOL_SQRT_RATIO =
         1461446703485210103287273052203988822378723970342;
-
-    /// @notice Maximum amount of assets permitted for a single collateral deposit
-    uint256 internal constant MAX_DEPOSIT_ASSETS = type(uint104).max;
-
-    /// @notice LeftRight-packed token0:token1 right:left quantities of virtual assets to delegate during liquidations/force exercises
-    /// @dev `LeftRightSigned.wrap(0).toRightSlot(MAX_DEPOSIT_ASSETS * 10_000).toLeftSlot(MAX_DEPOSIT_ASSETS * 10_000)`
-    int128 internal constant STANDARD_DELEGATION = int128(int256(MAX_DEPOSIT_ASSETS * 10_000));
 }

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -15,7 +15,6 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
-import "forge-std/Test.sol";
 
 /// @title Compute general math quantities relevant to Panoptic and AMM pool management.
 /// @author Axicon Labs Limited
@@ -948,7 +947,6 @@ library PanopticMath {
                 exerciseFees.rightSlot();
 
             if (balanceShortage > 0) {
-                console2.log("BS1");
                 return
                     LeftRightSigned
                         .wrap(0)
@@ -974,7 +972,6 @@ library PanopticMath {
                 exerciseFees.leftSlot();
 
             if (balanceShortage > 0) {
-                console2.log("BS2");
                 return
                     LeftRightSigned
                         .wrap(0)
@@ -989,7 +986,6 @@ library PanopticMath {
             }
         }
 
-        console2.log("NO BS");
         // otherwise, no need to deviate from the original exercise fee deltas
         return exerciseFees;
     }

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -15,6 +15,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {TokenId} from "@types/TokenId.sol";
+import "forge-std/Test.sol";
 
 /// @title Compute general math quantities relevant to Panoptic and AMM pool management.
 /// @author Axicon Labs Limited
@@ -919,6 +920,7 @@ library PanopticMath {
 
     /// @notice Redistribute the final exercise fee deltas between tokens if necessary according to the available collateral from the exercised user.
     /// @param exercisee Address of the force exercisee
+    /// @param delegatedShares The amount of virtual shares delegated to the exercisor that must be returned to the protocol
     /// @param exerciseFees Exercise fees to debit from exercisor at tick(atTick) rightSlot = token0 left = token1
     /// @param atTick Tick to convert values at. This can be the current tick or some TWAP/median tick
     /// @param collateral0 CollateralTracker for token0
@@ -926,6 +928,7 @@ library PanopticMath {
     /// @return The LeftRight-packed deltas for token0/token1 to move from the exercisor to the exercisee
     function getExerciseDeltas(
         address exercisee,
+        LeftRightUnsigned delegatedShares,
         LeftRightSigned exerciseFees,
         int24 atTick,
         CollateralTracker collateral0,
@@ -934,11 +937,18 @@ library PanopticMath {
         uint160 sqrtPriceX96 = Math.getSqrtRatioAtTick(atTick);
         unchecked {
             // if the refunder lacks sufficient token0 to pay back the virtual shares, have the exercisor cover the difference in exchange for token1 (and vice versa)
-            int256 balanceShortage = Constants.STANDARD_DELEGATION -
+            int256 balanceShortage = int256(
+                Math.mulDivRoundingUp(
+                    delegatedShares.rightSlot(),
+                    collateral0.totalAssets(),
+                    collateral0.totalSupply()
+                )
+            ) -
                 int256(collateral0.convertToAssets(collateral0.balanceOf(exercisee))) +
                 exerciseFees.rightSlot();
 
             if (balanceShortage > 0) {
+                console2.log("BS1");
                 return
                     LeftRightSigned
                         .wrap(0)
@@ -953,11 +963,18 @@ library PanopticMath {
             }
 
             balanceShortage =
-                Constants.STANDARD_DELEGATION -
+                int256(
+                    Math.mulDivRoundingUp(
+                        delegatedShares.leftSlot(),
+                        collateral1.totalAssets(),
+                        collateral1.totalSupply()
+                    )
+                ) -
                 int256(collateral1.convertToAssets(collateral1.balanceOf(exercisee))) +
                 exerciseFees.leftSlot();
 
             if (balanceShortage > 0) {
+                console2.log("BS2");
                 return
                     LeftRightSigned
                         .wrap(0)
@@ -972,6 +989,7 @@ library PanopticMath {
             }
         }
 
+        console2.log("NO BS");
         // otherwise, no need to deviate from the original exercise fee deltas
         return exerciseFees;
     }

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -917,61 +917,62 @@ library PanopticMath {
         }
     }
 
-    /// @notice Returns the original delegated value to a user at a certain tick based on the available collateral from the exercised user.
-    /// @param refunder Address of the user the refund is coming from (the force exercisee)
-    /// @param refundValues Token values to refund at the given tick(atTick) rightSlot = token0 left = token1
+    /// @notice Redistribute the final exercise fee deltas between tokens if necessary according to the available collateral from the exercised user.
+    /// @param exercisee Address of the force exercisee
+    /// @param exerciseFees Exercise fees to debit from exercisor at tick(atTick) rightSlot = token0 left = token1
     /// @param atTick Tick to convert values at. This can be the current tick or some TWAP/median tick
     /// @param collateral0 CollateralTracker for token0
     /// @param collateral1 CollateralTracker for token1
-    /// @return The LeftRight-packed amount of token0/token1 to refund to the user
-    function getRefundAmounts(
-        address refunder,
-        LeftRightSigned refundValues,
+    /// @return The LeftRight-packed deltas for token0/token1 to move from the exercisor to the exercisee
+    function getExerciseDeltas(
+        address exercisee,
+        LeftRightSigned exerciseFees,
         int24 atTick,
         CollateralTracker collateral0,
         CollateralTracker collateral1
     ) external view returns (LeftRightSigned) {
         uint160 sqrtPriceX96 = Math.getSqrtRatioAtTick(atTick);
         unchecked {
-            // if the refunder lacks sufficient token0 to pay back the refundee, have them pay back the equivalent value in token1
-            // NOTE: it is possible for refunds to be negative when the exercise fee is higher than the delegated amounts. This is expected behavior
-            int256 balanceShortage = refundValues.rightSlot() -
-                int256(collateral0.convertToAssets(collateral0.balanceOf(refunder)));
+            // if the refunder lacks sufficient token0 to pay back the virtual shares, have the exercisor cover the difference in exchange for token1 (and vice versa)
+            int256 balanceShortage = Constants.STANDARD_DELEGATION -
+                int256(collateral0.convertToAssets(collateral0.balanceOf(exercisee))) +
+                exerciseFees.rightSlot();
 
             if (balanceShortage > 0) {
                 return
                     LeftRightSigned
                         .wrap(0)
-                        .toRightSlot(int128(refundValues.rightSlot() - balanceShortage))
+                        .toRightSlot(int128(exerciseFees.rightSlot() - balanceShortage))
                         .toLeftSlot(
                             int128(
                                 int256(
                                     PanopticMath.convert0to1(uint256(balanceShortage), sqrtPriceX96)
-                                ) + refundValues.leftSlot()
+                                ) + exerciseFees.leftSlot()
                             )
                         );
             }
 
             balanceShortage =
-                refundValues.leftSlot() -
-                int256(collateral1.convertToAssets(collateral1.balanceOf(refunder)));
+                Constants.STANDARD_DELEGATION -
+                int256(collateral1.convertToAssets(collateral1.balanceOf(exercisee))) +
+                exerciseFees.leftSlot();
 
             if (balanceShortage > 0) {
                 return
                     LeftRightSigned
                         .wrap(0)
-                        .toLeftSlot(int128(refundValues.leftSlot() - balanceShortage))
+                        .toLeftSlot(int128(exerciseFees.leftSlot() - balanceShortage))
                         .toRightSlot(
                             int128(
                                 int256(
                                     PanopticMath.convert1to0(uint256(balanceShortage), sqrtPriceX96)
-                                ) + refundValues.rightSlot()
+                                ) + exerciseFees.rightSlot()
                             )
                         );
             }
         }
 
-        // otherwise, we can just refund the original amounts requested with no problems
-        return refundValues;
+        // otherwise, no need to deviate from the original exercise fee deltas
+        return exerciseFees;
     }
 }

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1886,7 +1886,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertApproxEqAbs(assetsBefore0, assetsAfter0, 5);
     }
 
-    function test_Success_refund_virtual(uint256 x, uint104 shares) public {
+    function test_Success_revoke_virtual(uint256 x, uint104 shares) public {
         {
             // fuzz
             _initWorld(x);
@@ -1925,16 +1925,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 convertedShares = convertToShares(1_000_000_000, collateralToken0);
 
         // invoke delegate transactions from the Panoptic pool
-        panopticPool.revoke(
-            Alice,
-            convertToAssets(sharesBefore0, collateralToken0),
-            collateralToken0
-        );
-        panopticPool.revoke(
-            Alice,
-            convertToAssets(sharesBefore1, collateralToken1),
-            collateralToken1
-        );
+        panopticPool.revoke(Alice, sharesBefore0, collateralToken0);
+        panopticPool.revoke(Alice, sharesBefore1, collateralToken1);
 
         // make sure share price stays the same
         assertEq(convertedShares, convertToShares(1_000_000_000, collateralToken0));
@@ -1943,8 +1935,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 sharesAfter0 = collateralToken0.balanceOf(Alice);
         uint256 sharesAfter1 = collateralToken1.balanceOf(Alice);
 
-        assertApproxEqAbs(0, convertToAssets(sharesAfter0, collateralToken0), 5);
-        assertApproxEqAbs(0, convertToAssets(sharesAfter1, collateralToken1), 5);
+        assertEq(0, sharesAfter0);
+        assertEq(0, sharesAfter1);
     }
 
     function test_success_refund_positive(uint256 x, uint104 shares) public {

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -206,12 +206,12 @@ contract PanopticPoolHarness is PanopticPool {
         collateralToken.refund(delegator, delegatee, requestedAmount);
     }
 
-    function refund(
+    function revoke(
         address delegatee,
         uint256 requestedAmount,
         CollateralTracker collateralToken
     ) external {
-        collateralToken.refund(delegatee, requestedAmount);
+        collateralToken.revoke(delegatee, requestedAmount);
     }
 
     function getTWAP() external view returns (int24 twapTick) {
@@ -1925,12 +1925,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 convertedShares = convertToShares(1_000_000_000, collateralToken0);
 
         // invoke delegate transactions from the Panoptic pool
-        panopticPool.refund(
+        panopticPool.revoke(
             Alice,
             convertToAssets(sharesBefore0, collateralToken0),
             collateralToken0
         );
-        panopticPool.refund(
+        panopticPool.revoke(
             Alice,
             convertToAssets(sharesBefore1, collateralToken1),
             collateralToken1
@@ -2060,7 +2060,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.delegate(address(0), 0);
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
-        collateralToken0.refund(address(0), 0);
+        collateralToken0.revoke(address(0), 0);
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
         collateralToken0.revoke(address(0), address(0), 0);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -537,6 +537,81 @@ contract Misctest is Test, PositionUtils {
         );
     }
 
+    // are delegations for ITM positions sufficient?
+    function test_success_exercise_crossDelegate() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        vm.startPrank(Seller);
+
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK
+        );
+
+        $posIdList[0] = TokenId.wrap(0).addPoolId(PanopticMath.getPoolId(address(uniPool))).addLeg(
+            0,
+            1,
+            1,
+            1,
+            0,
+            0,
+            15,
+            1
+        );
+
+        vm.startPrank(Alice);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            type(uint64).max,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK
+        );
+
+        editCollateral(ct1, Alice, 0);
+
+        vm.startPrank(Swapper);
+
+        PanopticMath.twapFilter(uniPool, 600);
+
+        vm.warp(block.timestamp + 600);
+        vm.roll(block.number + 1);
+
+        swapperc.swapTo(uniPool, 10 * 2 ** 96);
+
+        vm.warp(block.timestamp + 600);
+        vm.roll(block.number + 1);
+
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+        swapperc.burn(uniPool, -10, 10, 10 ** 18);
+
+        PanopticMath.twapFilter(uniPool, 600);
+
+        vm.startPrank(Bob);
+        pp.forceExercise(Alice, $posIdList, new TokenId[](0), new TokenId[](0));
+    }
+
     function test_success_ITMspreadfee_0_01bp() public {
         CollateralTracker(collateralReference).startToken(
             true,

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5417,7 +5417,7 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
-    function test_Success_getRefundAmounts(
+    function test_Success_getExerciseDeltas(
         uint256 x,
         uint256 balance0,
         uint256 balance1,
@@ -5449,10 +5449,12 @@ contract PanopticPoolTest is PositionUtils {
         ct0.deposit(balance0, Charlie);
         ct1.deposit(balance1, Charlie);
 
-        int256 shortage = refund0 - int(ct0.convertToAssets(ct0.balanceOf(Charlie)));
+        int256 shortage = Constants.STANDARD_DELEGATION +
+            refund0 -
+            int(ct0.convertToAssets(ct0.balanceOf(Charlie)));
 
         if (shortage > 0) {
-            LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
+            LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
                 Charlie,
                 LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
                 int24(atTick),
@@ -5471,10 +5473,13 @@ contract PanopticPoolTest is PositionUtils {
             return;
         }
 
-        shortage = refund1 - int(ct1.convertToAssets(ct1.balanceOf(Charlie)));
+        shortage =
+            Constants.STANDARD_DELEGATION +
+            refund1 -
+            int(ct1.convertToAssets(ct1.balanceOf(Charlie)));
 
         if (shortage > 0) {
-            LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
+            LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
                 Charlie,
                 LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
                 int24(atTick),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -4514,10 +4514,6 @@ contract PanopticPoolTest is PositionUtils {
             ? (notionalVals1[0] * int24(2 * (fee / 100))) / 10_000
             : -((notionalVals1[0] * int24(2 * (fee / 100))) / 10_000);
 
-        console2.log("ITMSpread", ITMSpread);
-        console2.log("notionalVals[0]", notionalVals[0]);
-        console2.log("notionalVals[1]", notionalVals[1]);
-        console2.log("tokensOwed0", tokensOwed0);
         assertApproxEqAbs(
             int256(balanceBefores[0]) - int256(uint256(type(uint104).max)),
             -ITMSpread -
@@ -4530,10 +4526,6 @@ contract PanopticPoolTest is PositionUtils {
             "Incorrect token0 delta"
         );
 
-        console2.log("ITMSpread1", ITMSpread1);
-        console2.log("notionalVals1[0]", notionalVals1[0]);
-        console2.log("notionalVals1[1]", notionalVals1[1]);
-        console2.log("tokensOwed1", tokensOwed1);
         assertApproxEqAbs(
             int256(balanceBefores[1]) - int256(uint256(type(uint104).max)),
             -ITMSpread1 - notionalVals1[0] - notionalVals1[1] + int256(uint256(tokensOwed1)),
@@ -5386,10 +5378,6 @@ contract PanopticPoolTest is PositionUtils {
         {
             $balanceDelta0 = int256(exerciseFeeAmounts[0]) - $intrinsicValue0 + $expectedPremia0;
 
-            console2.log("exerciseFeeAmounts[0]", exerciseFeeAmounts[0]);
-            console2.log("intrinsicValue0", $intrinsicValue0);
-            console2.log("expectedPremia0", $expectedPremia0);
-
             $balanceDelta0 = $balanceDelta0 > 0
                 ? int256(uint256($balanceDelta0))
                 : -int256(uint256(-$balanceDelta0));
@@ -5400,8 +5388,6 @@ contract PanopticPoolTest is PositionUtils {
                 ? int256(uint256($balanceDelta1))
                 : -int256(uint256(-$balanceDelta1));
 
-            console2.log("lastCollateralBalance0[Alice]", lastCollateralBalance0[Alice]);
-            console2.log("ct0.balanceOf(Alice)", ct0.balanceOf(Alice));
             assertApproxEqAbs(
                 int256(ct0.convertToAssets(ct0.balanceOf(Alice))) -
                     int256(lastCollateralBalance0[Alice]),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5458,7 +5458,7 @@ contract PanopticPoolTest is PositionUtils {
 
             int256 shortage = int256(
                 Math.mulDivRoundingUp(
-                    ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)),
+                    ct0.convertToShares(type(uint104).max),
                     ct0.totalAssets(),
                     ct0.totalSupply()
                 )
@@ -5471,12 +5471,8 @@ contract PanopticPoolTest is PositionUtils {
                     Charlie,
                     LeftRightUnsigned
                         .wrap(0)
-                        .toRightSlot(
-                            uint128(ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
-                        )
-                        .toLeftSlot(
-                            uint128(ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
-                        ),
+                        .toRightSlot(uint128(ct0.convertToShares(type(uint104).max)))
+                        .toLeftSlot(uint128(ct1.convertToShares(type(uint104).max))),
                     LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
                         int128(refund1)
                     ),
@@ -5502,7 +5498,7 @@ contract PanopticPoolTest is PositionUtils {
             shortage =
                 int256(
                     Math.mulDivRoundingUp(
-                        ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)),
+                        ct1.convertToShares(type(uint104).max),
                         ct1.totalAssets(),
                         ct1.totalSupply()
                     )
@@ -5515,12 +5511,8 @@ contract PanopticPoolTest is PositionUtils {
                     Charlie,
                     LeftRightUnsigned
                         .wrap(0)
-                        .toRightSlot(
-                            uint128(ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
-                        )
-                        .toLeftSlot(
-                            uint128(ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
-                        ),
+                        .toRightSlot(uint128(ct0.convertToShares(type(uint104).max)))
+                        .toLeftSlot(uint128(ct1.convertToShares(type(uint104).max))),
                     LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
                         int128(refund1)
                     ),
@@ -5544,12 +5536,8 @@ contract PanopticPoolTest is PositionUtils {
                     Charlie,
                     LeftRightUnsigned
                         .wrap(0)
-                        .toRightSlot(
-                            uint128(ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
-                        )
-                        .toLeftSlot(
-                            uint128(ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
-                        ),
+                        .toRightSlot(uint128(ct0.convertToShares(type(uint104).max)))
+                        .toLeftSlot(uint128(ct1.convertToShares(type(uint104).max))),
                     LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
                         int128(refund1)
                     ),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5386,6 +5386,10 @@ contract PanopticPoolTest is PositionUtils {
         {
             $balanceDelta0 = int256(exerciseFeeAmounts[0]) - $intrinsicValue0 + $expectedPremia0;
 
+            console2.log("exerciseFeeAmounts[0]", exerciseFeeAmounts[0]);
+            console2.log("intrinsicValue0", $intrinsicValue0);
+            console2.log("expectedPremia0", $expectedPremia0);
+
             $balanceDelta0 = $balanceDelta0 > 0
                 ? int256(uint256($balanceDelta0))
                 : -int256(uint256(-$balanceDelta0));
@@ -5396,6 +5400,8 @@ contract PanopticPoolTest is PositionUtils {
                 ? int256(uint256($balanceDelta1))
                 : -int256(uint256(-$balanceDelta1));
 
+            console2.log("lastCollateralBalance0[Alice]", lastCollateralBalance0[Alice]);
+            console2.log("ct0.balanceOf(Alice)", ct0.balanceOf(Alice));
             assertApproxEqAbs(
                 int256(ct0.convertToAssets(ct0.balanceOf(Alice))) -
                     int256(lastCollateralBalance0[Alice]),
@@ -5417,83 +5423,100 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
-    function test_Success_getExerciseDeltas(
-        uint256 x,
-        uint256 balance0,
-        uint256 balance1,
-        int256 refund0,
-        int256 refund1,
-        int256 atTickSeed
-    ) public {
-        _initPool(x);
+    // function test_Success_getExerciseDeltas(
+    //     uint256 x,
+    //     uint256 balance0,
+    //     uint256 balance1,
+    //     int256 refund0,
+    //     int256 refund1,
+    //     int256 atTickSeed
+    // ) public {
+    //     unchecked {
+    //     _initPool(x);
 
-        balance0 = bound(balance0, 0, type(uint104).max);
-        balance1 = bound(balance1, 0, type(uint104).max);
-        refund0 = bound(
-            refund0,
-            -int256(uint256(type(uint104).max)),
-            int256(uint256(type(uint104).max))
-        );
-        refund1 = bound(
-            refund1,
-            -int256(uint256(type(uint104).max)),
-            int256(uint256(type(uint104).max))
-        );
-        // possible for the amounts used here to overflow beyond these ticks
-        // convert0To1 is tested on the full tickrange elsewhere
-        atTick = int24(bound(atTickSeed, -159_000, 159_000));
+    //     balance0 = bound(balance0, 0, type(uint104).max);
+    //     balance1 = bound(balance1, 0, type(uint104).max);
+    //     refund0 = bound(
+    //         refund0,
+    //         -int256(uint256(type(uint104).max)),
+    //         int256(uint256(type(uint104).max))
+    //     );
+    //     refund1 = bound(
+    //         refund1,
+    //         -int256(uint256(type(uint104).max)),
+    //         int256(uint256(type(uint104).max))
+    //     );
+    //     // possible for the amounts used here to overflow beyond these ticks
+    //     // convert0To1 is tested on the full tickrange elsewhere
+    //     atTick = int24(bound(atTickSeed, -159_000, 159_000));
 
-        uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(int24(atTick));
+    //     uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(int24(atTick));
 
-        vm.startPrank(Charlie);
-        ct0.deposit(balance0, Charlie);
-        ct1.deposit(balance1, Charlie);
+    //     vm.startPrank(Charlie);
+    //     ct0.deposit(balance0, Charlie);
+    //     ct1.deposit(balance1, Charlie);
 
-        int256 shortage = Constants.STANDARD_DELEGATION +
-            refund0 -
-            int(ct0.convertToAssets(ct0.balanceOf(Charlie)));
+    //     int256 shortage = Constants.STANDARD_DELEGATION +
+    //         refund0 -
+    //         int(ct0.convertToAssets(ct0.balanceOf(Charlie)));
 
-        if (shortage > 0) {
-            LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
-                Charlie,
-                LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
-                int24(atTick),
-                ct0,
-                ct1
-            );
+    //     if (shortage > 0) {
+    //         LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+    //             Charlie,
+    //             LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
+    //             int24(atTick),
+    //             ct0,
+    //             ct1
+    //         );
 
-            refund0 = refund0 - shortage;
-            refund1 = PanopticMath.convert0to1(shortage, sqrtPriceX96) + refund1;
+    //         refund0 = int128(refund0) - int128(shortage);
+    //         refund1 = int128(PanopticMath.convert0to1(shortage, sqrtPriceX96)) + int128(refund1);
 
-            assertEq(refundAmounts.rightSlot(), refund0);
-            assertEq(refundAmounts.leftSlot(), refund1);
-            // if there is a shortage of token1, it won't be reached since it's only considered possible to have a shortage
-            // of one token with force exercises. If there is a shortage of both the account is insolvent and it will fail
-            // when trying to transfer the tokens
-            return;
-        }
+    //         assertEq(refundAmounts.rightSlot(), refund0);
+    //         assertEq(refundAmounts.leftSlot(), refund1);
 
-        shortage =
-            Constants.STANDARD_DELEGATION +
-            refund1 -
-            int(ct1.convertToAssets(ct1.balanceOf(Charlie)));
+    //         // if there is a shortage of token1, it won't be reached since it's only considered possible to have a shortage
+    //         // of one token with force exercises. If there is a shortage of both the account is insolvent and it will fail
+    //         // when trying to transfer the tokens
+    //         return;
+    //     }
 
-        if (shortage > 0) {
-            LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
-                Charlie,
-                LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
-                int24(atTick),
-                ct0,
-                ct1
-            );
+    //     shortage =
+    //         Constants.STANDARD_DELEGATION +
+    //         refund1 -
+    //         int(ct1.convertToAssets(ct1.balanceOf(Charlie)));
 
-            refund1 = refund1 - shortage;
-            refund0 = PanopticMath.convert1to0(shortage, sqrtPriceX96) + refund0;
+    //     if (shortage > 0) {
+    //         LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+    //             Charlie,
+    //             LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
+    //             int24(atTick),
+    //             ct0,
+    //             ct1
+    //         );
 
-            assertEq(refundAmounts.rightSlot(), refund0);
-            assertEq(refundAmounts.leftSlot(), refund1);
-        }
-    }
+    //         refund1 = int128(refund1) - shortage;
+    //         refund0 = int128(PanopticMath.convert1to0(shortage, sqrtPriceX96)) + int128(refund0);
+
+    //         assertEq(refundAmounts.rightSlot(), refund0);
+    //         assertEq(refundAmounts.leftSlot(), refund1);
+
+    //         return;
+    //     }
+    //     {
+    //     LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+    //         Charlie,
+    //         LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
+    //         int24(atTick),
+    //         ct0,
+    //         ct1
+    //     );
+
+    //     assertEq(refundAmounts.rightSlot(), int128(refund0));
+    //     assertEq(refundAmounts.leftSlot(), int128(refund1));
+    //     }
+    //     }
+    // }
 
     function test_Fail_forceExercise_ExercisorNotSolvent(
         uint256 x,

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5423,100 +5423,146 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
-    // function test_Success_getExerciseDeltas(
-    //     uint256 x,
-    //     uint256 balance0,
-    //     uint256 balance1,
-    //     int256 refund0,
-    //     int256 refund1,
-    //     int256 atTickSeed
-    // ) public {
-    //     unchecked {
-    //     _initPool(x);
+    function test_Success_getExerciseDeltas(
+        uint256 x,
+        uint256 balance0,
+        uint256 balance1,
+        int256 refund0,
+        int256 refund1,
+        int256 atTickSeed
+    ) public {
+        unchecked {
+            _initPool(x);
 
-    //     balance0 = bound(balance0, 0, type(uint104).max);
-    //     balance1 = bound(balance1, 0, type(uint104).max);
-    //     refund0 = bound(
-    //         refund0,
-    //         -int256(uint256(type(uint104).max)),
-    //         int256(uint256(type(uint104).max))
-    //     );
-    //     refund1 = bound(
-    //         refund1,
-    //         -int256(uint256(type(uint104).max)),
-    //         int256(uint256(type(uint104).max))
-    //     );
-    //     // possible for the amounts used here to overflow beyond these ticks
-    //     // convert0To1 is tested on the full tickrange elsewhere
-    //     atTick = int24(bound(atTickSeed, -159_000, 159_000));
+            balance0 = bound(balance0, 0, type(uint104).max);
+            balance1 = bound(balance1, 0, type(uint104).max);
+            refund0 = bound(
+                refund0,
+                -int256(uint256(type(uint104).max)),
+                int256(uint256(type(uint104).max))
+            );
+            refund1 = bound(
+                refund1,
+                -int256(uint256(type(uint104).max)),
+                int256(uint256(type(uint104).max))
+            );
+            // possible for the amounts used here to overflow beyond these ticks
+            // convert0To1 is tested on the full tickrange elsewhere
+            atTick = int24(bound(atTickSeed, -159_000, 159_000));
 
-    //     uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(int24(atTick));
+            uint160 sqrtPriceX96 = TickMath.getSqrtRatioAtTick(int24(atTick));
 
-    //     vm.startPrank(Charlie);
-    //     ct0.deposit(balance0, Charlie);
-    //     ct1.deposit(balance1, Charlie);
+            vm.startPrank(Charlie);
+            ct0.deposit(balance0, Charlie);
+            ct1.deposit(balance1, Charlie);
 
-    //     int256 shortage = Constants.STANDARD_DELEGATION +
-    //         refund0 -
-    //         int(ct0.convertToAssets(ct0.balanceOf(Charlie)));
+            int256 shortage = int256(
+                Math.mulDivRoundingUp(
+                    ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)),
+                    ct0.totalAssets(),
+                    ct0.totalSupply()
+                )
+            ) +
+                refund0 -
+                int(ct0.convertToAssets(ct0.balanceOf(Charlie)));
 
-    //     if (shortage > 0) {
-    //         LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
-    //             Charlie,
-    //             LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
-    //             int24(atTick),
-    //             ct0,
-    //             ct1
-    //         );
+            if (shortage > 0) {
+                LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+                    Charlie,
+                    LeftRightUnsigned
+                        .wrap(0)
+                        .toRightSlot(
+                            uint128(ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
+                        )
+                        .toLeftSlot(
+                            uint128(ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
+                        ),
+                    LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
+                        int128(refund1)
+                    ),
+                    int24(atTick),
+                    ct0,
+                    ct1
+                );
 
-    //         refund0 = int128(refund0) - int128(shortage);
-    //         refund1 = int128(PanopticMath.convert0to1(shortage, sqrtPriceX96)) + int128(refund1);
+                refund0 = int128(refund0) - int128(shortage);
+                refund1 =
+                    int128(PanopticMath.convert0to1(shortage, sqrtPriceX96)) +
+                    int128(refund1);
 
-    //         assertEq(refundAmounts.rightSlot(), refund0);
-    //         assertEq(refundAmounts.leftSlot(), refund1);
+                assertEq(refundAmounts.rightSlot(), refund0);
+                assertEq(refundAmounts.leftSlot(), refund1);
 
-    //         // if there is a shortage of token1, it won't be reached since it's only considered possible to have a shortage
-    //         // of one token with force exercises. If there is a shortage of both the account is insolvent and it will fail
-    //         // when trying to transfer the tokens
-    //         return;
-    //     }
+                // if there is a shortage of token1, it won't be reached since it's only considered possible to have a shortage
+                // of one token with force exercises. If there is a shortage of both the account is insolvent and it will fail
+                // when trying to transfer the tokens
+                return;
+            }
 
-    //     shortage =
-    //         Constants.STANDARD_DELEGATION +
-    //         refund1 -
-    //         int(ct1.convertToAssets(ct1.balanceOf(Charlie)));
+            shortage =
+                int256(
+                    Math.mulDivRoundingUp(
+                        ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)),
+                        ct1.totalAssets(),
+                        ct1.totalSupply()
+                    )
+                ) +
+                refund1 -
+                int(ct1.convertToAssets(ct1.balanceOf(Charlie)));
 
-    //     if (shortage > 0) {
-    //         LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
-    //             Charlie,
-    //             LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
-    //             int24(atTick),
-    //             ct0,
-    //             ct1
-    //         );
+            if (shortage > 0) {
+                LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+                    Charlie,
+                    LeftRightUnsigned
+                        .wrap(0)
+                        .toRightSlot(
+                            uint128(ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
+                        )
+                        .toLeftSlot(
+                            uint128(ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
+                        ),
+                    LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
+                        int128(refund1)
+                    ),
+                    int24(atTick),
+                    ct0,
+                    ct1
+                );
 
-    //         refund1 = int128(refund1) - shortage;
-    //         refund0 = int128(PanopticMath.convert1to0(shortage, sqrtPriceX96)) + int128(refund0);
+                refund1 = int128(refund1) - shortage;
+                refund0 =
+                    int128(PanopticMath.convert1to0(shortage, sqrtPriceX96)) +
+                    int128(refund0);
 
-    //         assertEq(refundAmounts.rightSlot(), refund0);
-    //         assertEq(refundAmounts.leftSlot(), refund1);
+                assertEq(refundAmounts.rightSlot(), refund0);
+                assertEq(refundAmounts.leftSlot(), refund1);
 
-    //         return;
-    //     }
-    //     {
-    //     LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
-    //         Charlie,
-    //         LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
-    //         int24(atTick),
-    //         ct0,
-    //         ct1
-    //     );
+                return;
+            }
+            {
+                LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+                    Charlie,
+                    LeftRightUnsigned
+                        .wrap(0)
+                        .toRightSlot(
+                            uint128(ct0.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
+                        )
+                        .toLeftSlot(
+                            uint128(ct1.convertToShares(uint128(Constants.STANDARD_DELEGATION)))
+                        ),
+                    LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
+                        int128(refund1)
+                    ),
+                    int24(atTick),
+                    ct0,
+                    ct1
+                );
 
-    //     assertEq(refundAmounts.rightSlot(), int128(refund0));
-    //     assertEq(refundAmounts.leftSlot(), int128(refund1));
-    //     }
-    //     }
-    // }
+                assertEq(refundAmounts.rightSlot(), int128(refund0));
+                assertEq(refundAmounts.leftSlot(), int128(refund1));
+            }
+        }
+    }
 
     function test_Fail_forceExercise_ExercisorNotSolvent(
         uint256 x,


### PR DESCRIPTION
Our previous method of delegating virtual shares for force exercises involved computing the maximum possible quantities of tokens required to exercise the user's options under any circumstance. Unfortunately, the method we were using to compute those quantities was flawed and would require a force exercisor to send tokens directly to an exercisee without being compensated. While this was unlikely in liquid pools when we had ITM swaps enabled, disabling ITM swaps introduces the potential for long positions that require different tokens of a different type than the corresponding `movedAmounts` when ITM.

This PR moves force exercises to a fixed-size delegation of `DEPOSIT_LIMIT * 10_000` to reduce the amount of calculation required and any further estimation risks. While a position could *in theory* require more tokens than that to close, the reasoning is that:
1. Under any circumstances where a virtual delegation is required, the exercisor is required to cover the difference because the exercisee must pay the full delegation back to the protocol (the only purpose of the virtual delegation is to allow the positions to be settled before the exercisor provides the requisite tokens without breaking the accounting, avoiding an extra precalculation step before the positions are closed.)
2. Thus, any exercisor would need to deposit the *required* delegation amount before executing the force exercise.
3. Any operation that requires ~10,000 distinct deposit calls can for all intents and purposes be considered a DoS
4. Therefore, this fixed-size delegation (which is very large, but not large enough to cause any accounting problems) does not impede force exercises in any meaningful way compared to a solution that attempts to calculate the maximum required delegation, given that a force exercise would be practically impossible in any situation where they differ 

I'm kind of tempted to do a similar thing for liquidations (eliminating the requirement for liquidators to compute the delegation amounts themselves), but the current system works well enough there so will likely keep it the same in the absence of any significant exigence.