### PR TITLE
fix: resolve stack-too-deep error on 0.8.26

### DIFF
--- a/contracts/base/FactoryNFT.sol
+++ b/contracts/base/FactoryNFT.sol
@@ -94,8 +94,7 @@ contract FactoryNFT is MetadataStore, ERC721 {
                                     PanopticMath.uniswapFeeToString(uint24(fee)),
                                     " market"
                                 ),
-                                '", "attributes": [{',
-                                '"trait_type": "Rarity", "value": "',
+                                '", "attributes": [{"trait_type": "Rarity", "value": "',
                                 string.concat(
                                     LibString.toString(rarity),
                                     " - ",
@@ -105,8 +104,7 @@ contract FactoryNFT is MetadataStore, ERC721 {
                                 metadata[bytes32("strategies")][lastCharVal].dataStr(),
                                 '"}, {"trait_type": "ChainId", "value": "',
                                 getChainName(),
-                                '"}]',
-                                ', "image": "',
+                                '"}], "image": "',
                                 "data:image/svg+xml;base64,",
                                 Base64.encode(bytes(svgOut)),
                                 '"}'

--- a/contracts/base/FactoryNFT.sol
+++ b/contracts/base/FactoryNFT.sol
@@ -104,8 +104,7 @@ contract FactoryNFT is MetadataStore, ERC721 {
                                 metadata[bytes32("strategies")][lastCharVal].dataStr(),
                                 '"}, {"trait_type": "ChainId", "value": "',
                                 getChainName(),
-                                '"}], "image": "',
-                                "data:image/svg+xml;base64,",
+                                '"}], "image": "data:image/svg+xml;base64,',
                                 Base64.encode(bytes(svgOut)),
                                 '"}'
                             )


### PR DESCRIPTION
Attempting to compile the contracts on 0.8.26 will result in the following error, which provides no identifying information about the source of the issue: 
```
Error: Compiler error (/solidity/libyul/backends/evm/AsmCodeGen.cpp:62):Stack too deep. Try compiling with `--via-ir` (cli) or the equivalent `viaIR: true` (standard JSON) while enabling the optimizer. Otherwise, try removing local variables. When compiling inline assembly: Variable pos is 2 slot(s) too deep inside the stack. Stack too deep. Try compiling with `--via-ir` (cli) or the equivalent `viaIR: true` (standard JSON) while enabling the optimizer. Otherwise, try removing local variables.
```

I'm not sure what exactly in 0.8.26 triggered this but after a bunch of trial and error I tracked it down to the `constructMetadata` function in the new `FactoryNFT.sol` contract. Removing a few items from the `abi.encodePacked` call seems to do the trick (we had a few consecutive strings passed as separate items that could be combined).