### PR TITLE
fix: typo in docstring for tokenData1 arg of convertCollateralData

### DIFF
--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -446,7 +446,7 @@ library PanopticMath {
 
     /// @notice Adds required collateral and collateral balance from collateralTracker0 and collateralTracker1 and converts to single values in terms of `tokenType`.
     /// @param tokenData0 LeftRight type container holding the collateralBalance (right slot) and requiredCollateral (left slot) for a user in CollateralTracker0 (expressed in terms of token0)
-    /// @param tokenData1 LeftRight type container holding the collateralBalance (right slot) and requiredCollateral (left slot) for a user in CollateralTracker0 (expressed in terms of token1)
+    /// @param tokenData1 LeftRight type container holding the collateralBalance (right slot) and requiredCollateral (left slot) for a user in CollateralTracker1 (expressed in terms of token1)
     /// @param tokenType The type of token (token0 or token1) to express collateralBalance and requiredCollateral in
     /// @param sqrtPriceX96 The sqrt price at which to convert between token0/token1
     /// @return The total combined balance of token0 and token1 for a user in terms of tokenType
@@ -472,7 +472,7 @@ library PanopticMath {
 
     /// @notice Adds required collateral and collateral balance from collateralTracker0 and collateralTracker1 and converts to single values in terms of `tokenType`.
     /// @param tokenData0 LeftRight type container holding the collateralBalance (right slot) and requiredCollateral (left slot) for a user in CollateralTracker0 (expressed in terms of token0)
-    /// @param tokenData1 LeftRight type container holding the collateralBalance (right slot) and requiredCollateral (left slot) for a user in CollateralTracker0 (expressed in terms of token1)
+    /// @param tokenData1 LeftRight type container holding the collateralBalance (right slot) and requiredCollateral (left slot) for a user in CollateralTracker1 (expressed in terms of token1)
     /// @param tokenType The type of token (token0 or token1) to express collateralBalance and requiredCollateral in
     /// @param tick The tick at which to convert between token0/token1
     /// @return The total combined balance of token0 and token1 for a user in terms of tokenType

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -544,11 +544,11 @@ library PanopticMath {
         }
     }
 
-    /// @notice Convert an amount of token0 into an amount of token1 given the sqrtPriceX96 in a Uniswap pool defined as sqrt(1/0)*2^96.
+    /// @notice Convert an amount of token1 into an amount of token0 given the sqrtPriceX96 in a Uniswap pool defined as sqrt(1/0)*2^96.
     /// @dev Uses reduced precision after tick 443636 in order to accommodate the full range of ticks.
-    /// @param amount The amount of token0 to convert into token1
-    /// @param sqrtPriceX96 The square root of the price at which to convert `amount` of token0 into token1
-    /// @return The converted `amount` of token0 represented in terms of token1
+    /// @param amount The amount of token1 to convert into token0
+    /// @param sqrtPriceX96 The square root of the price at which to convert `amount` of token1 into token0
+    /// @return The converted `amount` of token1 represented in terms of token0
     function convert1to0(int256 amount, uint160 sqrtPriceX96) internal pure returns (int256) {
         unchecked {
             // the tick 443636 is the maximum price where (price) * 2**192 fits into a uint256 (< 2**256-1)


### PR DESCRIPTION
Typo [here](https://github.com/panoptic-labs/panoptic-v1-core-private/blob/00b684e296dca3c0b44b4a09201bfa953a56c576/contracts/libraries/PanopticMath.sol#L524) and [here](https://github.com/panoptic-labs/panoptic-v1-core-private/blob/00b684e296dca3c0b44b4a09201bfa953a56c576/contracts/libraries/PanopticMath.sol#L549), i believe, on the tokenData1 argument to `convertCollateralData`

You can see us actually passing in a CollateralTrack1 balance for the tokenData1 arg here in `checkCollateral`: https://github.com/panoptic-labs/panoptic-v1-core-private/blob/f38e1e4b457bbd0d0ff44ba352611bb4991ab1f8/periphery/PanopticHelper.sol#L65

So either we're using the method wrong there, or the docstring is typo'ed