### PR TITLE
fix: increase container size for delegated shares

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1157,50 +1157,54 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
         _validatePositionList(msg.sender, positionIdListExercisor, 0);
 
+        uint128 positionBalance = s_positionBalance[account][touchedId[0]].rightSlot();
+
         int24 twapTick = getUniV3TWAP();
 
         // on forced exercise, the price *must* be outside the position's range for at least 1 leg
         touchedId[0].validateIsExercisable(twapTick);
 
-        // The protocol delegates some virtual shares to ensure the burn can be settled.
-        LeftRightUnsigned delegatedShares = LeftRightUnsigned
-            .wrap(0)
-            .toRightSlot(
-                uint128((s_collateralToken0.delegate(account, uint256(type(uint104).max) * 10_000)))
-            )
-            .toLeftSlot(
-                uint128(s_collateralToken1.delegate(account, uint256(type(uint104).max) * 10_000))
+        LeftRightSigned exerciseFees;
+        {
+            (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
+
+            // compute the notional value of the short legs (the maximum amount of tokens required to exercise - premia)
+            // and the long legs (from which the exercise cost is computed)
+            (LeftRightSigned longAmounts, ) = PanopticMath.computeExercisedAmounts(
+                touchedId[0],
+                positionBalance
             );
 
-        uint128 positionBalance = s_positionBalance[account][touchedId[0]].rightSlot();
+            // Compute the exerciseFee, this will decrease the further away the price is from the forcedExercised position
+            // Use an oracle tick to prevent price manipulations based on swaps.
+            exerciseFees = s_collateralToken0.exerciseCost(
+                currentTick,
+                twapTick,
+                touchedId[0],
+                positionBalance,
+                longAmounts
+            );
+        }
 
-        // compute the notional value of the short legs (the maximum amount of tokens required to exercise - premia)
-        // and the long legs (from which the exercise cost is computed)
-        (LeftRightSigned longAmounts, ) = PanopticMath.computeExercisedAmounts(
-            touchedId[0],
-            positionBalance
+        // The protocol delegates some virtual shares to ensure the burn can be settled.
+        uint256 delegated0 = s_collateralToken0.delegate(
+            account,
+            uint256(type(uint104).max) * 10_000
         );
-
-        (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
+        uint256 delegated1 = s_collateralToken1.delegate(
+            account,
+            uint256(type(uint104).max) * 10_000
+        );
 
         // Exercise the option
         // Turn off ITM swapping to prevent swap at potentially unfavorable price
         _burnAllOptionsFrom(account, MIN_SWAP_TICK, MAX_SWAP_TICK, COMMIT_LONG_SETTLED, touchedId);
 
-        // Compute the exerciseFee, this will decrease the further away the price is from the forcedExercised position
-        // Use an oracle tick to prevent price manipulations based on swaps.
-        LeftRightSigned exerciseFees = s_collateralToken0.exerciseCost(
-            currentTick,
-            twapTick,
-            touchedId[0],
-            positionBalance,
-            longAmounts
-        );
-
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
             account,
-            delegatedShares,
+            delegated0,
+            delegated1,
             exerciseFees,
             twapTick,
             s_collateralToken0,
@@ -1212,8 +1216,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         s_collateralToken1.refund(account, msg.sender, refundAmounts.leftSlot());
 
         // revoke the virual shares that were delegated after settling the difference with the exercisor
-        s_collateralToken0.revoke(account, delegatedShares.rightSlot());
-        s_collateralToken1.revoke(account, delegatedShares.leftSlot());
+        s_collateralToken0.revoke(account, delegated0);
+        s_collateralToken1.revoke(account, delegated1);
 
         _validateSolvency(account, positionIdListExercisee, NO_BUFFER);
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -919,7 +919,8 @@ library PanopticMath {
 
     /// @notice Redistribute the final exercise fee deltas between tokens if necessary according to the available collateral from the exercised user.
     /// @param exercisee Address of the force exercisee
-    /// @param delegatedShares The amount of virtual shares delegated to the exercisor that must be returned to the protocol
+    /// @param delegated0 The amount of virtual token0 shares delegated to the exercisor that must be returned to the protocol
+    /// @param delegated1 The amount of virtual token1 shares delegated to the exercisor that must be returned to the protocol
     /// @param exerciseFees Exercise fees to debit from exercisor at tick(atTick) rightSlot = token0 left = token1
     /// @param atTick Tick to convert values at. This can be the current tick or some TWAP/median tick
     /// @param collateral0 CollateralTracker for token0
@@ -927,7 +928,8 @@ library PanopticMath {
     /// @return The LeftRight-packed deltas for token0/token1 to move from the exercisor to the exercisee
     function getExerciseDeltas(
         address exercisee,
-        LeftRightUnsigned delegatedShares,
+        uint256 delegated0,
+        uint256 delegated1,
         LeftRightSigned exerciseFees,
         int24 atTick,
         CollateralTracker collateral0,
@@ -938,7 +940,7 @@ library PanopticMath {
             // if the refunder lacks sufficient token0 to pay back the virtual shares, have the exercisor cover the difference in exchange for token1 (and vice versa)
             int256 balanceShortage = int256(
                 Math.mulDivRoundingUp(
-                    delegatedShares.rightSlot(),
+                    delegated0,
                     collateral0.totalAssets(),
                     collateral0.totalSupply()
                 )
@@ -963,7 +965,7 @@ library PanopticMath {
             balanceShortage =
                 int256(
                     Math.mulDivRoundingUp(
-                        delegatedShares.leftSlot(),
+                        delegated1,
                         collateral1.totalAssets(),
                         collateral1.totalSupply()
                     )

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5455,10 +5455,8 @@ contract PanopticPoolTest is PositionUtils {
             if (shortage > 0) {
                 LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
                     Charlie,
-                    LeftRightUnsigned
-                        .wrap(0)
-                        .toRightSlot(uint128(ct0.convertToShares(type(uint104).max)))
-                        .toLeftSlot(uint128(ct1.convertToShares(type(uint104).max))),
+                    ct0.convertToShares(type(uint104).max),
+                    ct1.convertToShares(type(uint104).max),
                     LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
                         int128(refund1)
                     ),
@@ -5495,10 +5493,8 @@ contract PanopticPoolTest is PositionUtils {
             if (shortage > 0) {
                 LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
                     Charlie,
-                    LeftRightUnsigned
-                        .wrap(0)
-                        .toRightSlot(uint128(ct0.convertToShares(type(uint104).max)))
-                        .toLeftSlot(uint128(ct1.convertToShares(type(uint104).max))),
+                    ct0.convertToShares(type(uint104).max),
+                    ct1.convertToShares(type(uint104).max),
                     LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
                         int128(refund1)
                     ),
@@ -5520,10 +5516,8 @@ contract PanopticPoolTest is PositionUtils {
             {
                 LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
                     Charlie,
-                    LeftRightUnsigned
-                        .wrap(0)
-                        .toRightSlot(uint128(ct0.convertToShares(type(uint104).max)))
-                        .toLeftSlot(uint128(ct1.convertToShares(type(uint104).max))),
+                    ct0.convertToShares(type(uint104).max),
+                    ct1.convertToShares(type(uint104).max),
                     LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(
                         int128(refund1)
                     ),


### PR DESCRIPTION
The delegated amounts returned by the `CollateralTracker`  for token0/1 were originally placed in a LeftRight container to prevent stack-too-deep issues by saving a stack slot. The reasoning was that the amount of *assets* we delegate is `(2**104 - 1) * 10_000`, which fits comfortably within a `uint128` type. However, when the denomination was switched from *assets* to *shares* (to prevent issues caused by asset conversions after rounding errors are introduced into the share price), this ceased to be the case because the starting share price is 1M shares/asset, so the delegation amount is roughly `(2**104 - 1) * 10_000 * 1_000_000` for a fresh pool, a quantity that greatly exceeds the `uint128` container and causes most of the shares to remain unrevoked post-exercise.

This issue is impossible to detect with the legacy stateless fuzz test suite because the share price is edited to ~1 to prevent compatibility issues. However, the invariant test suite (ran at a natural, unmodified share price) instantly detects a discrepancy between the amount of shares the exercisee receives compared to a burn (most of the original delegation) and the shares contributed by the exercisor (0).

The solution is to separate the delegated amounts for each token into their own (uint256) stack variables, making any overflows impossible. I was able to shift around/scope some statements to accommodate the extra variables without having to stack roll or reread from storage. 