### PR TITLE
Moved getOracleTicks to PanopticMath

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -117,12 +117,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @notice The minimum window (in seconds) used to calculate the TWAP price for solvency checks during liquidations.
     uint32 internal constant TWAP_WINDOW = 600;
 
-    /// @notice Parameter that determines which oracle type to use for the "slow" oracle price on non-liquidation solvency checks.
-    /// @dev If false, an 8-slot internal median array is used to compute the "slow" oracle price.
-    /// @dev This oracle is updated with the last Uniswap observation during `mintOptions` if MEDIAN_PERIOD has elapsed past the last observation.
-    /// @dev If true, the "slow" oracle price is instead computed on-the-fly from 8 Uniswap observations (spaced 5 observations apart) irrespective of the frequency of `mintOptions` calls.
-    bool internal constant SLOW_ORACLE_UNISWAP_MODE = false;
-
     /// @notice The minimum amount of time, in seconds, permitted between internal TWAP updates.
     uint256 internal constant MEDIAN_PERIOD = 60;
 
@@ -134,13 +128,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @dev Uniswap observations snapshot the last block's closing price at the first interaction with the pool in a block.
     /// @dev In this case, if there is an interaction every block, the "fast" oracle can consider 3 consecutive block end prices (min=36 seconds on Ethereum).
     uint256 internal constant FAST_ORACLE_PERIOD = 1;
-
-    /// @notice Amount of Uniswap observations to include in the "slow" oracle price (in Uniswap mode).
-    uint256 internal constant SLOW_ORACLE_CARDINALITY = 8;
-
-    /// @notice Amount of observation indices to skip in between each observation for the "slow" oracle price.
-    /// @dev Structured such that the minimum total observation time is 8 minutes on Ethereum (similar to internal median mode).
-    uint256 internal constant SLOW_ORACLE_PERIOD = 5;
 
     /// @notice The maximum allowed delta between the currentTick and the Uniswap TWAP tick during a liquidation (~5% down, ~5.26% up).
     /// @dev Mitigates manipulation of the currentTick that causes positions to be liquidated at a less favorable price.
@@ -499,14 +486,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
     /// @notice Updates the internal median with the last Uniswap observation if the MEDIAN_PERIOD has elapsed.
     function pokeMedian() external {
-        (, , uint16 observationIndex, uint16 observationCardinality, , , ) = s_univ3pool.slot0();
-
-        (, uint256 medianData) = PanopticMath.computeInternalMedian(
-            observationIndex,
-            observationCardinality,
+        (, , , , uint256 medianData) = PanopticMath.getOracleTicks(
+            s_univ3pool,
+            FAST_ORACLE_CARDINALITY,
+            FAST_ORACLE_PERIOD,
             MEDIAN_PERIOD,
-            s_miniMedian,
-            s_univ3pool
+            s_miniMedian
         );
 
         if (medianData != 0) s_miniMedian = medianData;
@@ -875,7 +860,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
             int24 slowOracleTick,
             int24 lastObservedTick,
             uint256 _medianData
-        ) = _getOracleTicks();
+        ) = PanopticMath.getOracleTicks(
+                s_univ3pool,
+                FAST_ORACLE_CARDINALITY,
+                FAST_ORACLE_PERIOD,
+                MEDIAN_PERIOD,
+                s_miniMedian
+            );
 
         medianData = _medianData;
 
@@ -904,56 +895,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         if (!_checkSolvencyAtTicks(user, positionIdList, currentTick, atTicks, buffer))
             revert Errors.AccountInsolvent();
-    }
-
-    /// @notice Gets several ticks from Uniswap regarding the underlying pair.
-    /// @return currentTick The current tick in the Uniswap pool (as returned in slot0)
-    /// @return fastOracleTick The fast oracle tick computed as the median of the past N observations in the Uniswap Pool
-    /// @return slowOracleTick The slow oracle tick as tracked by `s_miniMedian`
-    /// @return latestObservation The latest observation from the Uniswap pool (price at the end of the last block)
-    /// @return medianData the updated value for `s_miniMedian` (returns 0 if not enough time has passed since last observation)
-    function _getOracleTicks()
-        internal
-        view
-        returns (
-            int24 currentTick,
-            int24 fastOracleTick,
-            int24 slowOracleTick,
-            int24 latestObservation,
-            uint256 medianData
-        )
-    {
-        IUniswapV3Pool _univ3pool = s_univ3pool;
-        uint16 observationIndex;
-        uint16 observationCardinality;
-
-        (, currentTick, observationIndex, observationCardinality, , , ) = _univ3pool.slot0();
-
-        (fastOracleTick, latestObservation) = PanopticMath.computeMedianObservedPrice(
-            _univ3pool,
-            observationIndex,
-            observationCardinality,
-            FAST_ORACLE_CARDINALITY,
-            FAST_ORACLE_PERIOD
-        );
-
-        if (SLOW_ORACLE_UNISWAP_MODE) {
-            (slowOracleTick, ) = PanopticMath.computeMedianObservedPrice(
-                _univ3pool,
-                observationIndex,
-                observationCardinality,
-                SLOW_ORACLE_CARDINALITY,
-                SLOW_ORACLE_PERIOD
-            );
-        } else {
-            (slowOracleTick, medianData) = PanopticMath.computeInternalMedian(
-                observationIndex,
-                observationCardinality,
-                MEDIAN_PERIOD,
-                s_miniMedian,
-                _univ3pool
-            );
-        }
     }
 
     /// @notice Burns and handles the exercise of options.
@@ -1502,7 +1443,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
             uint256 medianData
         )
     {
-        (currentTick, fastOracleTick, slowOracleTick, latestObservation, ) = _getOracleTicks();
+        (currentTick, fastOracleTick, slowOracleTick, latestObservation, ) = PanopticMath
+            .getOracleTicks(
+                s_univ3pool,
+                FAST_ORACLE_CARDINALITY,
+                FAST_ORACLE_PERIOD,
+                MEDIAN_PERIOD,
+                s_miniMedian
+            );
         medianData = s_miniMedian;
     }
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -112,7 +112,7 @@ library PanopticMath {
     }
 
     /*//////////////////////////////////////////////////////////////
-                          ORACLE CALCULATIONS
+                              UTILITIES
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Update an existing account's "positions hash" with a new single position `tokenId`.
@@ -144,6 +144,59 @@ library PanopticMath {
         }
     }
 
+    /*//////////////////////////////////////////////////////////////
+                          ORACLE CALCULATIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Gets several ticks from Uniswap regarding the underlying pair.
+    /// @return currentTick The current tick in the Uniswap pool (as returned in slot0)
+    /// @return fastOracleTick The fast oracle tick computed as the median of the past N observations in the Uniswap Pool
+    /// @return slowOracleTick The slow oracle tick as tracked by `s_miniMedian`
+    /// @return latestObservation The latest observation from the Uniswap pool (price at the end of the last block)
+    /// @return medianData the updated value for `s_miniMedian` (returns 0 if not enough time has passed since last observation)
+    function getOracleTicks(
+        IUniswapV3Pool univ3pool,
+        uint256 FAST_ORACLE_CARDINALITY,
+        uint256 FAST_ORACLE_PERIOD,
+        uint256 MEDIAN_PERIOD,
+        uint256 miniMedian
+    )
+        external
+        view
+        returns (
+            int24 currentTick,
+            int24 fastOracleTick,
+            int24 slowOracleTick,
+            int24 latestObservation,
+            uint256 medianData
+        )
+    {
+        uint16 observationIndex;
+        uint16 observationCardinality;
+
+        IUniswapV3Pool _univ3pool = univ3pool;
+        (, currentTick, observationIndex, observationCardinality, , , ) = univ3pool.slot0();
+
+        {
+            (fastOracleTick, latestObservation) = computeMedianObservedPrice(
+                _univ3pool,
+                observationIndex,
+                observationCardinality,
+                FAST_ORACLE_CARDINALITY,
+                FAST_ORACLE_PERIOD
+            );
+        }
+        {
+            (slowOracleTick, medianData) = computeInternalMedian(
+                observationIndex,
+                observationCardinality,
+                MEDIAN_PERIOD,
+                miniMedian,
+                _univ3pool
+            );
+        }
+    }
+
     /// @notice Returns the median of the last `cardinality` average prices over `period` observations from `univ3pool`.
     /// @dev Used when we need a manipulation-resistant TWAP price.
     /// @dev Uniswap observations snapshot the closing price of the last block before the first interaction of a given block.
@@ -164,7 +217,7 @@ library PanopticMath {
         uint256 observationCardinality,
         uint256 cardinality,
         uint256 period
-    ) external view returns (int24, int24) {
+    ) internal view returns (int24, int24) {
         unchecked {
             int256[] memory tickCumulatives = new int256[](cardinality + 1);
 
@@ -207,7 +260,7 @@ library PanopticMath {
         uint256 period,
         uint256 medianData,
         IUniswapV3Pool univ3pool
-    ) external view returns (int24 medianTick, uint256 updatedMedianData) {
+    ) internal view returns (int24 medianTick, uint256 updatedMedianData) {
         unchecked {
             // return the average of the rank 3 and 4 values
             medianTick =

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -125,15 +125,15 @@ contract PanopticPoolHarness is PanopticPool {
         // Start and store the collateral token0/1
         _initalizeCollateralPair(token0, token1, uniswapPool);
 
-        (, , uint16 observationIndex, uint16 observationCardinality, , , ) = uniswapPool.slot0();
+        (
+            ,
+            int24 currentTick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            ,
+            ,
 
-        (int24 slowOracleTick, ) = PanopticMath.computeMedianObservedPrice(
-            uniswapPool,
-            observationIndex,
-            observationCardinality,
-            SLOW_ORACLE_CARDINALITY,
-            SLOW_ORACLE_PERIOD
-        );
+        ) = uniswapPool.slot0();
 
         unchecked {
             s_miniMedian =
@@ -141,8 +141,8 @@ contract PanopticPoolHarness is PanopticPool {
                 // magic number which adds (7,5,3,1,0,2,4,6) order and minTick in positions 7, 5, 3 and maxTick in 6, 4, 2
                 // see comment on s_miniMedian initialization for format of this magic number
                 (uint256(0xF590A6F276170D89E9F276170D89E9F276170D89E9000000000000)) +
-                (uint256(uint24(slowOracleTick)) << 24) + // add to slot 4
-                (uint256(uint24(slowOracleTick))); // add to slot 3
+                (uint256(uint24(currentTick)) << 24) + // add to slot 4
+                (uint256(uint24(currentTick))); // add to slot 3
         }
 
         // Approve transfers of Panoptic Pool funds by SFPM


### PR DESCRIPTION
This is partly to reduce the bytecode size of PanopticPool.sol, and partly to simplify the calls to PanopticMath when getting the oracle ticks.

- Bytecode size:
  - `main`: `24,532kb`
  - `this branch`: `24,247kb` 
  - = `285b` savings
- PanopticMath external calls in _getOracleTicks:
  - `main` (2):
    - `PanopticMath.computeMedianObservedPrice` and 
    - `PanopticMath.computeInternalMedian`)
  - `this branch` (1):
    - `PanopticMath.getOracleTicks()`