### PR TITLE
feat: segregate long and short premium in collateral requirements

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1165,7 +1165,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             tokenRequired = _getTotalRequiredCollateral(atTick, positionBalanceArray) + longPremium;
         }
 
-        uint256 netBalance = convertToAssets(balanceOf[user]) + uint128(shortPremium);
+        uint256 netBalance = convertToAssets(balanceOf[user]) + shortPremium;
 
         // store assetBalance and tokens required in tokenData variable
         tokenData = tokenData.toRightSlot(netBalance.toUint128()).toLeftSlot(

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -543,8 +543,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         );
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-
-        return shares;
     }
 
     /// @notice Redeem the amount of shares required to withdraw the specified amount of assets.
@@ -588,8 +586,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         );
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-
-        return shares;
     }
 
     /// @notice Returns the maximum amount of shares that can be redeemed for a given user.
@@ -648,8 +644,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         );
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-
-        return assets;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1148,7 +1142,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...]
     /// @param shortPremium The total amount of premium (prorated by available settled tokens) owed to the short legs of `user`
     /// @param longPremium The total amount of premium owed by the long legs of `user`
-    /// @return tokenData Information collected for the tokens about the health of the account
+    /// @return Information collected for the tokens about the health of the account
     /// The collateral balance of the user is in the right slot and the threshold for margin call is in the left slot.
     function getAccountMarginDetails(
         address user,
@@ -1156,22 +1150,19 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256[2][] memory positionBalanceArray,
         uint128 shortPremium,
         uint128 longPremium
-    ) public view returns (LeftRightUnsigned tokenData) {
-        uint256 tokenRequired;
-
-        // if the account has active options, compute the required collateral to keep account in good health
-        if (positionBalanceArray.length > 0) {
-            // get all collateral required for the incoming list of positions
-            tokenRequired = _getTotalRequiredCollateral(atTick, positionBalanceArray) + longPremium;
+    ) public view returns (LeftRightUnsigned) {
+        unchecked {
+            return
+                LeftRightUnsigned
+                    .wrap(0)
+                    .toRightSlot((convertToAssets(balanceOf[user]) + shortPremium).toUint128())
+                    .toLeftSlot(
+                        positionBalanceArray.length > 0
+                            ? (_getTotalRequiredCollateral(atTick, positionBalanceArray) +
+                                longPremium).toUint128()
+                            : 0
+                    );
         }
-
-        uint256 netBalance = convertToAssets(balanceOf[user]) + shortPremium;
-
-        // store assetBalance and tokens required in tokenData variable
-        tokenData = tokenData.toRightSlot(netBalance.toUint128()).toLeftSlot(
-            tokenRequired.toUint128()
-        );
-        return tokenData;
     }
 
     /// @notice Get the total required amount of collateral tokens of a user/account across all active positions to stay above the margin requirement.
@@ -1213,8 +1204,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 ++i;
             }
         }
-
-        return tokenRequired;
     }
 
     /// @notice Get the required amount of collateral tokens corresponding to a specific single position 'tokenId' at a price 'tick'.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1144,57 +1144,28 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @dev NOTE: It's up to the caller to confirm from the returned result that the account has enough collateral.
     /// @dev This can be used to check the health: how many tokens a user has compared to the margin threshold.
     /// @param user The account to check collateral/margin health for
-    /// @param currentTick The tick at which to evaluate the account's positions
+    /// @param atTick The tick at which to evaluate the account's positions
     /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...]
-    /// @param premiumAllPositions The premium collected thus far across all positions
+    /// @param shortPremium The total amount of premium (prorated by available settled tokens) owed to the short legs of `user`
+    /// @param longPremium The total amount of premium owed by the long legs of `user`
     /// @return tokenData Information collected for the tokens about the health of the account
     /// The collateral balance of the user is in the right slot and the threshold for margin call is in the left slot.
     function getAccountMarginDetails(
         address user,
-        int24 currentTick,
-        uint256[2][] memory positionBalanceArray,
-        int128 premiumAllPositions
-    ) public view returns (LeftRightUnsigned tokenData) {
-        tokenData = _getAccountMargin(user, currentTick, positionBalanceArray, premiumAllPositions);
-    }
-
-    /// @notice Get the collateral status/margin details of an account/user.
-    /// @dev NOTE: It's up to the caller to confirm from the returned result that the account has enough collateral.
-    /// @dev This can be used to check the health: how many tokens a user has compared to the margin threshold.
-    /// @param user The account to check collateral/margin health for.
-    /// @param atTick The tick at which to evaluate the account's positions
-    /// @param positionBalanceArray The list of all historical positions held by the 'optionOwner', stored as [[tokenId, balance/poolUtilizationAtMint], ...]
-    /// @param premiumAllPositions The premium collected thus far across all positions
-    /// @return tokenData Information collected for the tokens about the health of the account;
-    /// the collateral balance of the user is in the right slot and the threshold for margin call is in the left slot
-    function _getAccountMargin(
-        address user,
         int24 atTick,
         uint256[2][] memory positionBalanceArray,
-        int128 premiumAllPositions
-    ) internal view returns (LeftRightUnsigned tokenData) {
+        uint128 shortPremium,
+        uint128 longPremium
+    ) public view returns (LeftRightUnsigned tokenData) {
         uint256 tokenRequired;
 
         // if the account has active options, compute the required collateral to keep account in good health
         if (positionBalanceArray.length > 0) {
             // get all collateral required for the incoming list of positions
-            tokenRequired = _getTotalRequiredCollateral(atTick, positionBalanceArray);
-
-            // If premium is negative (ie. user has to pay for their purchased options), add this long premium to the token requirement
-            if (premiumAllPositions < 0) {
-                unchecked {
-                    tokenRequired += uint128(-premiumAllPositions);
-                }
-            }
+            tokenRequired = _getTotalRequiredCollateral(atTick, positionBalanceArray) + longPremium;
         }
 
-        // if premium is positive (ie. user will receive funds due to selling options), add this premum to the user's balance
-        uint256 netBalance = convertToAssets(balanceOf[user]);
-        if (premiumAllPositions > 0) {
-            unchecked {
-                netBalance += uint256(uint128(premiumAllPositions));
-            }
-        }
+        uint256 netBalance = convertToAssets(balanceOf[user]) + uint128(shortPremium);
 
         // store assetBalance and tokens required in tokenData variable
         tokenData = tokenData.toRightSlot(netBalance.toUint128()).toLeftSlot(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -470,8 +470,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         );
                     }
                 } else {
-                    longPremium = longPremium.sub(
-                        LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(premiaByLeg[leg])))
+                    longPremium = LeftRightUnsigned.wrap(
+                        uint256(
+                            LeftRightSigned.unwrap(
+                                LeftRightSigned
+                                    .wrap(int256(LeftRightUnsigned.unwrap(longPremium)))
+                                    .sub(premiaByLeg[leg])
+                            )
+                        )
                     );
                 }
                 unchecked {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -354,7 +354,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param user Address of the user that owns the positions
     /// @param positionIdList List of positions. Written as [tokenId1, tokenId2, ...]
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
-    /// @return shortPremium The total amount of premium owed (according to `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
+    /// @return shortPremium The total amount of premium owed (which may `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return longPremium The total amount of premium owed by the long legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
     function calculateAccumulatedFeesBatch(
@@ -399,7 +399,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param positionIdList The list of all option positions held by user
     /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false)
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
-    /// @return shortPremium The total amount of premium owed (according to `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
+    /// @return shortPremium The total amount of premium owed (which may `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return longPremium The total amount of premium owed by the long legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return balances A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
     function _calculateAccumulatedPremia(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -354,28 +354,26 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param user Address of the user that owns the positions
     /// @param positionIdList List of positions. Written as [tokenId1, tokenId2, ...]
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
-    /// @return premium0 Premium for token0 (negative = amount is owed)
-    /// @return premium1 Premium for token1 (negative = amount is owed)
+    /// @return shortPremium The total amount of premium owed (according to `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
+    /// @return longPremium The total amount of premium owed by the long legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
     function calculateAccumulatedFeesBatch(
         address user,
         bool includePendingPremium,
         TokenId[] calldata positionIdList
-    ) external view returns (int128 premium0, int128 premium1, uint256[2][] memory) {
+    ) external view returns (LeftRightUnsigned, LeftRightUnsigned, uint256[2][] memory) {
         // Get the current tick of the Uniswap pool
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
 
         // Compute the accumulated premia for all tokenId in positionIdList (includes short+long premium)
-        (LeftRightSigned premia, uint256[2][] memory balances) = _calculateAccumulatedPremia(
-            user,
-            positionIdList,
-            COMPUTE_ALL_PREMIA,
-            includePendingPremium,
-            currentTick
-        );
-
-        // Return the premia as (token0, token1)
-        return (premia.rightSlot(), premia.leftSlot(), balances);
+        return
+            _calculateAccumulatedPremia(
+                user,
+                positionIdList,
+                COMPUTE_ALL_PREMIA,
+                includePendingPremium,
+                currentTick
+            );
     }
 
     /// @notice Compute the net token amounts owned by a given positionIdList in the Uniswap pool at the given price tick.
@@ -401,7 +399,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param positionIdList The list of all option positions held by user
     /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false)
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
-    /// @return portfolioPremium The computed premia of the user's positions, where premia contains the accumulated premia for token0 in the right slot and for token1 in the left slot
+    /// @return shortPremium The total amount of premium owed (according to `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
+    /// @return longPremium The total amount of premium owed by the long legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return balances A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
     function _calculateAccumulatedPremia(
         address user,
@@ -409,7 +408,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
         bool computeAllPremia,
         bool includePendingPremium,
         int24 atTick
-    ) internal view returns (LeftRightSigned portfolioPremium, uint256[2][] memory balances) {
+    )
+        internal
+        view
+        returns (
+            LeftRightUnsigned shortPremium,
+            LeftRightUnsigned longPremium,
+            uint256[2][] memory balances
+        )
+    {
         uint256 pLength = positionIdList.length;
         balances = new uint256[2][](pLength);
 
@@ -434,28 +441,38 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
             uint256 numLegs = tokenId.countLegs();
             for (uint256 leg = 0; leg < numLegs; ) {
-                if (tokenId.isLong(leg) == 0 && !includePendingPremium) {
-                    bytes32 chunkKey = keccak256(
-                        abi.encodePacked(
-                            tokenId.strike(leg),
-                            tokenId.width(leg),
-                            tokenId.tokenType(leg)
-                        )
-                    );
+                if (tokenId.isLong(leg) == 0) {
+                    if (!includePendingPremium) {
+                        bytes32 chunkKey = keccak256(
+                            abi.encodePacked(
+                                tokenId.strike(leg),
+                                tokenId.width(leg),
+                                tokenId.tokenType(leg)
+                            )
+                        );
 
-                    (uint256 totalLiquidity, , ) = _getLiquidities(tokenId, leg);
-                    LeftRightUnsigned availablePremium = _getAvailablePremium(
-                        totalLiquidity,
-                        s_settledTokens[chunkKey],
-                        s_grossPremiumLast[chunkKey],
-                        LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(premiaByLeg[leg]))),
-                        premiumAccumulatorsByLeg[leg]
-                    );
-                    portfolioPremium = portfolioPremium.add(
-                        LeftRightSigned.wrap(int256(LeftRightUnsigned.unwrap(availablePremium)))
-                    );
+                        (uint256 totalLiquidity, , ) = _getLiquidities(tokenId, leg);
+                        LeftRightUnsigned availablePremium = _getAvailablePremium(
+                            totalLiquidity,
+                            s_settledTokens[chunkKey],
+                            s_grossPremiumLast[chunkKey],
+                            LeftRightUnsigned.wrap(
+                                uint256(LeftRightSigned.unwrap(premiaByLeg[leg]))
+                            ),
+                            premiumAccumulatorsByLeg[leg]
+                        );
+                        shortPremium = shortPremium.add(availablePremium);
+                    } else {
+                        shortPremium = shortPremium.add(
+                            LeftRightUnsigned.wrap(
+                                uint256(LeftRightSigned.unwrap(premiaByLeg[leg]))
+                            )
+                        );
+                    }
                 } else {
-                    portfolioPremium = portfolioPremium.add(premiaByLeg[leg]);
+                    longPremium = longPremium.sub(
+                        LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(premiaByLeg[leg])))
+                    );
                 }
                 unchecked {
                     ++leg;
@@ -466,7 +483,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 ++k;
             }
         }
-        return (portfolioPremium, balances);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -938,11 +954,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
-        LeftRightSigned premia;
+        LeftRightUnsigned shortPremium;
 
         {
             uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
-            (premia, positionBalanceArray) = _calculateAccumulatedPremia(
+            LeftRightUnsigned longPremium;
+            (shortPremium, longPremium, positionBalanceArray) = _calculateAccumulatedPremia(
                 liquidatee,
                 positionIdList,
                 COMPUTE_ALL_PREMIA,
@@ -954,14 +971,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 liquidatee,
                 twapTick,
                 positionBalanceArray,
-                premia.rightSlot()
+                shortPremium.rightSlot(),
+                longPremium.rightSlot()
             );
 
             tokenData1 = s_collateralToken1.getAccountMarginDetails(
                 liquidatee,
                 twapTick,
                 positionBalanceArray,
-                premia.leftSlot()
+                shortPremium.leftSlot(),
+                longPremium.leftSlot()
             );
         }
 
@@ -998,7 +1017,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     Math.getSqrtRatioAtTick(twapTick),
                     Math.getSqrtRatioAtTick(twapTick),
                     netExchanged,
-                    premia
+                    shortPremium
                 );
 
             // premia cannot be paid if there is protocol loss associated with the liquidatee
@@ -1168,7 +1187,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         uint256 buffer
     ) internal view returns (bool) {
         (
-            LeftRightSigned portfolioPremium,
+            LeftRightUnsigned shortPremium,
+            LeftRightUnsigned longPremium,
             uint256[2][] memory positionBalanceArray
         ) = _calculateAccumulatedPremia(
                 account,
@@ -1189,7 +1209,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         account,
                         atTicks[i],
                         positionBalanceArray,
-                        portfolioPremium,
+                        shortPremium,
+                        longPremium,
                         buffer
                     )
                         ? uint8(1)
@@ -1212,28 +1233,33 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param account The account to check solvency for
     /// @param atTick The tick to check solvency at
     /// @param positionBalanceArray A list of balances and pool utilization for each position, of the form [[tokenId0, balances0], [tokenId1, balances1], ...]
-    /// @param portfolioPremium The computed premia of the user's positions, where premia contains the accumulated premia for token0 in the right slot and for token1 in the left slot
+    /// @param shortPremium The total amount of premium (prorated by available settled tokens) owed to the short legs of `account`
+    /// @param longPremium The total amount of premium owed by the long legs of `account`
     /// @param buffer The buffer to apply to the collateral requirement
     /// @return Whether the account is solvent at the given tick
     function _checkCrossBalances(
         address account,
         int24 atTick,
         uint256[2][] memory positionBalanceArray,
-        LeftRightSigned portfolioPremium,
+        LeftRightUnsigned shortPremium,
+        LeftRightUnsigned longPremium,
         uint256 buffer
     ) internal view returns (bool) {
         LeftRightUnsigned tokenData0 = s_collateralToken0.getAccountMarginDetails(
             account,
             atTick,
             positionBalanceArray,
-            portfolioPremium.rightSlot()
+            shortPremium.rightSlot(),
+            longPremium.rightSlot()
         );
         LeftRightUnsigned tokenData1 = s_collateralToken1.getAccountMarginDetails(
             account,
             atTick,
             positionBalanceArray,
-            portfolioPremium.leftSlot()
+            shortPremium.leftSlot(),
+            longPremium.leftSlot()
         );
+
         (uint256 balanceCross, uint256 thresholdCross) = _getSolvencyBalances(
             tokenData0,
             tokenData1,

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -712,7 +712,7 @@ library PanopticMath {
     /// @param sqrtPriceX96Twap The sqrt(price) of the TWAP tick before liquidation used to evaluate solvency
     /// @param sqrtPriceX96Final The current sqrt(price) of the AMM after liquidating a user
     /// @param netExchanged The net exchanged value of the closed portfolio
-    /// @param shortPremium Total owed premium (prorated by available settled tokens) across all short legs being liquidated present in tokenData
+    /// @param shortPremium Total owed premium (prorated by available settled tokens) across all short legs being liquidated
     /// @return bonus0 Bonus amount for token0
     /// @return bonus1 Bonus amount for token1
     /// @return The LeftRight-packed protocol loss for both tokens, i.e., the delta between the user's balance and expended tokens

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -712,7 +712,7 @@ library PanopticMath {
     /// @param sqrtPriceX96Twap The sqrt(price) of the TWAP tick before liquidation used to evaluate solvency
     /// @param sqrtPriceX96Final The current sqrt(price) of the AMM after liquidating a user
     /// @param netExchanged The net exchanged value of the closed portfolio
-    /// @param premia Premium across all positions being liquidated present in tokenData
+    /// @param shortPremium Total owed premium (prorated by available settled tokens) across all short legs being liquidated present in tokenData
     /// @return bonus0 Bonus amount for token0
     /// @return bonus1 Bonus amount for token1
     /// @return The LeftRight-packed protocol loss for both tokens, i.e., the delta between the user's balance and expended tokens
@@ -722,7 +722,7 @@ library PanopticMath {
         uint160 sqrtPriceX96Twap,
         uint160 sqrtPriceX96Final,
         LeftRightSigned netExchanged,
-        LeftRightSigned premia
+        LeftRightUnsigned shortPremium
     ) external pure returns (int256 bonus0, int256 bonus1, LeftRightSigned) {
         unchecked {
             // compute bonus as min(collateralBalance/2, required-collateralBalance)
@@ -760,9 +760,9 @@ library PanopticMath {
             // negative premium (owed to the liquidatee) is credited to the collateral balance
             // this is already present in the netExchanged amount, so to avoid double-counting we remove it from the balance
             int256 balance0 = int256(uint256(tokenData0.rightSlot())) -
-                Math.max(premia.rightSlot(), 0);
+                int256(uint256(shortPremium.rightSlot()));
             int256 balance1 = int256(uint256(tokenData1.rightSlot())) -
-                Math.max(premia.leftSlot(), 0);
+                int256(uint256(shortPremium.leftSlot()));
 
             int256 paid0 = bonus0 + int256(netExchanged.rightSlot());
             int256 paid1 = bonus1 + int256(netExchanged.leftSlot());

--- a/periphery/PanopticHelper.sol
+++ b/periphery/PanopticHelper.sol
@@ -52,21 +52,26 @@ contract PanopticHelper {
         TokenId[] calldata positionIdList
     ) public view returns (uint256, uint256) {
         // Compute premia for all options (includes short+long premium)
-        (int128 premium0, int128 premium1, uint256[2][] memory positionBalanceArray) = pool
-            .calculateAccumulatedFeesBatch(account, false, positionIdList);
+        (
+            LeftRightUnsigned shortPremium,
+            LeftRightUnsigned longPremium,
+            uint256[2][] memory positionBalanceArray
+        ) = pool.calculateAccumulatedFeesBatch(account, false, positionIdList);
 
         // Query the current and required collateral amounts for the two tokens
         LeftRightUnsigned tokenData0 = pool.collateralToken0().getAccountMarginDetails(
             account,
             atTick,
             positionBalanceArray,
-            premium0
+            shortPremium.rightSlot(),
+            longPremium.rightSlot()
         );
         LeftRightUnsigned tokenData1 = pool.collateralToken1().getAccountMarginDetails(
             account,
             atTick,
             positionBalanceArray,
-            premium1
+            shortPremium.leftSlot(),
+            longPremium.leftSlot()
         );
 
         // convert (using atTick) and return the total collateral balance and required balance in terms of tokenType

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -4189,7 +4189,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()
@@ -4700,7 +4700,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()
@@ -5059,7 +5059,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()
@@ -5225,7 +5225,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -2604,27 +2604,27 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 poolUtilizations = uint128(poolUtilization0) +
                 (uint128(poolUtilization1) << 64);
 
-            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
+            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 4, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
-            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+            required += int256(uint256($shortPremia.rightSlot())) -
                 int256(uint256($longPremia.rightSlot())) <
                 0
-                ? int128(
-                    10_000 *
+                ? uint128(
+                    (uint128(10_000) *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.rightSlot())) -
                                     int256(uint256($longPremia.rightSlot()))
                             )
-                        )
-                ) / 10_000
-                : int128(0);
-            required += int256(uint256($shortPremia.leftSlot())) -
+                        )) / 10_000
+                )
+                : 0;
+            int128 premium1 = int256(uint256($shortPremia.leftSlot())) -
                 int256(uint256($longPremia.leftSlot())) <
                 0
-                ? uint128(
-                    (uint128(10_000) *
+                ? int128(
+                    (10_000 *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.leftSlot())) -
@@ -2632,10 +2632,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
                             )
                         )) / 10_000
                 )
-                : 0;
-
-            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
-            assertEq(required, tokenData1.leftSlot(), "required token1");
+                : int128(0);
+            assertEq(required, tokenData0.leftSlot(), "required token0");
+            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
         }
 
         {
@@ -3053,24 +3052,24 @@ contract CollateralTrackerTest is Test, PositionUtils {
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
             // only add premium requirement if there is net premia owed
-            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+            required += int256(uint256($shortPremia.rightSlot())) -
                 int256(uint256($longPremia.rightSlot())) <
                 0
-                ? int128(
-                    10_000 *
+                ? uint128(
+                    (uint128(10_000) *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.rightSlot())) -
                                     int256(uint256($longPremia.rightSlot()))
                             )
-                        )
-                ) / 10_000
-                : int128(0);
-            required += int256(uint256($shortPremia.leftSlot())) -
+                        )) / 10_000
+                )
+                : 0;
+            int128 premium1 = int256(uint256($shortPremia.leftSlot())) -
                 int256(uint256($longPremia.leftSlot())) <
                 0
-                ? uint128(
-                    (uint128(10_000) *
+                ? int128(
+                    (10_000 *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.leftSlot())) -
@@ -3078,10 +3077,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
                             )
                         )) / 10_000
                 )
-                : 0;
+                : int128(0);
 
-            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
-            assertEq(required, tokenData1.leftSlot(), "required token1");
+            assertEq(required, tokenData0.leftSlot(), "required token0");
+            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
         }
 
         {
@@ -3523,24 +3522,24 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+            required += int256(uint256($shortPremia.rightSlot())) -
                 int256(uint256($longPremia.rightSlot())) <
                 0
-                ? int128(
-                    10_000 *
+                ? uint128(
+                    (uint128(10_000) *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.rightSlot())) -
                                     int256(uint256($longPremia.rightSlot()))
                             )
-                        )
-                ) / 10_000
-                : int128(0);
-            required += int256(uint256($shortPremia.leftSlot())) -
+                        )) / 10_000
+                )
+                : 0;
+            int128 premium1 = int256(uint256($shortPremia.leftSlot())) -
                 int256(uint256($longPremia.leftSlot())) <
                 0
-                ? uint128(
-                    (uint128(10_000) *
+                ? int128(
+                    (10_000 *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.leftSlot())) -
@@ -3548,10 +3547,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
                             )
                         )) / 10_000
                 )
-                : 0;
-
-            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
-            assertEq(required, tokenData1.leftSlot(), "required token1");
+                : int128(0);
+            assertEq(required, tokenData0.leftSlot(), "required token0");
+            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
         }
 
         {
@@ -3754,24 +3752,24 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+            required += int256(uint256($shortPremia.rightSlot())) -
                 int256(uint256($longPremia.rightSlot())) <
                 0
-                ? int128(
-                    10_000 *
+                ? uint128(
+                    (uint128(10_000) *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.rightSlot())) -
                                     int256(uint256($longPremia.rightSlot()))
                             )
-                        )
-                ) / 10_000
-                : int128(0);
-            required += int256(uint256($shortPremia.leftSlot())) -
+                        )) / 10_000
+                )
+                : 0;
+            int128 premium1 = int256(uint256($shortPremia.leftSlot())) -
                 int256(uint256($longPremia.leftSlot())) <
                 0
-                ? uint128(
-                    (uint128(10_000) *
+                ? int128(
+                    (10_000 *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.leftSlot())) -
@@ -3779,10 +3777,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
                             )
                         )) / 10_000
                 )
-                : 0;
-
-            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
-            assertEq(required, tokenData1.leftSlot(), "required token1");
+                : int128(0);
+            assertEq(required, tokenData0.leftSlot(), "required token0");
+            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
         }
 
         {
@@ -4141,7 +4138,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()
@@ -4192,7 +4189,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()
@@ -4317,7 +4314,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()
@@ -4513,7 +4510,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()
@@ -4542,24 +4539,24 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // checks tokens required
-            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+            required += int256(uint256($shortPremia.rightSlot())) -
                 int256(uint256($longPremia.rightSlot())) <
                 0
-                ? int128(
-                    10_000 *
+                ? uint128(
+                    (uint128(10_000) *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.rightSlot())) -
                                     int256(uint256($longPremia.rightSlot()))
                             )
-                        )
-                ) / 10_000
-                : int128(0);
-            required += int256(uint256($shortPremia.leftSlot())) -
+                        )) / 10_000
+                )
+                : 0;
+            int128 premium1 = int256(uint256($shortPremia.leftSlot())) -
                 int256(uint256($longPremia.leftSlot())) <
                 0
-                ? uint128(
-                    (uint128(10_000) *
+                ? int128(
+                    (10_000 *
                         uint128(
                             -int128(
                                 int256(uint256($shortPremia.leftSlot())) -
@@ -4567,10 +4564,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
                             )
                         )) / 10_000
                 )
-                : 0;
-
-            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
-            assertEq(required, tokenData1.leftSlot(), "required token1");
+                : int128(0);
+            assertEq(required, tokenData0.leftSlot(), "required token0");
+            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
         }
 
         {
@@ -4891,7 +4887,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                currentTick,
+                atTick,
                 posBalanceArray,
                 $shortPremia.rightSlot(),
                 $longPremia.rightSlot()

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -125,15 +125,7 @@ contract PanopticPoolHarness is PanopticPool {
         // Start and store the collateral token0/1
         _initalizeCollateralPair(token0, token1, uniswapPool);
 
-        (
-            ,
-            int24 currentTick,
-            uint16 observationIndex,
-            uint16 observationCardinality,
-            ,
-            ,
-
-        ) = uniswapPool.slot0();
+        (, int24 currentTick, , , , , ) = uniswapPool.slot0();
 
         unchecked {
             s_miniMedian =
@@ -440,6 +432,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     uint256 balanceData0;
     uint256 thresholdData0;
+
+    LeftRightUnsigned $longPremia;
+    LeftRightUnsigned $shortPremia;
+
+    uint256[2][] posBalanceArray;
 
     function _initWorld(uint256 seed) internal {
         // Pick a pool from the seed and cache initial state
@@ -2200,20 +2197,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -2226,9 +2225,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 tokenId1,
                 positionSize0 / 2,
                 poolUtilizations,
-                atTick,
-                premium0,
-                premium1
+                atTick
             );
 
             // checks tokens required
@@ -2239,20 +2236,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -2377,20 +2376,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -2402,28 +2403,55 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
-            premium0 = premium0 < 0 ? int128(10_000 * uint128(-premium0)) / 10_000 : int128(0);
-            required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
+            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot())) <
+                0
+                ? int128(
+                    10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )
+                ) / 10_000
+                : int128(0);
+            required += int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
 
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
 
         {
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
+
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -2552,20 +2580,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -2574,32 +2604,60 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 poolUtilizations = uint128(poolUtilization0) +
                 (uint128(poolUtilization1) << 64);
 
-            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 4, poolUtilizations);
+            uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
-            required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
-            premium1 = premium1 < 0 ? int128(10_000 * uint128(-premium1)) / 10_000 : int128(0);
-            assertEq(required, tokenData0.leftSlot(), "required token0");
-            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
+            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot())) <
+                0
+                ? int128(
+                    10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )
+                ) / 10_000
+                : int128(0);
+            required += int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
+
+            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
+            assertEq(required, tokenData1.leftSlot(), "required token1");
         }
 
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
+
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -2729,20 +2787,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -2754,8 +2814,33 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128 required = _spreadTokensRequired(tokenId1, positionSize0 / 2, poolUtilizations);
 
             // only add premium requirement if there is net premia owed
-            premium0 = premium0 < 0 ? int128((10_000 * uint128(-premium0)) / 10_000) : int128(0);
-            required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
+            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot())) <
+                0
+                ? int128(
+                    10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )
+                ) / 10_000
+                : int128(0);
+            required += int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
+
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
@@ -2763,20 +2848,23 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
+
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -2937,20 +3025,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -2963,29 +3053,56 @@ contract CollateralTrackerTest is Test, PositionUtils {
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
             // only add premium requirement if there is net premia owed
-            required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
-            assertEq(required, tokenData0.leftSlot(), "required token0");
-            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
+            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot())) <
+                0
+                ? int128(
+                    10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )
+                ) / 10_000
+                : int128(0);
+            required += int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
+
+            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
+            assertEq(required, tokenData1.leftSlot(), "required token1");
         }
 
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -3159,20 +3276,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -3181,30 +3300,55 @@ contract CollateralTrackerTest is Test, PositionUtils {
             console2.log("PU1", poolUtilization1);
 
             // only add premium requirement if there is net premia owed
-            required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
-            console2.log("premium0", premium0);
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
+            required += uint128(
+                int256(uint256($shortPremia.rightSlot())) -
+                    int256(uint256($longPremia.rightSlot())) <
+                    0
+                    ? int128(
+                        10_000 *
+                            uint128(
+                                -int128(
+                                    int256(uint256($shortPremia.rightSlot())) -
+                                        int256(uint256($longPremia.rightSlot()))
+                                )
+                            )
+                    ) / 10_000
+                    : int128(0)
+            );
+            uint128 premium1 = int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (int128(10_000) *
+                        -int128(
+                            int256(uint256($shortPremia.leftSlot())) -
+                                int256(uint256($longPremia.leftSlot()))
+                        )) / 10_000
+                )
+                : 0;
             assertEq(required, tokenData0.leftSlot(), "required token0");
-            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
+            assertEq(premium1, tokenData1.leftSlot(), "required token1");
         }
 
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -3345,20 +3489,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -3377,29 +3523,56 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
-            assertEq(required, tokenData0.leftSlot(), "required token0");
-            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
+            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot())) <
+                0
+                ? int128(
+                    10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )
+                ) / 10_000
+                : int128(0);
+            required += int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
+
+            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
+            assertEq(required, tokenData1.leftSlot(), "required token1");
         }
 
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -3547,20 +3720,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -3579,29 +3754,56 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
-            assertEq(required, tokenData0.leftSlot(), "required token0");
-            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
+            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot())) <
+                0
+                ? int128(
+                    10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )
+                ) / 10_000
+                : int128(0);
+            required += int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
+
+            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
+            assertEq(required, tokenData1.leftSlot(), "required token1");
         }
 
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -3735,20 +3937,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -3767,29 +3971,55 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // checks tokens required
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
-            required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
+            required += uint128(
+                int256(uint256($shortPremia.rightSlot())) -
+                    int256(uint256($longPremia.rightSlot())) <
+                    0
+                    ? int128(
+                        10_000 *
+                            uint128(
+                                -int128(
+                                    int256(uint256($shortPremia.rightSlot())) -
+                                        int256(uint256($longPremia.rightSlot()))
+                                )
+                            )
+                    ) / 10_000
+                    : int128(0)
+            );
+            uint128 premium1 = int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (int128(10_000) *
+                        -int128(
+                            int256(uint256($shortPremia.leftSlot())) -
+                                int256(uint256($longPremia.leftSlot()))
+                        )) / 10_000
+                )
+                : 0;
             assertEq(required, tokenData0.leftSlot(), "required token0");
-            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
+            assertEq(premium1, tokenData1.leftSlot(), "required token1");
         }
 
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Alice,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -3906,20 +4136,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -3938,7 +4170,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
+            int128 premium1 = int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? ((int128(10_000) *
+                    -int128(
+                        int256(uint256($shortPremia.leftSlot())) -
+                            int256(uint256($longPremia.leftSlot()))
+                    )) / 10_000)
+                : int8(0);
             assertEq(required, tokenData0.leftSlot(), "required token0");
             assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
         }
@@ -3947,20 +4187,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -4070,20 +4312,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -4106,8 +4350,32 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            premium0 = premium0 < 0 ? int128((10_000 * uint128(-premium0)) / 10_000) : int128(0);
-            required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
+            int128 premium0 = int128(
+                int256(uint256($shortPremia.rightSlot())) - int256(uint256($longPremia.rightSlot()))
+            ) < 0
+                ? int128(
+                    (10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )) / 10_000
+                )
+                : int128(0);
+            required += int128(
+                int256(uint256($shortPremia.leftSlot())) - int256(uint256($longPremia.leftSlot()))
+            ) < 0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
@@ -4116,20 +4384,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -4238,20 +4508,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -4270,29 +4542,56 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // checks tokens required
-            required += premium0 < 0 ? uint128((uint128(10_000) * uint128(-premium0)) / 10_000) : 0;
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
-            assertEq(required, tokenData0.leftSlot(), "required token0");
-            assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
+            int128 premium0 = int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot())) <
+                0
+                ? int128(
+                    10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )
+                ) / 10_000
+                : int128(0);
+            required += int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot())) <
+                0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
+
+            assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
+            assertEq(required, tokenData1.leftSlot(), "required token1");
         }
 
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -4400,20 +4699,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -4432,8 +4733,32 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            premium0 = premium0 < 0 ? int128((10_000 * uint128(-premium0)) / 10_000) : int128(0);
-            required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
+            int128 premium0 = int128(
+                int256(uint256($shortPremia.rightSlot())) - int256(uint256($longPremia.rightSlot()))
+            ) < 0
+                ? int128(
+                    (10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )) / 10_000
+                )
+                : int128(0);
+            required += int128(
+                int256(uint256($shortPremia.leftSlot())) - int256(uint256($longPremia.leftSlot()))
+            ) < 0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
@@ -4441,20 +4766,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -4559,20 +4886,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -4591,7 +4920,19 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            premium1 = premium1 < 0 ? int128((10_000 * uint128(-premium1)) / 10_000) : int128(0);
+            int128 premium1 = int128(
+                int256(uint256($shortPremia.leftSlot())) - int256(uint256($longPremia.leftSlot()))
+            ) < 0
+                ? int128(
+                    (10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : int128(0);
             assertEq(required, tokenData0.leftSlot(), "required token0");
             assertEq(premium1, int128(tokenData1.leftSlot()), "required token1");
         }
@@ -4599,20 +4940,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -4715,20 +5058,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -4747,8 +5092,32 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
 
             // only add premium requirement if there is net premia owed
-            premium0 = premium0 < 0 ? int128((10_000 * uint128(-premium0)) / 10_000) : int128(0);
-            required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
+            int128 premium0 = int128(
+                int256(uint256($shortPremia.rightSlot())) - int256(uint256($longPremia.rightSlot()))
+            ) < 0
+                ? int128(
+                    (10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )) / 10_000
+                )
+                : int128(0);
+            required += int128(
+                int256(uint256($shortPremia.leftSlot())) - int256(uint256($longPremia.leftSlot()))
+            ) < 0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
@@ -4756,20 +5125,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -4853,20 +5224,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = int24(bound(atTick, TickMath.MIN_TICK, TickMath.MAX_TICK));
             atTick = (atTick / tickSpacing) * tickSpacing;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
-                atTick,
+                currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 atTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticPool
@@ -4888,12 +5261,44 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 checkSingle
             );
 
-            assertTrue(premium0 >= 0 && premium1 >= 0, "invalid premia");
+            assertTrue(
+                int256(uint256($shortPremia.rightSlot())) -
+                    int256(uint256($longPremia.rightSlot())) >=
+                    0 &&
+                    int256(uint256($shortPremia.leftSlot())) -
+                        int256(uint256($longPremia.leftSlot())) >=
+                    0,
+                "invalid premia"
+            );
 
             // checks tokens required
             // only add premium requirement, if there is net premia owed
-            required += premium1 < 0 ? uint128((uint128(10_000) * uint128(-premium1)) / 10_000) : 0;
-            premium0 = premium0 < 0 ? int128((10_000 * uint128(-premium0)) / 10_000) : int128(0);
+            required += int128(
+                int256(uint256($shortPremia.leftSlot())) - int256(uint256($longPremia.leftSlot()))
+            ) < 0
+                ? uint128(
+                    (uint128(10_000) *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.leftSlot())) -
+                                    int256(uint256($longPremia.leftSlot()))
+                            )
+                        )) / 10_000
+                )
+                : 0;
+            int128 premium0 = int128(
+                int256(uint256($shortPremia.rightSlot())) - int256(uint256($longPremia.rightSlot()))
+            ) < 0
+                ? int128(
+                    (10_000 *
+                        uint128(
+                            -int128(
+                                int256(uint256($shortPremia.rightSlot())) -
+                                    int256(uint256($longPremia.rightSlot()))
+                            )
+                        )) / 10_000
+                )
+                : int128(0);
             assertEq(premium0, int128(tokenData0.leftSlot()), "required token0");
             assertEq(required, tokenData1.leftSlot(), "required token1");
         }
@@ -4902,20 +5307,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         {
             (, currentTick, , , , , ) = pool.slot0();
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = panopticPool
+            ($shortPremia, $longPremia, posBalanceArray) = panopticPool
                 .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium0
+                $shortPremia.rightSlot(),
+                $longPremia.rightSlot()
             );
             LeftRightUnsigned tokenData1 = collateralToken1.getAccountMarginDetails(
                 Bob,
                 currentTick,
                 posBalanceArray,
-                premium1
+                $shortPremia.leftSlot(),
+                $longPremia.leftSlot()
             );
 
             (uint256 calcBalanceCross, uint256 calcThresholdCross) = PanopticMath
@@ -6468,9 +6875,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         TokenId _tokenId,
         uint128 positionSize,
         uint128 poolUtilization,
-        int24 atTick,
-        int128 premium0,
-        int128 premium1
+        int24 atTick
     ) internal returns (uint128 tokensRequired0, uint128 tokensRequired1) {
         uint maxLoop = tokenId.countLegs();
 
@@ -6574,13 +6979,33 @@ contract CollateralTrackerTest is Test, PositionUtils {
             }
 
             if (tokenType == 0) {
-                tokensRequired0 = premium0 < 0
-                    ? tokensRequired += uint128((uint128(10_000) * uint128(-premium0)) / 10_000)
+                tokensRequired0 = int256(uint256($shortPremia.rightSlot())) -
+                    int256(uint256($longPremia.rightSlot())) <
+                    0
+                    ? tokensRequired += uint128(
+                        (uint128(10_000) *
+                            uint128(
+                                -int128(
+                                    int256(uint256($shortPremia.rightSlot())) -
+                                        int256(uint256($longPremia.rightSlot()))
+                                )
+                            )) / 10_000
+                    )
                     : tokensRequired;
                 tokensRequired = 0;
             } else {
-                tokensRequired1 = premium1 < 0
-                    ? tokensRequired += uint128((uint128(10_000) * uint128(-premium1)) / 10_000)
+                tokensRequired1 = int256(uint256($shortPremia.leftSlot())) -
+                    int256(uint256($longPremia.leftSlot())) <
+                    0
+                    ? tokensRequired += uint128(
+                        (uint128(10_000) *
+                            uint128(
+                                -int128(
+                                    int256(uint256($shortPremia.leftSlot())) -
+                                        int256(uint256($longPremia.leftSlot()))
+                                )
+                            )) / 10_000
+                    )
                     : tokensRequired;
                 tokensRequired = 0; // reset temp
             }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -160,6 +160,8 @@ contract Misctest is Test, PositionUtils {
     int24 fastOracleTick;
     int24 lastObservedTick;
 
+    uint256 medianData;
+
     uint256 assetsBefore0;
     uint256 assetsBefore1;
 
@@ -1373,7 +1375,7 @@ contract Misctest is Test, PositionUtils {
 
         swapperc.swapTo(uniPool, 2 ** 96);
         {
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
             LeftRightUnsigned accountLiquidityPrimary = sfpm.getAccountLiquidity(
                 address(uniPool),
                 address(pp),
@@ -2379,7 +2381,7 @@ contract Misctest is Test, PositionUtils {
 
         assertTrue(totalCollateralBalance0 > totalCollateralRequired0, "Is solvent at stale tick!");
 
-        (, int24 currentTick, , , , , ) = uniPool.slot0();
+        (, currentTick, , , , , ) = uniPool.slot0();
 
         (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
             pp,
@@ -2553,7 +2555,7 @@ contract Misctest is Test, PositionUtils {
 
         assertTrue(totalCollateralBalance0 > totalCollateralRequired0, "Is solvent at stale tick!");
 
-        (, int24 currentTick, , , , , ) = uniPool.slot0();
+        (, currentTick, , , , , ) = uniPool.slot0();
 
         (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
             pp,
@@ -2705,7 +2707,7 @@ contract Misctest is Test, PositionUtils {
 
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-953));
 
-        (int24 currentTick, int24 slowOracleTick, , , ) = pp.getOracleTicks();
+        (currentTick, slowOracleTick, , , ) = pp.getOracleTicks();
 
         assertTrue(Math.abs(currentTick - slowOracleTick) <= 953, "small price deviation");
         assertTrue(pp.isSafeMode() == false, "not in safe mode");
@@ -2729,7 +2731,7 @@ contract Misctest is Test, PositionUtils {
 
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(953));
 
-        (int24 currentTick, int24 slowOracleTick, , , ) = pp.getOracleTicks();
+        (currentTick, slowOracleTick, , , ) = pp.getOracleTicks();
 
         assertTrue(Math.abs(currentTick - slowOracleTick) <= 953, "small price deviation");
         assertTrue(pp.isSafeMode() == false, "not in safe mode");
@@ -2763,7 +2765,7 @@ contract Misctest is Test, PositionUtils {
 
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-955));
 
-        (int24 currentTick, int24 slowOracleTick, , , ) = pp.getOracleTicks();
+        (currentTick, slowOracleTick, , , ) = pp.getOracleTicks();
 
         assertTrue(Math.abs(currentTick - slowOracleTick) > 953, "small price deviation");
         assertTrue(pp.isSafeMode(), "in safe mode");
@@ -2810,7 +2812,7 @@ contract Misctest is Test, PositionUtils {
 
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-954));
 
-        (int24 currentTick, int24 slowOracleTick, , , ) = pp.getOracleTicks();
+        (currentTick, slowOracleTick, , , ) = pp.getOracleTicks();
 
         assertTrue(Math.abs(currentTick - slowOracleTick) <= 953, "small price deviation");
         assertTrue(!pp.isSafeMode(), "not in safe mode");
@@ -2871,9 +2873,6 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(0, Bob);
 
-        uint256 before0 = ct0.convertToAssets(ct0.balanceOf(Bob));
-        uint256 before1 = ct1.convertToAssets(ct1.balanceOf(Bob));
-
         // can mint covered positions
         pp.mintOptions(
             $posIdList,
@@ -2882,8 +2881,6 @@ contract Misctest is Test, PositionUtils {
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK
         );
-        uint256 after0 = ct0.convertToAssets(ct0.balanceOf(Bob));
-        uint256 after1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
         (uint128 balance, uint64 utilization0, uint64 utilization1) = pp.optionPositionBalance(
             Bob,
@@ -2917,7 +2914,7 @@ contract Misctest is Test, PositionUtils {
 
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-955));
 
-        (int24 currentTick, int24 slowOracleTick, , , ) = pp.getOracleTicks();
+        (currentTick, slowOracleTick, , , ) = pp.getOracleTicks();
 
         assertTrue(Math.abs(currentTick - slowOracleTick) > 953, "small price deviation");
         assertTrue(pp.isSafeMode(), "in safe mode");
@@ -2965,9 +2962,6 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(181_183, Bob); //
 
-        uint256 before0 = ct0.convertToAssets(ct0.balanceOf(Bob));
-        uint256 before1 = ct1.convertToAssets(ct1.balanceOf(Bob));
-
         // can mint covered positions
         pp.mintOptions(
             $posIdList,
@@ -2976,8 +2970,6 @@ contract Misctest is Test, PositionUtils {
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK
         );
-        uint256 after0 = ct0.convertToAssets(ct0.balanceOf(Bob));
-        uint256 after1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
         (uint128 balance, uint64 utilization0, uint64 utilization1) = pp.optionPositionBalance(
             Bob,
@@ -3045,7 +3037,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Swapper);
         swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-955));
 
-        (int24 currentTick, int24 slowOracleTick, , , ) = pp.getOracleTicks();
+        (currentTick, slowOracleTick, , , ) = pp.getOracleTicks();
 
         assertTrue(Math.abs(currentTick - slowOracleTick) > 953, "small price deviation");
         assertTrue(pp.isSafeMode(), "in safe mode");
@@ -3098,7 +3090,7 @@ contract Misctest is Test, PositionUtils {
         }
         swapperc.mint(uniPool, -10, 10, 10 ** 18);
 
-        (, , int24 slowOracleTick, , uint256 medianData) = pp.getOracleTicks();
+        (, , slowOracleTick, , medianData) = pp.getOracleTicks();
 
         // mint OTM position
         $posIdList.push(
@@ -3202,7 +3194,7 @@ contract Misctest is Test, PositionUtils {
         }
         swapperc.mint(uniPool, -10, 10, 10 ** 18);
 
-        (, , int24 slowOracleTick, , uint256 medianData) = pp.getOracleTicks();
+        (, , slowOracleTick, , medianData) = pp.getOracleTicks();
 
         // mint OTM position
         $posIdList.push(
@@ -3312,12 +3304,13 @@ contract Misctest is Test, PositionUtils {
             $posIdList
         );
 
-        (, int24 currentTick, , , , , ) = uniPool.slot0();
+        (, currentTick, , , , , ) = uniPool.slot0();
 
         LeftRightUnsigned tokenData0 = ct0.getAccountMarginDetails(
             Bob,
             currentTick,
             positionBalanceArray,
+            0,
             0
         );
 
@@ -3325,6 +3318,7 @@ contract Misctest is Test, PositionUtils {
             Bob,
             currentTick,
             positionBalanceArray,
+            0,
             0
         );
         (uint256 balance0, uint256 required0) = PanopticMath.convertCollateralData(
@@ -3750,7 +3744,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4037,7 +4031,7 @@ contract Misctest is Test, PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        (, int24 currentTick, , , , , ) = uniPool.slot0();
+        (, currentTick, , , , , ) = uniPool.slot0();
 
         vm.startPrank(Bob);
         ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4092,7 +4086,7 @@ contract Misctest is Test, PositionUtils {
             swapperc.burn(uniPool, -887200, 887200, 10 ** 18);
         }
 
-        int256 twapTick = PanopticMath.twapFilter(uniPool, 600);
+        twapTick = PanopticMath.twapFilter(uniPool, 600);
         {
             (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
                 pp,
@@ -4175,7 +4169,7 @@ contract Misctest is Test, PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        (, int24 currentTick, , , , , ) = uniPool.slot0();
+        (, currentTick, , , , , ) = uniPool.slot0();
 
         vm.startPrank(Bob);
         ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4230,7 +4224,7 @@ contract Misctest is Test, PositionUtils {
             swapperc.burn(uniPool, -887200, 887200, 10 ** 18);
         }
 
-        int256 twapTick = PanopticMath.twapFilter(uniPool, 600);
+        twapTick = PanopticMath.twapFilter(uniPool, 600);
         {
             (totalCollateralBalance0, totalCollateralRequired0) = ph.checkCollateral(
                 pp,
@@ -4243,7 +4237,7 @@ contract Misctest is Test, PositionUtils {
             assertTrue(totalCollateralBalance0 < totalCollateralRequired0, "Is liquidatable twap!");
         }
 
-        (uint256 liquidatorBalance0, uint256 liquidatorBalance1) = (
+        (, uint256 liquidatorBalance1) = (
             ct0.convertToAssets(ct0.balanceOf(Alice)),
             ct1.convertToAssets(ct1.balanceOf(Alice))
         );
@@ -4309,7 +4303,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4367,7 +4361,6 @@ contract Misctest is Test, PositionUtils {
             }
 
             (, currentTick, , , , , ) = uniPool.slot0();
-            int256 twapTick = PanopticMath.twapFilter(uniPool, 600);
 
             vm.startPrank(Alice);
             console2.log("");
@@ -4395,7 +4388,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4505,7 +4498,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4604,7 +4597,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4702,7 +4695,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4792,7 +4785,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4874,7 +4867,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -4985,7 +4978,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -5081,7 +5074,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -5175,7 +5168,7 @@ contract Misctest is Test, PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -5295,7 +5288,7 @@ contract Misctest is Test, PositionUtils {
 
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -5418,7 +5411,7 @@ contract Misctest is Test, PositionUtils {
 
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -5540,7 +5533,7 @@ contract Misctest is Test, PositionUtils {
 
             posIdList[0] = tokenId;
 
-            (, int24 currentTick, , , , , ) = uniPool.slot0();
+            (, currentTick, , , , , ) = uniPool.slot0();
 
             vm.startPrank(Bob);
             ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -64,28 +64,6 @@ contract PanopticPoolHarness is PanopticPool {
         return s_settledTokens[chunk];
     }
 
-    function calculateAccumulatedPremia(
-        address user,
-        bool computeAllPremia,
-        bool includePendingPremium,
-        TokenId[] calldata positionIdList
-    ) external view returns (int128 premium0, int128 premium1, uint256[2][] memory) {
-        // Get the current tick of the Uniswap pool
-        (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-
-        // Compute the accumulated premia for all tokenId in positionIdList (includes short+long premium)
-        (LeftRightSigned premia, uint256[2][] memory balances) = _calculateAccumulatedPremia(
-            user,
-            positionIdList,
-            computeAllPremia,
-            includePendingPremium,
-            currentTick
-        );
-
-        // Return the premia as (token0, token1)
-        return (premia.rightSlot(), premia.leftSlot(), balances);
-    }
-
     // return premiaByLeg
     function burnAllOptionsFrom(
         TokenId[] calldata positionIdList,
@@ -225,9 +203,6 @@ contract PanopticPoolTest is PositionUtils {
     int256 $amount0MovedBurn;
     int256 $amount1MovedBurn;
 
-    int128 $expectedPremia0;
-    int128 $expectedPremia1;
-
     int24[] tickLowers;
     int24[] tickUppers;
     uint160[] sqrtLowers;
@@ -288,7 +263,6 @@ contract PanopticPoolTest is PositionUtils {
 
     int256 $combinedBalance0;
     int256 $combinedBalance0Premium;
-    int256 $combinedBalance0NoPremium;
     int256 $bonusCombined0;
     int256 $burnDelta0Combined;
     int256 $burnDelta0;
@@ -314,7 +288,13 @@ contract PanopticPoolTest is PositionUtils {
     uint256[] settledTokens0;
 
     int256 longPremium0;
-    LeftRightSigned $premia;
+
+    LeftRightUnsigned $longPremia;
+    LeftRightUnsigned $shortPremia;
+
+    LeftRightUnsigned $longPremiaBefore;
+    LeftRightUnsigned $shortPremiaBefore;
+
     LeftRightSigned $netExchanged;
 
     /*//////////////////////////////////////////////////////////////
@@ -1691,10 +1671,22 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = pp
-                .calculateAccumulatedFeesBatch(Alice, false, posIdList);
-            assertEq(uint128(premium0), expectedPremia[0]);
-            assertEq(uint128(premium1), expectedPremia[1]);
+            uint256[2][] memory posBalanceArray;
+            ($shortPremia, $longPremia, posBalanceArray) = pp.calculateAccumulatedFeesBatch(
+                Alice,
+                false,
+                posIdList
+            );
+
+            assertEq(
+                int256(uint256($shortPremia.rightSlot())) -
+                    int256(uint256($longPremia.rightSlot())),
+                int256(expectedPremia[0])
+            );
+            assertEq(
+                int256(uint256($shortPremia.leftSlot())) - int256(uint256($longPremia.leftSlot())),
+                int256(expectedPremia[1])
+            );
             assertEq(posBalanceArray[0][0], TokenId.unwrap(tokenId));
             assertEq(LeftRightUnsigned.wrap(posBalanceArray[0][1]).rightSlot(), positionSizes[0]);
             assertEq(LeftRightUnsigned.wrap(posBalanceArray[0][1]).leftSlot(), 0);
@@ -1747,7 +1739,7 @@ contract PanopticPoolTest is PositionUtils {
         premiaSeed[0] = bound(premiaSeed[0], 2 ** 64, 2 ** 120);
         premiaSeed[1] = bound(premiaSeed[1], 2 ** 64, 2 ** 120);
 
-        (int256 premium0Before, int256 premium1Before, ) = pp.calculateAccumulatedFeesBatch(
+        ($shortPremiaBefore, $longPremiaBefore, ) = pp.calculateAccumulatedFeesBatch(
             Alice,
             true,
             posIdList
@@ -1758,26 +1750,32 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(address(sfpm));
         pool.burn(tickLower, tickUpper, 0);
 
-        (int256 premium0, int256 premium1, ) = pp.calculateAccumulatedFeesBatch(
-            Alice,
-            false,
-            posIdList
-        );
+        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(Alice, false, posIdList);
 
         // we have not settled any accrued premium yet, so the calculated amount (excluding pending premium) should be 0
-        assertEq(premium0, 0);
-        assertEq(premium1, 0);
+        assertEq(LeftRightUnsigned.unwrap($shortPremia), 0);
+        assertEq(LeftRightUnsigned.unwrap($longPremia), 0);
 
         // if we include pending premium, the amount should be the same as the accrued premium
-        (premium0, premium1, ) = pp.calculateAccumulatedFeesBatch(Alice, true, posIdList);
+        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(Alice, true, posIdList);
 
         assertApproxEqAbs(
-            uint256(premium0 - premium0Before),
+            uint256(
+                (int256(uint256($shortPremia.rightSlot())) -
+                    int256(uint256($longPremia.rightSlot()))) -
+                    (int256(uint256($shortPremiaBefore.rightSlot())) -
+                        int256(uint256($longPremiaBefore.rightSlot())))
+            ),
             premiaSeed[0],
             premiaSeed[0] / 1_000_000
         );
         assertApproxEqAbs(
-            uint256(premium1 - premium1Before),
+            uint256(
+                (int256(uint256($shortPremia.leftSlot())) -
+                    int256(uint256($longPremia.leftSlot()))) -
+                    (int256(uint256($shortPremiaBefore.leftSlot())) -
+                        int256(uint256($longPremiaBefore.leftSlot())))
+            ),
             premiaSeed[1],
             premiaSeed[1] / 1_000_000
         );
@@ -5270,11 +5268,7 @@ contract PanopticPoolTest is PositionUtils {
 
         updateIntrinsicValueBurn(longAmounts, shortAmounts);
 
-        ($expectedPremia0, $expectedPremia1, ) = pp.calculateAccumulatedFeesBatch(
-            Alice,
-            true,
-            posIdList
-        );
+        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(Alice, true, posIdList);
 
         vm.startPrank(Bob);
         (currentSqrtPriceX96, currentTick, observationIndex, observationCardinality, , , ) = pool
@@ -5387,13 +5381,21 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         {
-            $balanceDelta0 = int256(exerciseFeeAmounts[0]) - $intrinsicValue0 + $expectedPremia0;
+            $balanceDelta0 =
+                int256(exerciseFeeAmounts[0]) -
+                $intrinsicValue0 +
+                int256(uint256($shortPremia.rightSlot())) -
+                int256(uint256($longPremia.rightSlot()));
 
             $balanceDelta0 = $balanceDelta0 > 0
                 ? int256(uint256($balanceDelta0))
                 : -int256(uint256(-$balanceDelta0));
 
-            $balanceDelta1 = int256(exerciseFeeAmounts[1]) - $intrinsicValue1 + $expectedPremia1;
+            $balanceDelta1 =
+                int256(exerciseFeeAmounts[1]) -
+                $intrinsicValue1 +
+                int256(uint256($shortPremia.leftSlot())) -
+                int256(uint256($longPremia.leftSlot()));
 
             $balanceDelta1 = $balanceDelta1 > 0
                 ? int256(uint256($balanceDelta1))
@@ -6384,21 +6386,26 @@ contract PanopticPoolTest is PositionUtils {
         TWAPtick = pp.getUniV3TWAP_();
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-        ($expectedPremia0, $expectedPremia1, $positionBalanceArray) = pp
-            .calculateAccumulatedFeesBatch(Alice, false, $posIdLists[1]);
+        ($shortPremia, $longPremia, $positionBalanceArray) = pp.calculateAccumulatedFeesBatch(
+            Alice,
+            false,
+            $posIdLists[1]
+        );
 
         $tokenData0 = ct0.getAccountMarginDetails(
             Alice,
             TWAPtick,
             $positionBalanceArray,
-            $expectedPremia0
+            $shortPremia.rightSlot(),
+            $longPremia.rightSlot()
         );
 
         $tokenData1 = ct1.getAccountMarginDetails(
             Alice,
             TWAPtick,
             $positionBalanceArray,
-            $expectedPremia1
+            $shortPremia.leftSlot(),
+            $longPremia.leftSlot()
         );
 
         // initialize collateral share deltas - we measure the flow of value out of Alice account to find the bonus
@@ -6520,14 +6527,11 @@ contract PanopticPoolTest is PositionUtils {
                 TickMath.getSqrtRatioAtTick(TWAPtick)
             );
 
-        {
-            (int128 premium0, int128 premium1, ) = pp.calculateAccumulatedFeesBatch(
-                Alice,
-                false,
-                $posIdLists[1]
-            );
-            $premia = LeftRightSigned.wrap(0).toRightSlot(premium0).toLeftSlot(premium1);
-        }
+        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(
+            Alice,
+            false,
+            $posIdLists[1]
+        );
 
         ($bonus0, $bonus1, ) = PanopticMath.getLiquidationBonus(
             $tokenData0,
@@ -6535,7 +6539,7 @@ contract PanopticPoolTest is PositionUtils {
             Math.getSqrtRatioAtTick(TWAPtick),
             Math.getSqrtRatioAtTick(TWAPtick),
             $netExchanged,
-            $premia
+            $shortPremia
         );
 
         $delegated0 = uint256(
@@ -6609,14 +6613,6 @@ contract PanopticPoolTest is PositionUtils {
             "liquidator lost money"
         );
 
-        // get total balance for Alice before liquidation
-        $combinedBalance0NoPremium = int256(
-            (int256(uint256($tokenData0.rightSlot())) - Math.max($premia.rightSlot(), 0)) +
-                PanopticMath.convert1to0(
-                    int256(uint256($tokenData1.rightSlot())) - Math.max($premia.leftSlot(), 0),
-                    TickMath.getSqrtRatioAtTick(TWAPtick)
-                )
-        );
         $combinedBalance0Premium = int256(
             ($tokenData0.rightSlot()) +
                 PanopticMath.convert1to0(
@@ -6754,12 +6750,12 @@ contract PanopticPoolTest is PositionUtils {
 
         $balance0CombinedPostBurn =
             int256(uint256($tokenData0.rightSlot())) -
-            Math.max($premia.rightSlot(), 0) +
+            int256(uint256($shortPremia.rightSlot())) +
             $burnDelta0 +
             int256(
                 PanopticMath.convert1to0(
                     int256(uint256($tokenData1.rightSlot())) -
-                        Math.max($premia.leftSlot(), 0) +
+                        int256(uint256($shortPremia.leftSlot())) +
                         $burnDelta1,
                     TickMath.getSqrtRatioAtTick(TWAPtick)
                 )
@@ -6958,21 +6954,26 @@ contract PanopticPoolTest is PositionUtils {
         TWAPtick = pp.getUniV3TWAP_();
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-        ($expectedPremia0, $expectedPremia1, $positionBalanceArray) = pp
-            .calculateAccumulatedFeesBatch(Alice, false, $posIdLists[1]);
+        ($shortPremia, $longPremia, $positionBalanceArray) = pp.calculateAccumulatedFeesBatch(
+            Alice,
+            false,
+            $posIdLists[1]
+        );
 
         $tokenData0 = ct0.getAccountMarginDetails(
             Alice,
             TWAPtick,
             $positionBalanceArray,
-            $expectedPremia0
+            $shortPremia.rightSlot(),
+            $longPremia.rightSlot()
         );
 
         $tokenData1 = ct1.getAccountMarginDetails(
             Alice,
             TWAPtick,
             $positionBalanceArray,
-            $expectedPremia1
+            $shortPremia.leftSlot(),
+            $longPremia.leftSlot()
         );
 
         // initialize collateral share deltas - we measure the flow of value out of Alice account to find the bonus
@@ -7094,14 +7095,11 @@ contract PanopticPoolTest is PositionUtils {
                 TickMath.getSqrtRatioAtTick(TWAPtick)
             );
 
-        {
-            (int128 premium0, int128 premium1, ) = pp.calculateAccumulatedFeesBatch(
-                Alice,
-                false,
-                $posIdLists[1]
-            );
-            $premia = LeftRightSigned.wrap(0).toRightSlot(premium0).toLeftSlot(premium1);
-        }
+        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(
+            Alice,
+            false,
+            $posIdLists[1]
+        );
 
         ($bonus0, $bonus1, ) = PanopticMath.getLiquidationBonus(
             $tokenData0,
@@ -7109,7 +7107,7 @@ contract PanopticPoolTest is PositionUtils {
             Math.getSqrtRatioAtTick(TWAPtick),
             Math.getSqrtRatioAtTick(TWAPtick),
             $netExchanged,
-            $premia
+            $shortPremia
         );
 
         $delegated0 = uint256(
@@ -7183,14 +7181,6 @@ contract PanopticPoolTest is PositionUtils {
             "liquidator lost money"
         );
 
-        // get total balance for Alice before liquidation
-        $combinedBalance0NoPremium = int256(
-            (int256(uint256($tokenData0.rightSlot())) - Math.max($premia.rightSlot(), 0)) +
-                PanopticMath.convert1to0(
-                    int256(uint256($tokenData1.rightSlot())) - Math.max($premia.leftSlot(), 0),
-                    TickMath.getSqrtRatioAtTick(TWAPtick)
-                )
-        );
         $combinedBalance0Premium = int256(
             ($tokenData0.rightSlot()) +
                 PanopticMath.convert1to0(
@@ -7329,12 +7319,12 @@ contract PanopticPoolTest is PositionUtils {
 
         $balance0CombinedPostBurn =
             int256(uint256($tokenData0.rightSlot())) -
-            Math.max($premia.rightSlot(), 0) +
+            int256(uint256($shortPremia.rightSlot())) +
             $burnDelta0 +
             int256(
                 PanopticMath.convert1to0(
                     int256(uint256($tokenData1.rightSlot())) -
-                        Math.max($premia.leftSlot(), 0) +
+                        int256(uint256($shortPremia.leftSlot())) +
                         $burnDelta1,
                     TickMath.getSqrtRatioAtTick(TWAPtick)
                 )

--- a/test/foundry/periphery/PanopticHelper.t.sol
+++ b/test/foundry/periphery/PanopticHelper.t.sol
@@ -1091,11 +1091,26 @@ contract PanopticHelperTest is PositionUtils {
                 Constants.MIN_V3POOL_TICK
             );
 
-            (int128 premium0, int128 premium1, uint256[2][] memory posBalanceArray) = pp
-                .calculateAccumulatedFeesBatch(Alice, false, posIdList);
+            (
+                LeftRightUnsigned shortPremium,
+                LeftRightUnsigned longPremium,
+                uint256[2][] memory posBalanceArray
+            ) = pp.calculateAccumulatedFeesBatch(Alice, false, posIdList);
 
-            tokenData0 = ct0.getAccountMarginDetails(Alice, atTick, posBalanceArray, premium0);
-            tokenData1 = ct1.getAccountMarginDetails(Alice, atTick, posBalanceArray, premium1);
+            tokenData0 = ct0.getAccountMarginDetails(
+                Alice,
+                atTick,
+                posBalanceArray,
+                shortPremium.rightSlot(),
+                longPremium.rightSlot()
+            );
+            tokenData1 = ct1.getAccountMarginDetails(
+                Alice,
+                atTick,
+                posBalanceArray,
+                shortPremium.leftSlot(),
+                longPremium.leftSlot()
+            );
 
             (calculatedCollateralBalance, calculatedRequiredCollateral) = PanopticMath
                 .convertCollateralData(tokenData0, tokenData1, returnTokenType ? 1 : 0, atTick);


### PR DESCRIPTION
`
If an account’s premium is net positive, it is included in their balance, and if net negative, their collateral requirement. This means that in situations where a buffer is applied to the collateral requirement (minting, withdrawing, etc), long premium netted against short premium will have a lower effective collateral requirement (given that the short premium reduces the collateral requirement which is subject to that multiplier) than if the short premium was collected and added to their balance.
`

Fix: return separate net long and short premium values from `_calculateAccumulatedPremia`, adding long premium to the collateral requirement and short premium to balance. This means that `BP_DECREASE_BUFFER` will now be applied to *all* long premium regardless of how much can be netted against a users's (prorated) short premium.