### PR TITLE
Store ticks in `s_positionBalance`

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1187,9 +1187,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             uint128 positionSize = PositionBalance.wrap(positionBalanceArray[i][1]).positionSize();
 
             // read the pool utilization at mint
-            uint32 poolUtilization = PositionBalance
-                .wrap(positionBalanceArray[i][1])
-                .utilizations();
+            int16 poolUtilization = s_underlyingIsToken0
+                ? int16(PositionBalance.wrap(positionBalanceArray[i][1]).utilization0())
+                : int16(PositionBalance.wrap(positionBalanceArray[i][1]).utilization1());
 
             // Get tokens required for the current tokenId (a single active position)
             uint256 _tokenRequired = _getRequiredCollateralAtTickSinglePosition(
@@ -1220,7 +1220,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         TokenId tokenId,
         uint128 positionSize,
         int24 atTick,
-        uint32 poolUtilization
+        int16 poolUtilization
     ) internal view returns (uint256 tokenRequired) {
         bool underlyingIsToken0 = s_underlyingIsToken0;
         uint256 numLegs = tokenId.countLegs();
@@ -1253,7 +1253,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint32 poolUtilization
+        int16 poolUtilization
     ) internal view returns (uint256 required) {
         return
             tokenId.riskPartner(index) == index // does this leg have a risk partner? Affects required collateral
@@ -1285,7 +1285,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint32 poolUtilization
+        int16 poolUtilization
     ) internal view returns (uint256 required) {
         // extract the tokenType (token0 or token1)
         uint256 tokenType = tokenId.tokenType(index);
@@ -1296,15 +1296,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // amount moved is right slot if tokenType=0, left slot otherwise
         uint128 amountMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
-        // match tokenType with the correct pool utilization
-        int16 utilization = tokenType == 0
-            ? int16(uint16(poolUtilization))
-            : int16(uint16(poolUtilization >> 16));
-
         uint256 isLong = tokenId.isLong(index);
 
         // start with base requirement, which is based on isLong value
-        required = _getRequiredCollateralAtUtilization(amountMoved, isLong, utilization);
+        required = _getRequiredCollateralAtUtilization(amountMoved, isLong, poolUtilization);
 
         // if the position is long, required tokens does not depend on price
         unchecked {
@@ -1412,7 +1407,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint32 poolUtilization
+        int16 poolUtilization
     ) internal view returns (uint256 required) {
         // extract partner index (associated with another liquidity chunk)
         uint256 partnerIndex = tokenId.riskPartner(index);
@@ -1483,7 +1478,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint128 positionSize,
         uint256 index,
         uint256 partnerIndex,
-        uint32 poolUtilization
+        int16 poolUtilization
     ) internal view returns (uint256 spreadRequirement) {
         // compute the total amount of funds moved for the position's current leg
         LeftRightUnsigned amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, index);
@@ -1552,9 +1547,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             _getRequiredCollateralAtUtilization(
                 tokenType == 0 ? movedRight : movedLeft,
                 1,
-                tokenType == 0
-                    ? int16(uint16(poolUtilization))
-                    : int16(uint16(poolUtilization >> 16))
+                poolUtilization
             )
         );
     }
@@ -1573,7 +1566,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint32 poolUtilization
+        int16 poolUtilization
     ) internal view returns (uint256 strangleRequired) {
         // If both tokenTypes are the same, then this is a long or short strangle.
         // A strangle is an options strategy in which the investor holds a position
@@ -1599,14 +1592,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // A negative pool utilization is used to denote a position which is a strangle
             // at low pool utilization's strangle legs are evaluated at 2x capital efficiency
 
-            uint16 poolUtilization0 = uint16(poolUtilization);
-            uint16 poolUtilization1 = uint16(poolUtilization >> 16);
-
             // add 1 to handle poolUtilization = 0
-
-            poolUtilization =
-                uint32(uint16(-int16(poolUtilization0 == 0 ? 1 : poolUtilization0))) +
-                (uint32(uint16(-int16(poolUtilization1 == 0 ? 1 : poolUtilization1))) << 16);
+            poolUtilization = -(poolUtilization == 0 ? int16(1) : poolUtilization);
 
             return
                 strangleRequired = _getRequiredCollateralSingleLegNoPartner(

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -16,6 +16,7 @@ import {SafeTransferLib} from "@libraries/SafeTransferLib.sol";
 // Custom types
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
+import {PositionBalance} from "@types/PositionBalance.sol";
 import {TokenId} from "@types/TokenId.sol";
 
 /// @title Collateral Tracking System / Margin Accounting used in conjunction with a Panoptic Pool.
@@ -815,7 +816,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param utilization The fraction of totalBalance() that belongs to the Uniswap Pool
     /// @return buyCollateralRatio The buy collateral ratio at `utilization`
     function _buyCollateralRatio(
-        uint256 utilization
+        uint16 utilization
     ) internal view returns (uint256 buyCollateralRatio) {
         // linear from BUY to BUY/2 between 50% and 90%
         // the buy ratio is on a straight line defined between two points (x0,y0) and (x1,y1):
@@ -1012,7 +1013,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount
-    ) external onlyPanopticPool returns (int256 utilization) {
+    ) external onlyPanopticPool returns (int16 utilization) {
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
@@ -1043,7 +1044,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_poolAssets = uint256(updatedAssets).toUint128();
             s_inAMM = uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)).toUint128();
 
-            utilization = _poolUtilization();
+            utilization = int16(_poolUtilization());
         }
     }
 
@@ -1183,10 +1184,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             TokenId tokenId = TokenId.wrap(positionBalanceArray[i][0]);
 
             // read the position size and the pool utilization at mint
-            uint128 positionSize = LeftRightUnsigned.wrap(positionBalanceArray[i][1]).rightSlot();
+            uint128 positionSize = PositionBalance.wrap(positionBalanceArray[i][1]).positionSize();
 
             // read the pool utilization at mint
-            uint128 poolUtilization = LeftRightUnsigned.wrap(positionBalanceArray[i][1]).leftSlot();
+            uint32 poolUtilization = PositionBalance
+                .wrap(positionBalanceArray[i][1])
+                .utilizations();
 
             // Get tokens required for the current tokenId (a single active position)
             uint256 _tokenRequired = _getRequiredCollateralAtTickSinglePosition(
@@ -1217,7 +1220,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         TokenId tokenId,
         uint128 positionSize,
         int24 atTick,
-        uint128 poolUtilization
+        uint32 poolUtilization
     ) internal view returns (uint256 tokenRequired) {
         bool underlyingIsToken0 = s_underlyingIsToken0;
         uint256 numLegs = tokenId.countLegs();
@@ -1250,7 +1253,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint128 poolUtilization
+        uint32 poolUtilization
     ) internal view returns (uint256 required) {
         return
             tokenId.riskPartner(index) == index // does this leg have a risk partner? Affects required collateral
@@ -1282,7 +1285,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint128 poolUtilization
+        uint32 poolUtilization
     ) internal view returns (uint256 required) {
         // extract the tokenType (token0 or token1)
         uint256 tokenType = tokenId.tokenType(index);
@@ -1294,9 +1297,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint128 amountMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
         // match tokenType with the correct pool utilization
-        int64 utilization = tokenType == 0
-            ? int64(uint64(poolUtilization))
-            : int64(uint64(poolUtilization >> 64));
+        int16 utilization = tokenType == 0
+            ? int16(uint16(poolUtilization))
+            : int16(uint16(poolUtilization >> 16));
 
         uint256 isLong = tokenId.isLong(index);
 
@@ -1409,7 +1412,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint128 poolUtilization
+        uint32 poolUtilization
     ) internal view returns (uint256 required) {
         // extract partner index (associated with another liquidity chunk)
         uint256 partnerIndex = tokenId.riskPartner(index);
@@ -1441,7 +1444,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function _getRequiredCollateralAtUtilization(
         uint128 amount,
         uint256 isLong,
-        int256 utilization
+        int16 utilization
     ) internal view returns (uint256 required) {
         // if position is short, use sell collateral ratio
         if (isLong == 0) {
@@ -1456,7 +1459,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         } else if (isLong == 1) {
             // if options is long, use buy collateral ratio
             // compute the buy collateral ratio, which depends on the pool utilization
-            uint256 buyCollateral = _buyCollateralRatio(uint256(utilization));
+            uint256 buyCollateral = _buyCollateralRatio(uint16(utilization));
 
             // compute required as amount*collateralRatio
             // can use unsafe because denominator is always nonzero
@@ -1480,7 +1483,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint128 positionSize,
         uint256 index,
         uint256 partnerIndex,
-        uint128 poolUtilization
+        uint32 poolUtilization
     ) internal view returns (uint256 spreadRequirement) {
         // compute the total amount of funds moved for the position's current leg
         LeftRightUnsigned amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, index);
@@ -1550,8 +1553,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 tokenType == 0 ? movedRight : movedLeft,
                 1,
                 tokenType == 0
-                    ? int64(uint64(poolUtilization))
-                    : int64(uint64(poolUtilization >> 64))
+                    ? int16(uint16(poolUtilization))
+                    : int16(uint16(poolUtilization >> 16))
             )
         );
     }
@@ -1570,7 +1573,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 index,
         uint128 positionSize,
         int24 atTick,
-        uint128 poolUtilization
+        uint32 poolUtilization
     ) internal view returns (uint256 strangleRequired) {
         // If both tokenTypes are the same, then this is a long or short strangle.
         // A strangle is an options strategy in which the investor holds a position
@@ -1596,14 +1599,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // A negative pool utilization is used to denote a position which is a strangle
             // at low pool utilization's strangle legs are evaluated at 2x capital efficiency
 
-            uint64 poolUtilization0 = uint64(poolUtilization);
-            uint64 poolUtilization1 = uint64(poolUtilization >> 64);
+            uint16 poolUtilization0 = uint16(poolUtilization);
+            uint16 poolUtilization1 = uint16(poolUtilization >> 16);
 
             // add 1 to handle poolUtilization = 0
 
             poolUtilization =
-                uint128(uint64(-int64(poolUtilization0 == 0 ? 1 : poolUtilization0))) +
-                (uint128(uint64(-int64(poolUtilization1 == 0 ? 1 : poolUtilization1))) << 64);
+                uint32(uint16(-int16(poolUtilization0 == 0 ? 1 : poolUtilization0))) +
+                (uint32(uint16(-int16(poolUtilization1 == 0 ? 1 : poolUtilization1))) << 16);
 
             return
                 strangleRequired = _getRequiredCollateralSingleLegNoPartner(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -581,6 +581,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
             tickLimitHigh
         );
 
+        // update the users options balance of position 'tokenId'
+        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
+        // NOTE: cannot add the tickData yet because it is computed in _validateSolvency
+        s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
+            positionSize,
+            poolUtilizations,
+            uint96(0)
+        );
+
+
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         (uint256 medianData, uint96 tickData) = _validateSolvency(
@@ -592,13 +602,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
 
-        // update the users options balance of position 'tokenId'
-        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
+        // update the users options balance of position 'tokenId', adding the tickData
         s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
             tickData
         );
+
 
         emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations);
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -505,7 +505,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     ) external {
         _burnOptions(COMMIT_LONG_SETTLED, tokenId, msg.sender, tickLimitLow, tickLimitHigh);
 
-        (uint256 medianData, ) = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
+        uint256 medianData = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
@@ -530,7 +530,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             positionIdList
         );
 
-        (uint256 medianData, ) = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
+        uint256 medianData = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
@@ -776,7 +776,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         address user,
         TokenId[] calldata positionIdList,
         uint256 buffer
-    ) internal view returns (uint256 medianData, uint96 tickData) {
+    ) internal view returns (uint256 medianData) {
         (
             int24 currentTick,
             int24 fastOracleTick,
@@ -785,7 +785,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             uint256 _medianData
         ) = PanopticMath.getOracleTicks(s_univ3pool, s_miniMedian);
 
-        tickData = PositionBalanceLibrary.packTickData(
+        uint96 tickData = PositionBalanceLibrary.packTickData(
             currentTick,
             fastOracleTick,
             slowOracleTick,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -581,32 +581,41 @@ contract PanopticPool is ERC1155Holder, Multicall {
             tickLimitHigh
         );
 
+        uint256 medianData;
+        uint96 tickData;
+        {
+            (
+                int24 currentTick,
+                int24 fastOracleTick,
+                int24 slowOracleTick,
+                int24 lastObservedTick,
+                uint256 _medianData
+            ) = PanopticMath.getOracleTicks(s_univ3pool, s_miniMedian);
+
+            tickData = PositionBalanceLibrary.packTickData(
+                currentTick,
+                fastOracleTick,
+                slowOracleTick,
+                lastObservedTick
+            );
+
+            medianData = _medianData;
+            // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
+            if (medianData != 0) s_miniMedian = medianData;
+        }
+
         // update the users options balance of position 'tokenId'
         // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
         // NOTE: cannot add the tickData yet because it is computed in _validateSolvency
         s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
-            uint96(0)
+            uint96(tickData)
         );
 
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
-        (uint256 medianData, uint96 tickData) = _validateSolvency(
-            msg.sender,
-            positionIdList,
-            BP_DECREASE_BUFFER
-        );
-
-        // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
-        if (medianData != 0) s_miniMedian = medianData;
-
-        // update the users options balance of position 'tokenId', adding the tickData
-        s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
-            positionSize,
-            poolUtilizations,
-            tickData
-        );
+        _checkSolvency(msg.sender, positionIdList, tickData, BP_DECREASE_BUFFER);
 
         emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations);
     }
@@ -768,9 +777,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
         TokenId[] calldata positionIdList,
         uint256 buffer
     ) internal view returns (uint256 medianData, uint96 tickData) {
-        // check that the provided positionIdList matches the positions in memory
-        _validatePositionList(user, positionIdList, 0);
-
         (
             int24 currentTick,
             int24 fastOracleTick,
@@ -787,6 +793,30 @@ contract PanopticPool is ERC1155Holder, Multicall {
         );
 
         medianData = _medianData;
+
+        _checkSolvency(user, positionIdList, tickData, buffer);
+    }
+
+    /// @notice Validates the solvency of `user` from tickData.
+    /// @param user The account to validate
+    /// @param positionIdList The list of positions to validate solvency for
+    /// @param tickData the packed tick data to check solvency at
+    /// @param buffer The buffer to apply to the collateral requirement for `user`
+    function _checkSolvency(
+        address user,
+        TokenId[] calldata positionIdList,
+        uint96 tickData,
+        uint256 buffer
+    ) internal view {
+        // check that the provided positionIdList matches the positions in memory
+        _validatePositionList(user, positionIdList, 0);
+
+        (
+            int24 currentTick,
+            int24 fastOracleTick,
+            int24 slowOracleTick,
+            int24 lastObservedTick
+        ) = PositionBalanceLibrary.unpackTickData(tickData);
 
         int24[] memory atTicks;
         // Fall back to a conservative approach if there's high deviation between internal ticks:

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -17,6 +17,7 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 // Custom types
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
+import {PositionBalance, PositionBalanceLibrary} from "@types/PositionBalance.sol";
 import {TokenId} from "@types/TokenId.sol";
 
 /// @title The Panoptic Pool: Create permissionless options on a CLAMM.
@@ -219,7 +220,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //        token0          token1
     //  |<-- 64 bits -->|<-- 64 bits -->|<---------- 128 bits ---------->|
     //  |<-------------------------- 256 bits -------------------------->|
-    mapping(address account => mapping(TokenId tokenId => LeftRightUnsigned balanceAndUtilizations))
+    mapping(address account => mapping(TokenId tokenId => PositionBalance positionBalance))
         internal s_positionBalance;
 
     //    numPositions (32 positions max)    user positions hash
@@ -380,7 +381,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             TokenId tokenId = positionIdList[k];
 
             balances[k][0] = TokenId.unwrap(tokenId);
-            balances[k][1] = LeftRightUnsigned.unwrap(s_positionBalance[c_user][tokenId]);
+            balances[k][1] = PositionBalance.unwrap(s_positionBalance[c_user][tokenId]);
 
             (
                 LeftRightSigned[4] memory premiaByLeg,
@@ -568,11 +569,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // disallow user to mint exact same position
         // in order to do it, user should burn it first and then mint
-        if (LeftRightUnsigned.unwrap(s_positionBalance[msg.sender][tokenId]) != 0)
+        if (PositionBalance.unwrap(s_positionBalance[msg.sender][tokenId]) != 0)
             revert Errors.PositionAlreadyMinted();
 
         // Mint in the SFPM and update state of collateral
-        uint128 poolUtilizations = _mintInSFPMAndUpdateCollateral(
+        uint32 poolUtilizations = _mintInSFPMAndUpdateCollateral(
             tokenId,
             positionSize,
             effectiveLiquidityLimitX32,
@@ -580,19 +581,20 @@ contract PanopticPool is ERC1155Holder, Multicall {
             tickLimitHigh
         );
 
-        // update the users options balance of position 'tokenId'
-        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
-        s_positionBalance[msg.sender][tokenId] = LeftRightUnsigned
-            .wrap(0)
-            .toLeftSlot(poolUtilizations)
-            .toRightSlot(positionSize);
-
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         uint256 medianData = _validateSolvency(msg.sender, positionIdList, BP_DECREASE_BUFFER);
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
+
+        // update the users options balance of position 'tokenId'
+        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
+        s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
+            positionSize,
+            poolUtilizations,
+            uint96(0)
+        );
 
         emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations);
     }
@@ -611,7 +613,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         uint64 effectiveLiquidityLimitX32,
         int24 tickLimitLow,
         int24 tickLimitHigh
-    ) internal returns (uint128) {
+    ) internal returns (uint32) {
         bool safeMode = isSafeMode();
 
         // if safeMode, enforce covered deployment
@@ -631,10 +633,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
             effectiveLiquidityLimitX32
         );
 
-        uint128 poolUtilizations = _payCommissionAndWriteData(tokenId, positionSize, totalSwapped);
+        uint32 poolUtilizations = _payCommissionAndWriteData(tokenId, positionSize, totalSwapped);
 
         if (safeMode) {
-            return uint128(10_000) + uint128(10_000 << 64);
+            return uint32(10_000) + uint32(10_000 << 16);
         } else {
             return poolUtilizations;
         }
@@ -651,18 +653,18 @@ contract PanopticPool is ERC1155Holder, Multicall {
         TokenId tokenId,
         uint128 positionSize,
         LeftRightSigned totalSwapped
-    ) internal returns (uint128) {
+    ) internal returns (uint32) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        int256 utilization0 = s_collateralToken0.takeCommissionAddData(
+        int16 utilization0 = s_collateralToken0.takeCommissionAddData(
             msg.sender,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
             totalSwapped.rightSlot()
         );
-        int256 utilization1 = s_collateralToken1.takeCommissionAddData(
+        int16 utilization1 = s_collateralToken1.takeCommissionAddData(
             msg.sender,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
@@ -671,7 +673,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // return pool utilizations as a uint128 (pool Utilization is always < 10000)
         unchecked {
-            return uint128(uint256(utilization0) + uint128(uint256(utilization1) << 64));
+            return uint32(uint16(utilization0) + uint32(uint16(utilization1) << 64));
         }
     }
 
@@ -726,7 +728,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
-        uint128 positionSize = s_positionBalance[owner][tokenId].rightSlot();
+        uint128 positionSize = s_positionBalance[owner][tokenId].positionSize();
 
         LeftRightSigned premiaOwed;
         // burn position and do exercise checks
@@ -1050,7 +1052,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
         _validatePositionList(msg.sender, positionIdListExercisor, 0);
 
-        uint128 positionBalance = s_positionBalance[account][touchedId[0]].rightSlot();
+        uint128 positionBalance = s_positionBalance[account][touchedId[0]].positionSize();
 
         int24 twapTick = getUniV3TWAP();
 
@@ -1524,7 +1526,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
             tokenId,
             legIndex,
-            s_positionBalance[owner][tokenId].rightSlot()
+            s_positionBalance[owner][tokenId].positionSize()
         );
 
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
@@ -1944,7 +1946,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
 
         // reset balances and delete stored option data
-        s_positionBalance[owner][tokenId] = LeftRightUnsigned.wrap(0);
+        s_positionBalance[owner][tokenId] = PositionBalance.wrap(0);
 
         // REMOVE the current tikenId from the position list hash (hash = XOR of all keccak256(tokenId), remove by XOR'ing again)
         // and decrease the number of positions counter by 1.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -505,7 +505,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     ) external {
         _burnOptions(COMMIT_LONG_SETTLED, tokenId, msg.sender, tickLimitLow, tickLimitHigh);
 
-        uint256 medianData = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
+        (uint256 medianData, ) = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
@@ -530,7 +530,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             positionIdList
         );
 
-        uint256 medianData = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
+        (uint256 medianData, ) = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
@@ -583,7 +583,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
-        uint256 medianData = _validateSolvency(msg.sender, positionIdList, BP_DECREASE_BUFFER);
+        (uint256 medianData, uint96 tickData) = _validateSolvency(
+            msg.sender,
+            positionIdList,
+            BP_DECREASE_BUFFER
+        );
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
@@ -593,7 +597,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
-            uint96(0)
+            tickData
         );
 
         emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations);
@@ -755,7 +759,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         address user,
         TokenId[] calldata positionIdList,
         uint256 buffer
-    ) internal view returns (uint256 medianData) {
+    ) internal view returns (uint256 medianData, uint96 tickData) {
         // check that the provided positionIdList matches the positions in memory
         _validatePositionList(user, positionIdList, 0);
 
@@ -766,6 +770,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
             int24 lastObservedTick,
             uint256 _medianData
         ) = PanopticMath.getOracleTicks(s_univ3pool, s_miniMedian);
+
+        tickData = PositionBalanceLibrary.packTickData(
+            currentTick,
+            fastOracleTick,
+            slowOracleTick,
+            lastObservedTick
+        );
 
         medianData = _medianData;
 
@@ -1384,6 +1395,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /// @notice Get the `tokenId` position data for `user`
+    /// @param user The account to query
+    /// @param tokenId The tokenId for that account
+    /// @return currentTickAtMint currentTick at mint
+    /// @return fastOracleTickAtMint fast oracle tick at mint
+    /// @return slowOracleTickAtMint slow oracle tick at mint
+    /// @return lastObservedTickAtMint last observed tick at mint
+    /// @return utilization0AtMint utilization of token0 at mint
+    /// @return utilization1AtMint utilization of token1 at mint
+    /// @return positionSize size of the position
     function positionData(
         address user,
         TokenId tokenId

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -776,13 +776,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
         address user,
         TokenId[] calldata positionIdList,
         uint256 buffer
-    ) internal view returns (uint256 medianData) {
+    ) internal view returns (uint256) {
         (
             int24 currentTick,
             int24 fastOracleTick,
             int24 slowOracleTick,
             int24 lastObservedTick,
-            uint256 _medianData
+            uint256 medianData
         ) = PanopticMath.getOracleTicks(s_univ3pool, s_miniMedian);
 
         uint96 tickData = PositionBalanceLibrary.packTickData(
@@ -792,9 +792,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
             lastObservedTick
         );
 
-        medianData = _medianData;
-
         _checkSolvency(user, positionIdList, tickData, buffer);
+
+        return medianData;
     }
 
     /// @notice Validates the solvency of `user` from tickData.
@@ -1425,14 +1425,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
         medianData = s_miniMedian;
     }
 
-    /// @notice Get the current number of open positions for an account
+    /// @notice Get the current number of open positions for an account.
     /// @param user The account to query
     /// @return _numberOfPositions Number of open positions for `user`
     function numberOfPositions(address user) external view returns (uint256 _numberOfPositions) {
         _numberOfPositions = (s_positionsHash[user] >> 248);
     }
 
-    /// @notice Get the `tokenId` position data for `user`
+    /// @notice Get the `tokenId` position data for `user`.
     /// @param user The account to query
     /// @param tokenId The tokenId for that account
     /// @return currentTickAtMint currentTick at mint

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -590,7 +590,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
             uint96(0)
         );
 
-
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         (uint256 medianData, uint96 tickData) = _validateSolvency(
@@ -608,7 +607,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
             poolUtilizations,
             tickData
         );
-
 
         emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations);
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1383,6 +1383,38 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _numberOfPositions = (s_positionsHash[user] >> 248);
     }
 
+    /// @notice Get the `tokenId` position data for `user`
+    function positionData(
+        address user,
+        TokenId tokenId
+    )
+        external
+        view
+        returns (
+            int24 currentTickAtMint,
+            int24 fastOracleTickAtMint,
+            int24 slowOracleTickAtMint,
+            int24 lastObservedTickAtMint,
+            int256 utilization0AtMint,
+            int256 utilization1AtMint,
+            uint128 positionSize
+        )
+    {
+        PositionBalance positionBalance = s_positionBalance[user][tokenId];
+
+        (
+            currentTickAtMint,
+            fastOracleTickAtMint,
+            slowOracleTickAtMint,
+            lastObservedTickAtMint
+        ) = positionBalance.unpackTickData();
+
+        utilization0AtMint = positionBalance.utilization0();
+        utilization1AtMint = positionBalance.utilization1();
+
+        positionSize = positionBalance.positionSize();
+    }
+
     /// @notice Get the oracle price used to check solvency in liquidations.
     /// @return twapTick The current oracle price used to check solvency in liquidations
     function getUniV3TWAP() internal view returns (int24 twapTick) {

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -1,63 +1,35 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.24;
-
-// Custom types
-import {TokenId} from "@types/TokenId.sol";
-
+import "forge-std/Test.sol";
 type PositionBalance is uint256;
 using PositionBalanceLibrary for PositionBalance global;
 
-/// @title A Panoptic Liquidity Chunk. Tracks Tick Range and Liquidity Information for a "chunk." Used to track movement of chunks.
+/// @title A Panoptic Position Balance. Tracks the Position Size, the Pool Utilizations at mint, and the current/fastOracle/slowOracle/latestObserved ticks at mint.
 /// @author Axicon Labs Limited
 ///
-/// @notice A liquidity chunk is an amount of `liquidity` (an amount of WETH, e.g.) deployed between two ticks: `tickLower` and `tickUpper`
-/// into a concentrated liquidity AMM.
 //
-//                liquidity
-//                    ▲      liquidity chunk
-//                    │        │
-//                    │    ┌───▼────┐   ▲
-//                    │    │        │   │ liquidity/size
-//      Other AMM     │  ┌─┴────────┴─┐ ▼ of chunk
-//      liquidity  ───┼──┼─►          │
-//                    │  │            │
-//                    └──┴─▲────────▲─┴──► price ticks
-//                         │        │
-//                         │        │
-//                    tickLower     │
-//                              tickUpper
-//
-/// @notice Track Tick Range Information. Lower and Upper ticks including the liquidity deployed within that range.
-/// @notice This is used to track information about a leg in the Option Position identified by `TokenId.sol`.
-/// @notice We pack this tick range info into a uint256.
-//
-// PACKING RULES FOR A LIQUIDITYCHUNK:
+// PACKING RULES FOR A POSITIONBALANCE:
 // =================================================================================================
 //  From the LSB to the MSB:
-// (1) Liquidity        128bits  : The liquidity within the chunk (uint128).
-// ( ) (Zero-bits)       80bits  : Zero-bits to match a total uint256.
-// (2) tick Upper        24bits  : The upper tick of the chunk (int24).
-// (3) tick Lower        24bits  : The lower tick of the chunk (int24).
-// Total                256bits  : Total bits used by a chunk.
+// (1) positionSize     128bits : the size of that position  (uint128).
+// (2) poolUtilization0 16bits  : the pool utilization of token0, stored as (10000 * inAMM0)/totalAssets0 (uint16)
+// (3) poolUtilization1 16bits  : the pool utilization of token1, stored as (10000 * inAMM1)/totalAssets1 (uint16)
+// (4) currentTick      24bits  : The currentTick at mint (int24).
+// (5) fastOracleTick   24bits  : The fastOracleTick at mint (int24).
+// (6) slowOracleTick   24bits  : The slowOracleTick at mint (int24).
+// (7) lastObservedTick 24bits  : The lastObservedTick at mint (int24).
+// Total                256bits : Total bits used by a PositionBalance.
 // ===============================================================================================
 //
 // The bit pattern is therefore:
 //
-//           (3)             (2)             ( )                (1)
-//    <-- 24 bits -->  <-- 24 bits -->  <-- 80 bits -->   <-- 128 bits -->
-//        tickLower       tickUpper         Zeros             Liquidity
+//           (7)             (6)             (5)                (4)             (3)            (2)                 (1)
+//    <-- 24 bits -->  <-- 24 bits -->  <-- 24 bits -->   <-- 24 bits --> <-- 16 bits -->  <-- 16 bits -->   <-- 128 bits -->
+//   lastObservedTick   slowOracleTick   fastOracleTick     currentTick   utilization0      utilization1      positionSize
 //
 //        <--- most significant bit        least significant bit --->
 //
 library PositionBalanceLibrary {
-    /// @notice AND mask to strip the `tickLower` value from a packed LiquidityChunk.
-    uint256 internal constant CLEAR_TL_MASK =
-        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-
-    /// @notice AND mask to strip the `tickUpper` value from a packed LiquidityChunk.
-    uint256 internal constant CLEAR_TU_MASK =
-        0xFFFFFF000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
-
     /*//////////////////////////////////////////////////////////////
                                 ENCODING
     //////////////////////////////////////////////////////////////*/
@@ -89,26 +61,22 @@ library PositionBalanceLibrary {
         int24 lastObservedTick
     ) internal pure returns (uint96) {
         return
-            uint96(
-                uint24(currentTick) +
-                    (uint24(fastOracleTick) << 24) +
-                    (uint24(slowOracleTick) << 48) +
-                    (uint24(lastObservedTick) << 72)
-            );
+            uint96(uint24(currentTick)) +
+            (uint96(uint24(fastOracleTick)) << 24) +
+            (uint96(uint24(slowOracleTick)) << 48) +
+            (uint96(uint24(lastObservedTick)) << 72);
     }
 
     /*//////////////////////////////////////////////////////////////
                                 DECODING
     //////////////////////////////////////////////////////////////*/
 
-    function unpackTickData(uint96 tickData) internal pure returns (int24, int24, int24, int24) {}
-
     /// @notice Get the last observed tick of `self`.
     /// @param self The PositionBalance to get the requested tick
     /// @return The last observed tick of self
     function lastObservedTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 232));
+            return int24(int256((PositionBalance.unwrap(self) >> 232) % 2 ** 24));
         }
     }
 
@@ -117,7 +85,7 @@ library PositionBalanceLibrary {
     /// @return The slow oracle tick of self
     function slowOracleTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 208));
+            return int24(int256((PositionBalance.unwrap(self) >> 208) % 2 ** 24));
         }
     }
 
@@ -126,7 +94,7 @@ library PositionBalanceLibrary {
     /// @return The fast oracle tick of self
     function fastOracleTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 184));
+            return int24(int256((PositionBalance.unwrap(self) >> 184) % 2 ** 24));
         }
     }
 
@@ -135,7 +103,7 @@ library PositionBalanceLibrary {
     /// @return The current tick of self
     function currentTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 160));
+            return int24(int256((PositionBalance.unwrap(self) >> 160) % 2 ** 24));
         }
     }
 
@@ -145,15 +113,6 @@ library PositionBalanceLibrary {
     function tickData(PositionBalance self) internal pure returns (uint96) {
         unchecked {
             return uint96(PositionBalance.unwrap(self) >> 160);
-        }
-    }
-
-    /// @notice Get token1 utilization of `self`.
-    /// @param self The PositionBalance to get utilization
-    /// @return The token1 utilization, stored in bips
-    function utilization1(PositionBalance self) internal pure returns (int256) {
-        unchecked {
-            return int256((PositionBalance.unwrap(self) >> 144) % 2 ** 16);
         }
     }
 
@@ -183,6 +142,15 @@ library PositionBalanceLibrary {
     function utilization0(PositionBalance self) internal pure returns (int256) {
         unchecked {
             return int256((PositionBalance.unwrap(self) >> 128) % 2 ** 16);
+        }
+    }
+
+    /// @notice Get token1 utilization of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The token1 utilization, stored in bips
+    function utilization1(PositionBalance self) internal pure returns (int256) {
+        unchecked {
+            return int256((PositionBalance.unwrap(self) >> 144) % 2 ** 16);
         }
     }
 

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -155,6 +155,15 @@ library PositionBalanceLibrary {
         }
     }
 
+    /// @notice Get both token0 and token1 utilizations of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The token utilizations, stored in bips
+    function utilizations(PositionBalance self) internal pure returns (uint32) {
+        unchecked {
+            return uint32(PositionBalance.unwrap(self) >> 128);
+        }
+    }
+
     /// @notice Get the positionSize of `self`.
     /// @param self The PositionBalance to get the size from
     /// @return The positionSize of `self`

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -84,7 +84,7 @@ library PositionBalanceLibrary {
     /// @return The last observed tick of self
     function lastObservedTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256((PositionBalance.unwrap(self) >> 232) % 2 ** 24));
+            return int24(int256(PositionBalance.unwrap(self) >> 232));
         }
     }
 
@@ -93,7 +93,7 @@ library PositionBalanceLibrary {
     /// @return The slow oracle tick of self
     function slowOracleTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256((PositionBalance.unwrap(self) >> 208) % 2 ** 24));
+            return int24(int256(PositionBalance.unwrap(self) >> 208));
         }
     }
 
@@ -102,7 +102,7 @@ library PositionBalanceLibrary {
     /// @return The fast oracle tick of self
     function fastOracleTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256((PositionBalance.unwrap(self) >> 184) % 2 ** 24));
+            return int24(int256(PositionBalance.unwrap(self) >> 184));
         }
     }
 
@@ -111,7 +111,7 @@ library PositionBalanceLibrary {
     /// @return The current tick of self
     function currentTick(PositionBalance self) internal pure returns (int24) {
         unchecked {
-            return int24(int256((PositionBalance.unwrap(self) >> 160) % 2 ** 24));
+            return int24(int256(PositionBalance.unwrap(self) >> 160));
         }
     }
 

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.24;
-import "forge-std/Test.sol";
+
 type PositionBalance is uint256;
 using PositionBalanceLibrary for PositionBalance global;
 
 /// @title A Panoptic Position Balance. Tracks the Position Size, the Pool Utilizations at mint, and the current/fastOracle/slowOracle/latestObserved ticks at mint.
 /// @author Axicon Labs Limited
-///
+//
 //
 // PACKING RULES FOR A POSITIONBALANCE:
 // =================================================================================================
@@ -23,11 +23,11 @@ using PositionBalanceLibrary for PositionBalance global;
 //
 // The bit pattern is therefore:
 //
-//           (7)             (6)             (5)                (4)             (3)            (2)                 (1)
-//    <-- 24 bits -->  <-- 24 bits -->  <-- 24 bits -->   <-- 24 bits --> <-- 16 bits -->  <-- 16 bits -->   <-- 128 bits -->
-//   lastObservedTick   slowOracleTick   fastOracleTick     currentTick   utilization0      utilization1      positionSize
+//           (7)             (6)            (5)             (4)             (3)             (2)             (1)
+//    <-- 24 bits --> <-- 24 bits --> <-- 24 bits --> <-- 24 bits --> <-- 16 bits --> <-- 16 bits --> <-- 128 bits -->
+//  lastObservedTick   slowOracleTick  fastOracleTick   currentTick    utilization0     utilization1    positionSize
 //
-//        <--- most significant bit        least significant bit --->
+//    <--- most significant bit                                                             least significant bit --->
 //
 library PositionBalanceLibrary {
     /*//////////////////////////////////////////////////////////////
@@ -36,8 +36,8 @@ library PositionBalanceLibrary {
 
     /// @notice Create a new `PositionBalance` given by positionSize, utilizations, and its tickData.
     /// @param positionSize The amount of option minted
-    /// @param utilizations packing of two uint16 utilizations into a 32 bit word
-    /// @param tickData packing of 4 int25s into a single uint96
+    /// @param utilizations Packing of two uint16 utilizations into a 32 bit word
+    /// @param tickData Packing of 4 int25s into a single uint96
     /// @return The new PositionBalance with the given positionSize, utilization, and tickData
     function storeBalanceData(
         uint128 positionSize,
@@ -54,17 +54,25 @@ library PositionBalanceLibrary {
         }
     }
 
+    /// @notice Concatenate all oracle ticks into a single uint96.
+    /// @param currentTick The current tick
+    /// @param fastOracleTick The fast Oracle tick
+    /// @param slowOracleTick The slow Oracle tick
+    /// @param lastObservedTick The last observed tick
+    /// @return A 96bit word concatenating all 4 input ticks
     function packTickData(
         int24 currentTick,
         int24 fastOracleTick,
         int24 slowOracleTick,
         int24 lastObservedTick
     ) internal pure returns (uint96) {
-        return
-            uint96(uint24(currentTick)) +
-            (uint96(uint24(fastOracleTick)) << 24) +
-            (uint96(uint24(slowOracleTick)) << 48) +
-            (uint96(uint24(lastObservedTick)) << 72);
+        unchecked {
+            return
+                uint96(uint24(currentTick)) +
+                (uint96(uint24(fastOracleTick)) << 24) +
+                (uint96(uint24(slowOracleTick)) << 48) +
+                (uint96(uint24(lastObservedTick)) << 72);
+        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -130,7 +138,7 @@ library PositionBalanceLibrary {
             int24 lastObservedTick
         )
     {
-        PositionBalance self = storeBalanceData(0, 0, tickData);
+        PositionBalance self = PositionBalance.wrap(uint256(tickData) << 160);
 
         currentTick = self.currentTick();
         fastOracleTick = self.fastOracleTick();

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -108,7 +108,7 @@ library PositionBalanceLibrary {
     }
 
     /// @notice Get the tickData of `self`.
-    /// @param self The PositionBalance to get utilization
+    /// @param self The PositionBalance to get the ticks
     /// @return The packed tickData
     function tickData(PositionBalance self) internal pure returns (uint96) {
         unchecked {
@@ -116,8 +116,30 @@ library PositionBalanceLibrary {
         }
     }
 
+    /// @notice Get the unpacked tickData of uint96 tickData.
+    /// @param tickData The packed tickData to get ticks from
+    function unpackTickData(
+        uint96 tickData
+    )
+        internal
+        pure
+        returns (
+            int24 currentTick,
+            int24 fastOracleTick,
+            int24 slowOracleTick,
+            int24 lastObservedTick
+        )
+    {
+        PositionBalance self = storeBalanceData(0, 0, tickData);
+
+        currentTick = self.currentTick();
+        fastOracleTick = self.fastOracleTick();
+        slowOracleTick = self.slowOracleTick();
+        lastObservedTick = self.lastObservedTick();
+    }
+
     /// @notice Get the unpacked tickData of `self`.
-    /// @param self The PositionBalance to get utilization
+    /// @param self The PositionBalance to get ticks from
     function unpackTickData(
         PositionBalance self
     )

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -82,7 +82,7 @@ library PositionBalanceLibrary {
         }
     }
 
-    function createTickData(
+    function packTickData(
         int24 currentTick,
         int24 fastOracleTick,
         int24 slowOracleTick,
@@ -100,6 +100,8 @@ library PositionBalanceLibrary {
     /*//////////////////////////////////////////////////////////////
                                 DECODING
     //////////////////////////////////////////////////////////////*/
+
+    function unpackTickData(uint96 tickData) internal pure returns (int24, int24, int24, int24) {}
 
     /// @notice Get the last observed tick of `self`.
     /// @param self The PositionBalance to get the requested tick
@@ -137,6 +139,15 @@ library PositionBalanceLibrary {
         }
     }
 
+    /// @notice Get the tickData of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The packed tickData
+    function tickData(PositionBalance self) internal pure returns (uint96) {
+        unchecked {
+            return uint96(PositionBalance.unwrap(self) >> 160);
+        }
+    }
+
     /// @notice Get token1 utilization of `self`.
     /// @param self The PositionBalance to get utilization
     /// @return The token1 utilization, stored in bips
@@ -144,6 +155,26 @@ library PositionBalanceLibrary {
         unchecked {
             return int256((PositionBalance.unwrap(self) >> 144) % 2 ** 16);
         }
+    }
+
+    /// @notice Get the unpacked tickData of `self`.
+    /// @param self The PositionBalance to get utilization
+    function unpackTickData(
+        PositionBalance self
+    )
+        internal
+        pure
+        returns (
+            int24 currentTick,
+            int24 fastOracleTick,
+            int24 slowOracleTick,
+            int24 lastObservedTick
+        )
+    {
+        currentTick = self.currentTick();
+        fastOracleTick = self.fastOracleTick();
+        slowOracleTick = self.slowOracleTick();
+        lastObservedTick = self.lastObservedTick();
     }
 
     /// @notice Get token0 utilization of `self`.

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.24;
+
+// Custom types
+import {TokenId} from "@types/TokenId.sol";
+
+type PositionBalance is uint256;
+using PositionBalanceLibrary for PositionBalance global;
+
+/// @title A Panoptic Liquidity Chunk. Tracks Tick Range and Liquidity Information for a "chunk." Used to track movement of chunks.
+/// @author Axicon Labs Limited
+///
+/// @notice A liquidity chunk is an amount of `liquidity` (an amount of WETH, e.g.) deployed between two ticks: `tickLower` and `tickUpper`
+/// into a concentrated liquidity AMM.
+//
+//                liquidity
+//                    ▲      liquidity chunk
+//                    │        │
+//                    │    ┌───▼────┐   ▲
+//                    │    │        │   │ liquidity/size
+//      Other AMM     │  ┌─┴────────┴─┐ ▼ of chunk
+//      liquidity  ───┼──┼─►          │
+//                    │  │            │
+//                    └──┴─▲────────▲─┴──► price ticks
+//                         │        │
+//                         │        │
+//                    tickLower     │
+//                              tickUpper
+//
+/// @notice Track Tick Range Information. Lower and Upper ticks including the liquidity deployed within that range.
+/// @notice This is used to track information about a leg in the Option Position identified by `TokenId.sol`.
+/// @notice We pack this tick range info into a uint256.
+//
+// PACKING RULES FOR A LIQUIDITYCHUNK:
+// =================================================================================================
+//  From the LSB to the MSB:
+// (1) Liquidity        128bits  : The liquidity within the chunk (uint128).
+// ( ) (Zero-bits)       80bits  : Zero-bits to match a total uint256.
+// (2) tick Upper        24bits  : The upper tick of the chunk (int24).
+// (3) tick Lower        24bits  : The lower tick of the chunk (int24).
+// Total                256bits  : Total bits used by a chunk.
+// ===============================================================================================
+//
+// The bit pattern is therefore:
+//
+//           (3)             (2)             ( )                (1)
+//    <-- 24 bits -->  <-- 24 bits -->  <-- 80 bits -->   <-- 128 bits -->
+//        tickLower       tickUpper         Zeros             Liquidity
+//
+//        <--- most significant bit        least significant bit --->
+//
+library PositionBalanceLibrary {
+    /// @notice AND mask to strip the `tickLower` value from a packed LiquidityChunk.
+    uint256 internal constant CLEAR_TL_MASK =
+        0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+
+    /// @notice AND mask to strip the `tickUpper` value from a packed LiquidityChunk.
+    uint256 internal constant CLEAR_TU_MASK =
+        0xFFFFFF000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+
+    /*//////////////////////////////////////////////////////////////
+                                ENCODING
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Create a new `PositionBalance` given by positionSize, utilizations, and its tickData.
+    /// @param positionSize The amount of option minted
+    /// @param utilizations packing of two uint16 utilizations into a 32 bit word
+    /// @param tickData packing of 4 int25s into a single uint96
+    /// @return The new PositionBalance with the given positionSize, utilization, and tickData
+    function storeBalanceData(
+        uint128 positionSize,
+        uint32 utilizations,
+        uint96 tickData
+    ) internal pure returns (PositionBalance) {
+        unchecked {
+            return
+                PositionBalance.wrap(
+                    (uint256(tickData) << 160) +
+                        (uint256(utilizations) << 128) +
+                        uint256(positionSize)
+                );
+        }
+    }
+
+    function createTickData(
+        int24 currentTick,
+        int24 fastOracleTick,
+        int24 slowOracleTick,
+        int24 lastObservedTick
+    ) internal pure returns (uint96) {
+        return
+            uint96(
+                uint24(currentTick) +
+                    (uint24(fastOracleTick) << 24) +
+                    (uint24(slowOracleTick) << 48) +
+                    (uint24(lastObservedTick) << 72)
+            );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                DECODING
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Get the last observed tick of `self`.
+    /// @param self The PositionBalance to get the requested tick
+    /// @return The last observed tick of self
+    function lastObservedTick(PositionBalance self) internal pure returns (int24) {
+        unchecked {
+            return int24(int256(PositionBalance.unwrap(self) >> 232));
+        }
+    }
+
+    /// @notice Get the slow oracle tick of `self`.
+    /// @param self The PositionBalance to get the requested tick
+    /// @return The slow oracle tick of self
+    function slowOracleTick(PositionBalance self) internal pure returns (int24) {
+        unchecked {
+            return int24(int256(PositionBalance.unwrap(self) >> 208));
+        }
+    }
+
+    /// @notice Get the last observed tick of `self`.
+    /// @param self The PositionBalance to get the last observed tick
+    /// @return The fast oracle tick of self
+    function fastOracleTick(PositionBalance self) internal pure returns (int24) {
+        unchecked {
+            return int24(int256(PositionBalance.unwrap(self) >> 184));
+        }
+    }
+
+    /// @notice Get the current tick of `self`.
+    /// @param self The PositionBalance to get the requested tick
+    /// @return The current tick of self
+    function currentTick(PositionBalance self) internal pure returns (int24) {
+        unchecked {
+            return int24(int256(PositionBalance.unwrap(self) >> 160));
+        }
+    }
+
+    /// @notice Get token1 utilization of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The token1 utilization, stored in bips
+    function utilization1(PositionBalance self) internal pure returns (int256) {
+        unchecked {
+            return int256((PositionBalance.unwrap(self) >> 144) % 2 ** 16);
+        }
+    }
+
+    /// @notice Get token0 utilization of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The token0 utilization, stored in bips
+    function utilization0(PositionBalance self) internal pure returns (int256) {
+        unchecked {
+            return int256((PositionBalance.unwrap(self) >> 128) % 2 ** 16);
+        }
+    }
+
+    /// @notice Get the positionSize of `self`.
+    /// @param self The PositionBalance to get the size from
+    /// @return The positionSize of `self`
+    function positionSize(PositionBalance self) internal pure returns (uint128) {
+        unchecked {
+            return uint128(PositionBalance.unwrap(self));
+        }
+    }
+}

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -16,6 +16,7 @@ import {Errors} from "@libraries/Errors.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {TokenId} from "@types/TokenId.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
+import {PositionBalance} from "@types/PositionBalance.sol";
 import {Constants} from "@libraries/Constants.sol";
 // Panoptic Interfaces
 import {IERC20Partial} from "@tokens/interfaces/IERC20Partial.sol";
@@ -80,7 +81,7 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
     function getRequiredCollateralAtUtilization(
         uint128 amount,
         uint256 isLong,
-        int64 utilization
+        int16 utilization
     ) external view returns (uint256 required) {
         return _getRequiredCollateralAtUtilization(amount, isLong, utilization);
     }
@@ -101,7 +102,7 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
     }
 
     function buyCollateralRatio(int256 utilization) external view returns (uint256) {
-        return _buyCollateralRatio(uint256(utilization));
+        return _buyCollateralRatio(uint16(uint256(utilization)));
     }
 }
 
@@ -213,7 +214,7 @@ contract PanopticPoolHarness is PanopticPool {
     function positionBalance(
         address account,
         TokenId tokenId
-    ) external view returns (LeftRightUnsigned balanceAndUtilizations) {
+    ) external view returns (PositionBalance balanceAndUtilizations) {
         balanceAndUtilizations = s_positionBalance[account][tokenId];
     }
 }
@@ -6831,8 +6832,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                                 uint128(tokenType == 0 ? movedRight : movedLeft),
                                 1,
                                 tokenType == 0
-                                    ? int64(uint64(poolUtilizations))
-                                    : int64(uint64(poolUtilizations >> 64))
+                                    ? int16(uint16(poolUtilizations))
+                                    : int16(uint16(poolUtilizations >> 16))
                             )
                         ),
                         _tempTokensRequired
@@ -6843,8 +6844,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                             uint128(tokenType == 0 ? movedRight : movedLeft),
                             1,
                             tokenType == 0
-                                ? int64(uint64(poolUtilizations))
-                                : int64(uint64(poolUtilizations >> 64))
+                                ? int16(uint16(poolUtilizations))
+                                : int16(uint16(poolUtilizations >> 16))
                         )
                     );
                     console2.log(
@@ -6854,8 +6855,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                     console2.log(
                         "util req poolutil",
                         tokenType == 0
-                            ? int64(uint64(poolUtilizations))
-                            : int64(uint64(poolUtilizations >> 64))
+                            ? int16(uint16(poolUtilizations))
+                            : int16(uint16(poolUtilizations >> 16))
                     );
 
                     vm.assume(_tempTokensRequired < type(uint128).max);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -3869,8 +3869,6 @@ contract Misctest is Test, PositionUtils {
         // L = 1
         uniPool.liquidity();
 
-        /// @dev single leg, wide atm call, liquidation through price move making options ITM, no-cross collateral
-
         uint256 asset = 0;
         uint256 tokenType = 0;
         TokenId tokenId = TokenId

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -9,6 +9,7 @@ import {FeesCalc} from "@libraries/FeesCalc.sol";
 import {TokenId} from "@types/TokenId.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {LiquidityChunk, LiquidityChunkLibrary} from "@types/LiquidityChunk.sol";
+import {PositionBalance} from "@types/PositionBalance.sol";
 import {IERC20Partial} from "@tokens/interfaces/IERC20Partial.sol";
 import {TickMath} from "v3-core/libraries/TickMath.sol";
 import {FullMath} from "v3-core/libraries/FullMath.sol";
@@ -1684,14 +1685,14 @@ contract PanopticPoolTest is PositionUtils {
                 int256(expectedPremia[1])
             );
             assertEq(posBalanceArray[0][0], TokenId.unwrap(tokenId));
-            assertEq(LeftRightUnsigned.wrap(posBalanceArray[0][1]).rightSlot(), positionSizes[0]);
-            assertEq(LeftRightUnsigned.wrap(posBalanceArray[0][1]).leftSlot(), 0);
+            assertEq(PositionBalance.wrap(posBalanceArray[0][1]).positionSize(), positionSizes[0]);
+            assertEq(PositionBalance.wrap(posBalanceArray[0][1]).utilizations(), 0);
             assertEq(posBalanceArray[1][0], TokenId.unwrap(tokenId2));
             assertEq(LeftRightUnsigned.wrap(posBalanceArray[1][1]).rightSlot(), positionSizes[1]);
             assertEq(
-                LeftRightUnsigned.wrap(posBalanceArray[1][1]).leftSlot(),
-                uint128(poolUtilizationsAtMint.rightSlot()) +
-                    (uint128(poolUtilizationsAtMint.leftSlot()) << 64)
+                PositionBalance.wrap(posBalanceArray[1][1]).utilizations(),
+                uint32(uint128(poolUtilizationsAtMint.rightSlot())) +
+                    (uint32(uint128(poolUtilizationsAtMint.leftSlot())) << 16)
             );
         }
     }

--- a/test/foundry/test_periphery/PanopticHelper.sol
+++ b/test/foundry/test_periphery/PanopticHelper.sol
@@ -159,9 +159,7 @@ contract PanopticHelper {
             tokenIdList
         );
 
-        PositionBalance balanceAndUtilization = PositionBalance.wrap(
-            positionBalanceArray[0][1]
-        );
+        PositionBalance balanceAndUtilization = PositionBalance.wrap(positionBalanceArray[0][1]);
 
         return (
             balanceAndUtilization.positionSize(),

--- a/test/foundry/test_periphery/PanopticHelper.sol
+++ b/test/foundry/test_periphery/PanopticHelper.sol
@@ -13,6 +13,7 @@ import {PanopticMath} from "@libraries/PanopticMath.sol";
 import {LeftRightUnsigned} from "@types/LeftRight.sol";
 import {TokenId, TokenIdLibrary} from "@types/TokenId.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
+import {PositionBalance, PositionBalanceLibrary} from "@types/PositionBalance.sol";
 
 /// @title Utility contract for token ID construction and advanced queries.
 /// @author Axicon Labs Limited
@@ -148,7 +149,7 @@ contract PanopticHelper {
         PanopticPool pool,
         address account,
         TokenId tokenId
-    ) external view returns (uint128, uint64, uint64) {
+    ) external view returns (uint128, uint16, uint16) {
         TokenId[] memory tokenIdList = new TokenId[](1);
         tokenIdList[0] = tokenId;
 
@@ -158,14 +159,14 @@ contract PanopticHelper {
             tokenIdList
         );
 
-        LeftRightUnsigned balanceAndUtilization = LeftRightUnsigned.wrap(
+        PositionBalance balanceAndUtilization = PositionBalance.wrap(
             positionBalanceArray[0][1]
         );
 
         return (
-            balanceAndUtilization.rightSlot(),
-            uint64(balanceAndUtilization.leftSlot()),
-            uint64(balanceAndUtilization.leftSlot() >> 64)
+            balanceAndUtilization.positionSize(),
+            uint16(balanceAndUtilization.utilizations()),
+            uint16(balanceAndUtilization.utilizations() >> 16)
         );
     }
 

--- a/test/foundry/types/PositionBalance.t.sol
+++ b/test/foundry/types/PositionBalance.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.24;
+
+// foundry
+import "forge-std/Test.sol";
+// internal
+import {Errors} from "../../../contracts/libraries/Errors.sol";
+import {PositionBalanceHarness} from "./harnesses/PositionBalanceHarness.sol";
+import {PositionBalance, PositionBalanceLibrary} from "@types/PositionBalance.sol";
+
+/**
+ * Test Position Balance using Foundry and Fuzzing.
+ *
+ * @author Axicon Labs Limited
+ */
+contract PositionBalanceTest is Test {
+    // harness
+    PositionBalanceHarness harness;
+
+    function setUp() public {
+        harness = new PositionBalanceHarness();
+    }
+
+    function test_Success_storeBalanceData(uint128 y, uint16 z, uint16 u, uint96 w) public {
+        uint32 utilizations = uint32(z) + (uint32(u) << 16);
+        PositionBalance x = harness.storeBalanceData(y, utilizations, w);
+        assertEq(harness.positionSize(x), y);
+        assertEq(harness.utilizations(x), utilizations);
+        assertEq(harness.utilization0(x), int256(uint256(z)));
+        assertEq(harness.utilization1(x), int256(uint256(u)));
+        assertEq(harness.tickData(x), w);
+    }
+
+    function test_Success_storeBalanceData_utilizations(uint128 y, uint32 z, uint96 u) public {
+        PositionBalance x = harness.storeBalanceData(y, z, u);
+        assertEq(harness.positionSize(x), y);
+        assertEq(harness.utilizations(x), z);
+        assertEq(harness.tickData(x), u);
+    }
+
+    function test_Success_packTickData(int24 y, int24 z, int24 u, int24 w) public {
+        uint96 x = harness.packTickData(y, z, u, w);
+
+        console2.log("x", x);
+        PositionBalance p = harness.storeBalanceData(uint128(0), uint32(0), x);
+
+        assertEq(harness.currentTick(p), y);
+        assertEq(harness.fastOracleTick(p), z);
+        assertEq(harness.slowOracleTick(p), u);
+        assertEq(harness.lastObservedTick(p), w);
+    }
+}

--- a/test/foundry/types/harnesses/PositionBalanceHarness.sol
+++ b/test/foundry/types/harnesses/PositionBalanceHarness.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.24;
+
+import {PositionBalance, PositionBalanceLibrary} from "@types/PositionBalance.sol";
+
+/// @title PositionBalanceHarness: A harness to expose the PositionBalance library for code coverage analysis.
+/// @notice Replicates the interface of the PositionBalance library, passing through any function calls
+/// @author Axicon Labs Limited
+contract PositionBalanceHarness {
+    /// @notice Create a new `PositionBalance` given by positionSize, utilizations, and its tickData.
+    /// @param positionSize The amount of option minted
+    /// @param utilizations packing of two uint16 utilizations into a 32 bit word
+    /// @param tickData packing of 4 int25s into a single uint96
+    /// @return The new PositionBalance with the given positionSize, utilization, and tickData
+    function storeBalanceData(
+        uint128 positionSize,
+        uint32 utilizations,
+        uint96 tickData
+    ) public pure returns (PositionBalance) {
+        return PositionBalanceLibrary.storeBalanceData(positionSize, utilizations, tickData);
+    }
+
+    function packTickData(
+        int24 currentTick,
+        int24 fastOracleTick,
+        int24 slowOracleTick,
+        int24 lastObservedTick
+    ) public pure returns (uint96) {
+        return
+            PositionBalanceLibrary.packTickData(
+                currentTick,
+                fastOracleTick,
+                slowOracleTick,
+                lastObservedTick
+            );
+    }
+
+    /// @notice Get the positionSize of `self`.
+    /// @param self The PositionBalance to get the size from
+    /// @return The positionSize of `self`
+    function positionSize(PositionBalance self) public pure returns (uint128) {
+        return PositionBalanceLibrary.positionSize(self);
+    }
+
+    /// @notice Get both token0 and token1 utilizations of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The token utilizations, stored in bips
+    function utilizations(PositionBalance self) public pure returns (uint32) {
+        return PositionBalanceLibrary.utilizations(self);
+    }
+
+    /// @notice Get token0 utilization of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The token0 utilization, stored in bips
+    function utilization0(PositionBalance self) public pure returns (int256) {
+        return PositionBalanceLibrary.utilization0(self);
+    }
+
+    /// @notice Get token1 utilization of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The token1 utilization, stored in bips
+    function utilization1(PositionBalance self) public pure returns (int256) {
+        return PositionBalanceLibrary.utilization1(self);
+    }
+
+    /// @notice Get the tickData of `self`.
+    /// @param self The PositionBalance to get utilization
+    /// @return The packed tickData
+    function tickData(PositionBalance self) public pure returns (uint96) {
+        return PositionBalanceLibrary.tickData(self);
+    }
+
+    /// @notice Get the last observed tick of `self`.
+    /// @param self The PositionBalance to get the requested tick
+    /// @return The last observed tick of self
+    function lastObservedTick(PositionBalance self) public pure returns (int24) {
+        return PositionBalanceLibrary.lastObservedTick(self);
+    }
+
+    /// @notice Get the slow oracle tick of `self`.
+    /// @param self The PositionBalance to get the requested tick
+    /// @return The slow oracle tick of self
+    function slowOracleTick(PositionBalance self) public pure returns (int24) {
+        return PositionBalanceLibrary.slowOracleTick(self);
+    }
+
+    /// @notice Get the last observed tick of `self`.
+    /// @param self The PositionBalance to get the last observed tick
+    /// @return The fast oracle tick of self
+    function fastOracleTick(PositionBalance self) public pure returns (int24) {
+        return PositionBalanceLibrary.fastOracleTick(self);
+    }
+
+    /// @notice Get the current tick of `self`.
+    /// @param self The PositionBalance to get the requested tick
+    /// @return The current tick of self
+    function currentTick(PositionBalance self) public pure returns (int24) {
+        return PositionBalanceLibrary.currentTick(self);
+    }
+}


### PR DESCRIPTION
This PR stores a ticks snapshot in `s_positionBalance`, this is something we need in `PanopticHelper` when computing the maintenance margin requirement.

It may also make it easier to get the `tickAtMint` than in the subgraph (ie. no need to call it anymore), and that tick information could also be used to plot svg PnL charts from a RPC call from `PanopticHelper`.

There is enough free space in that storage slot, and it shouldn't add much more gas for mints and extra packing/unpacking logic. So it should be straightforward to merge.

More specifically, `s_positionBalance` is currently structured like this:
```
    /// @notice Tracks the amount of liquidity for a user+tokenId (right slot) and the initial pool utilizations when that position was minted (left slot).
    //    poolUtilizations when minted (left)    liquidity=ERC1155 balance (right)
    //        token0          token1
    //  |<-- 64 bits -->|<-- 64 bits -->|<---------- 128 bits ---------->|
    //  |<-------------------------- 256 bits -------------------------->|
    mapping(address account => mapping(TokenId tokenId => LeftRightUnsigned balanceAndUtilizations))
        internal s_positionBalance; 
```

This PR reduces the utilizations to `uint16` (since they're never over 10,000) and I use the remaining 96bits to store the 4 ticks returned by getOracleTicks:

```
    //  |<- tickData->|<-- util1 -->|<-- util0 -->|<-------- 128 bits -------->|             
    //  |<- 96 bits ->|<- 16 bits ->|<- 16 bits ->|<-------- 128 bits -------->|
    //  |<------------------------------ 256 bits ---------------------------->|
```

Where tickData is:
```
|<- lastObservedTick ->|<- slowOracleTick ->|<- fastOracleTick ->|<- currentTick ->|
|<----- 24 bits ------>|<---- 24 bits ----->|<---- 24 bits ----->|<--- 24 bits --->|
```

I created a new PositionBalance type that facilitates the storage+retrieval of all those quantities. And I also exposed all those quantities in `PanopticPool.positionData(user, tokenId)`