### PR TITLE
fix: correct reversed force exercise compensation

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -725,7 +725,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 // reverse any token deltas between the current and oracle prices for the chunk the exercisee had to mint in Uniswap
                 // the outcome of current price crossing a long chunk will always be less favorable than the status quo, i.e.,
                 // if the current price is moved downward such that some part of the chunk is between the current and market prices,
-                // the chunk will composition will swap token1 for token0 at a price (token0/token1) more favorable than market (token1/token0),
+                // the chunk composition will swap token1 for token0 at a price (token0/token1) more favorable than market (token1/token0),
                 // forcing the exercisee to provide more value in token0 than they would have provided in token1 at market, and vice versa.
                 // (the excess value provided by the exercisee could then be captured in a return swap across their newly added liquidity)
                 exerciseFees = exerciseFees.sub(

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -722,13 +722,17 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     );
                 }
 
-                // compensate user for loss in value if chunk has lost money between current and median tick
-                // NOTE: the delta for one token will be positive and the other will be negative. This cancels out any moves in their positions
+                // reverse any token deltas between the current and oracle prices for the chunk the exercisee had to mint in Uniswap
+                // the outcome of current price crossing a long chunk will always be less favorable than the status quo, i.e.,
+                // if the current price is moved downward such that some part of the chunk is between the current and market prices,
+                // the chunk will composition will swap token1 for token0 at a price (token0/token1) more favorable than market (token1/token0),
+                // forcing the exercisee to provide more value in token0 than they would have provided in token1 at market, and vice versa.
+                // (the excess value provided by the exercisee could then be captured in a return swap across their newly added liquidity)
                 exerciseFees = exerciseFees.sub(
                     LeftRightSigned
                         .wrap(0)
-                        .toRightSlot(int128(uint128(oracleValue0)) - int128(uint128(currentValue0)))
-                        .toLeftSlot(int128(uint128(oracleValue1)) - int128(uint128(currentValue1)))
+                        .toRightSlot(int128(uint128(currentValue0)) - int128(uint128(oracleValue0)))
+                        .toLeftSlot(int128(uint128(currentValue1)) - int128(uint128(oracleValue1)))
                 );
             }
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5300,8 +5300,8 @@ contract PanopticPoolTest is PositionUtils {
 
             // compensate user for loss in value if chunk has lost money between current and median tick
             // note: the delta for one token will be positive and the other will be negative. This cancels out any moves in their positions
-            exerciseFeeAmounts[0] += int256(medianValue0) - int256(currentValue0);
-            exerciseFeeAmounts[1] += int256(medianValue1) - int256(currentValue1);
+            exerciseFeeAmounts[0] += int256(currentValue0) - int256(medianValue0);
+            exerciseFeeAmounts[1] += int256(currentValue1) - int256(medianValue1);
         }
 
         // since the position is sufficiently OTM, the spread between value at current tick and median tick is 0

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -7740,7 +7740,13 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
         vm.assume(Math.abs(int256(currentTick) - pp.getUniV3TWAP_()) < 953);
 
-        vm.expectRevert(Errors.NotMarginCalled.selector);
-        pp.liquidate(new TokenId[](0), Alice, LeftRightUnsigned.wrap(0), $posIdLists[1]);
+        try pp.liquidate(new TokenId[](0), Alice, LeftRightUnsigned.wrap(0), $posIdLists[1]) {
+            assertFalse(true, "liquidation should have failed");
+        } catch (bytes memory reason) {
+            assertTrue(
+                bytes4(reason) == Errors.NotMarginCalled.selector ||
+                    bytes4(reason) == Errors.DivergentSolvencyCheck.selector
+            );
+        }
     }
 }


### PR DESCRIPTION
My `ForceExercise: Sanity check - Exercisee token value is lower than before` invariant broke, and it  turns out we’ve been calculating loss compensation for force exercisees wrong the entire time.

The idea behind loss compensation is that *for long positions*, manipulating the current price can lead to less favorable (benchmarked against the organic market price or oracle tick) outcomes than burning the position under normal circumstances. Therefore, the decision was made to compensate force exercisees for any possible such changes in their long legs caused by price manipulation.

To implement this change and revert the exercisee’s token balances back to the value they would have received burning at the oracle tick, we’ve always done something like:
`exerciseFee -= (oracle/medianvalue - currentValue)` for each token. For example, if the liquidity underlying the position is worth 5000 token0 at the current price (out-of-range) and 1000 token1 at the oracle price (also out-of-range), the exercisee would be compensated with 1000 token1 in exchange for refunding 5000 token0 to the exercisor (a negative exercise fee represents a payment from exercisee to exercisor), in theory returning their account to the state it would have been had they burned at the oracle price.

However, the key error here is that this calculation is for *long positions*. When that exercisee closes their position, they add liquidity to Uniswap and actually *pay* 1000 USDC, so in order to return their account to the oracle-tick state you would actually have to do the exact opposite, compensating them with 1000 token1 in exchange for a refund of 5000 token0 (i.e. we need to swap currentValue and oracleValue in that expression)

My guess as to why auditors didn’t catch this is that it’s more of an economic issue and they may have believed that it was intended behavior. Still, we need to fix this because currently:
- The logic here *does not prevent* the intended attack vector of atomic price manipulation across far-out-of-range exercisees
- It actually makes the original attack vector *more profitable* because it about doubles the size of the forced trade at the (unfavorable) far-out-of-range strike price