### PR TITLE
chore: note the `--verify` flag one can use when deploying Panoptic

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ To deploy Panoptic, run:
 forge script script/DeployProtocol.s.sol:DeployProtocol --rpc-url sepolia -vvvv --broadcast
 ```
 
+Include the `--verify` flag, after exporting your ETHERSCAN_API_KEY into the environment, to ensure deployed contracts are verified on Etherscan.
+
 The preconfigured RPC URL aliases are: `sepolia`. To deploy on another chain a custom RPC URL can be passed.
 
 ## License


### PR DESCRIPTION
Many people deploying the protocol will wish for the contracts to be verified on their chain. I think it'd make sense to note how you can do that easily when we show users how to deploy. A more aggressive approach here could just be to change the recommended command from:

```
forge script script/DeployProtocol.s.sol:DeployProtocol --rpc-url sepolia -vvvv --broadcast
```

to

```
forge script script/DeployProtocol.s.sol:DeployProtocol --rpc-url sepolia -vvvv --broadcast --verify
```

and just _assume_ users intend to verify when deploying.

However, I could hear an argument that the average README user would be deploying to a private forked chain or something rather than one where their deployment should be publicly verified; or, perhaps most users are already familiar with this verify flag and know to use it if that's what they need.