### PR TITLE
fix: off-by-one overestimates on `maxWithdraw`/`maxRedeem`

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -486,7 +486,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function maxWithdraw(address owner) public view returns (uint256 maxAssets) {
         // We can only use the standard 4626 withdraw function if the user has no open positions
         // For the sake of simplicity assets can only be withdrawn through the redeem function
-        uint256 available = s_poolAssets;
+        uint256 available = s_poolAssets - 1;
         uint256 balance = convertToAssets(balanceOf[owner]);
         return s_panopticPool.numberOfPositions(owner) == 0 ? Math.min(available, balance) : 0;
     }
@@ -590,7 +590,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param owner The redeeming address.
     /// @return maxShares The maximum amount of shares that can be redeemed.
     function maxRedeem(address owner) public view returns (uint256 maxShares) {
-        uint256 available = convertToShares(s_poolAssets);
+        uint256 available = convertToShares(s_poolAssets - 1);
         uint256 balance = balanceOf[owner];
         return s_panopticPool.numberOfPositions(owner) == 0 ? Math.min(available, balance) : 0;
     }


### PR DESCRIPTION
[EIP-4626](https://eips.ethereum.org/EIPS/eip-4626) requires `maxWithdraw` and `maxRedeem` to return an amount of assets or shares that can be withdrawn without reverting. If the asset value of a user's shares is greater than `s_poolAssets`, attempting a withdrawal of amounts returned by the `maxWithdraw/Redeem` functions will fail in many cases because `s_poolAssets` includes one virtual asset, resulting in `s_poolAssets > underlyingToken.balanceOf(panopticPool)` unless rounding or direct transfers have eliminated the discrepancy prior to the withdrawal transaction. 

Will probably add an invariant for this.