### PR TITLE
fix: expand `tokenToPay` calculations to 256 bits

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1059,7 +1059,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
             // add premium and token deltas not covered by swap to be paid/collected on position close
-            int256 tokenToPay = swappedAmount - (longAmount - shortAmount) - realizedPremium;
+            int256 tokenToPay = int256(swappedAmount) -
+                (longAmount - shortAmount) -
+                realizedPremium;
 
             if (tokenToPay > 0) {
                 // if user must pay tokens, burn them from user balance (revert if balance too small)
@@ -1099,7 +1101,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         unchecked {
             // intrinsic value is the amount that need to be exchanged due to minting in-the-money
-            int256 intrinsicValue = swappedAmount - (shortAmount - longAmount);
+            int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
 
             if (intrinsicValue != 0) {
                 // the swap commission is paid on the intrinsic value, and it is always positive

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -505,8 +505,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
     function twoWaySwap(uint256 swapSize) public {
         vm.startPrank(Swapper);
 
-        // give Swapper the max amount of tokens
-        _grantTokens(Swapper);
+        deal(token0, Swapper, type(uint248).max);
+        deal(token1, Swapper, type(uint248).max);
 
         IERC20Partial(token0).approve(address(router), type(uint256).max);
         IERC20Partial(token1).approve(address(router), type(uint256).max);


### PR DESCRIPTION
These can overflow for pools with tokens that break our `totalSupply < 2^127 - 1` invariant. We will not support those pools, but our invariant test actors ignore that invariant and have large quantities of tokens at their disposal. Expanding these calculations reduces gas slightly and allows our invariant tests to pass without introducing a kill switch for the `totalSupply < 2^127 - 1` invariant.