### PR TITLE
Code freeze: v1.0.0

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -485,9 +485,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function maxWithdraw(address owner) public view returns (uint256 maxAssets) {
         // We can only use the standard 4626 withdraw function if the user has no open positions
         // For the sake of simplicity assets can only be withdrawn through the redeem function
-        uint256 available = s_poolAssets - 1;
-        uint256 balance = convertToAssets(balanceOf[owner]);
-        return s_panopticPool.numberOfPositions(owner) == 0 ? Math.min(available, balance) : 0;
+        uint256 poolAssets = s_poolAssets;
+        unchecked {
+            uint256 available = poolAssets > 0 ? poolAssets - 1 : 0;
+            uint256 balance = convertToAssets(balanceOf[owner]);
+            return s_panopticPool.numberOfPositions(owner) == 0 ? Math.min(available, balance) : 0;
+        }
     }
 
     /// @notice Returns the amount of shares that would be burned to withdraw a given amount of assets.
@@ -589,9 +592,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param owner The redeeming address
     /// @return maxShares The maximum amount of shares that can be redeemed by `owner`
     function maxRedeem(address owner) public view returns (uint256 maxShares) {
-        uint256 available = convertToShares(s_poolAssets - 1);
-        uint256 balance = balanceOf[owner];
-        return s_panopticPool.numberOfPositions(owner) == 0 ? Math.min(available, balance) : 0;
+        uint256 poolAssets = s_poolAssets;
+        unchecked {
+            uint256 available = convertToShares(poolAssets > 0 ? poolAssets - 1 : 0);
+            uint256 balance = balanceOf[owner];
+            return s_panopticPool.numberOfPositions(owner) == 0 ? Math.min(available, balance) : 0;
+        }
     }
 
     /// @notice Returns the amount of assets resulting from a given amount of shares being redeemed.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1001,19 +1001,26 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
+    /// @param isCovered Whether the option was minted as covered (no swap occured if ITM)
     /// @return utilization The final utilization of the collateral vault
     function takeCommissionAddData(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount
+        int128 swappedAmount,
+        bool isCovered
     ) external onlyPanopticPool returns (uint32 utilization) {
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
             // constrict premium to only assets not belonging to PLPs (i.e premium paid by sellers or collected from the pool earlier)
-            int256 tokenToPay = _getExchangedAmount(longAmount, shortAmount, swappedAmount);
+            int256 tokenToPay = _getExchangedAmount(
+                longAmount,
+                shortAmount,
+                swappedAmount,
+                isCovered
+            );
 
             // compute tokens to be paid due to swap
             // mint or burn tokens due to minting in-the-money
@@ -1094,11 +1101,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of long options held
     /// @param shortAmount The amount of short options held
     /// @param swappedAmount The amount of tokens moved during creation of the option position
+    /// @param isCovered Whether the option was minted as covered (no swap occured if ITM)
     /// @return exchangedAmount The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
     function _getExchangedAmount(
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount
+        int128 swappedAmount,
+        bool isCovered
     ) internal view returns (int256 exchangedAmount) {
         // If amount swapped is positive, the amount of tokens to pay is the ITM amount
 
@@ -1107,11 +1116,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
 
             if (intrinsicValue != 0) {
-                // the swap commission is paid on the intrinsic value, and it is always positive
-                uint256 swapCommission = Math.unsafeDivRoundingUp(
-                    s_ITMSpreadFee * uint256(Math.abs(intrinsicValue)),
-                    DECIMALS * 100
-                );
+                // the swap commission is paid on the intrinsic value (if a swap occured -- users who mint covered options with their own collateral do not pay this fee)
+                uint256 swapCommission = isCovered
+                    ? 0
+                    : Math.unsafeDivRoundingUp(
+                        s_ITMSpreadFee * uint256(Math.abs(intrinsicValue)),
+                        DECIMALS * 100
+                    );
 
                 // set the exchanged amount to the sum of the intrinsic value and swapCommission
                 exchangedAmount = intrinsicValue + int256(swapCommission);

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -220,7 +220,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         s_initialized = true;
 
         // these virtual shares function as a multiplier for the capital requirement to manipulate the pool price
-        // e.g if the virtual shares are 10**6, then the capital requirement to manipulate the price to 10**12 is 10**18
+        // e.g. if the virtual shares are 10**6, then the capital requirement to manipulate the price to 10**12 is 10**18
         totalSupply = 10 ** 6;
 
         // set total assets to 1

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -203,10 +203,10 @@ contract PanopticFactory is FactoryNFT, Multicall {
 
         // Deploy collateral token proxies
         CollateralTracker collateralTracker0 = CollateralTracker(
-            Clones.clone(COLLATERAL_REFERENCE)
+            COLLATERAL_REFERENCE.cloneDeterministic(bytes32(uint256(salt32) + 1))
         );
         CollateralTracker collateralTracker1 = CollateralTracker(
-            Clones.clone(COLLATERAL_REFERENCE)
+            COLLATERAL_REFERENCE.cloneDeterministic(bytes32(uint256(salt32) + 2))
         );
 
         // Run state initialization sequence for pool and collateral tokens

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -324,13 +324,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _validateSolvency(user, positionIdList, BP_DECREASE_BUFFER);
     }
 
-    /// @notice Returns the total amount of premium accumulated for a list of positions and a list containing positions data.
+    /// @notice Returns the total amount of premium accumulated for a list of positions and a list containing the corresponding `PositionBalance` information for each position.
     /// @param user Address of the user that owns the positions
     /// @param positionIdList List of positions. Written as `[tokenId1, tokenId2, ...]`
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
     /// @return The total amount of premium owed (which may `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return The total amount of premium owed by the long legs in `positionIdList` (token0: right slot, token1: left slot)
-    /// @return A list of balances and pool utilization for each position, of the form `[[tokenId0, balances0], [tokenId1, balances1], ...]`
+    /// @return A list of `PositionBalance` data (balance and pool utilization/oracle ticks at last mint) for each position, of the form `[[tokenId0, PositionBalance_0], [tokenId1, PositionBalance_1], ...]`
     function getAccumulatedFeesAndPositionsData(
         address user,
         bool includePendingPremium,
@@ -1156,7 +1156,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Check whether an account is solvent at a given `atTick` with a collateral requirement of `buffer/10_000` multiplied by the requirement of `positionIdList`.
-    /// @dev This will revert if `account` is not solvent at all provided ticks and `expectedSolvent == true`, or if `account` is solvent at all ticks and `expectedSolvent == false`.
+    /// @dev Reverts if `account` is not solvent at all provided ticks and `expectedSolvent == true`, or if `account` is solvent at all ticks and `!expectedSolvent`.
     /// @param account The account to check solvency for
     /// @param positionIdList The list of positions to check solvency for
     /// @param currentTick The current tick of the Uniswap pool (needed for fee calculations)

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -324,14 +324,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
         _validateSolvency(user, positionIdList, BP_DECREASE_BUFFER);
     }
 
-    /// @notice Compute the total amount of premium accumulated for a list of positions.
+    /// @notice Returns the total amount of premium accumulated for a list of positions and a list containing positions data.
     /// @param user Address of the user that owns the positions
     /// @param positionIdList List of positions. Written as `[tokenId1, tokenId2, ...]`
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
     /// @return The total amount of premium owed (which may `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return The total amount of premium owed by the long legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return A list of balances and pool utilization for each position, of the form `[[tokenId0, balances0], [tokenId1, balances1], ...]`
-    function calculateAccumulatedFeesBatch(
+    function getAccumulatedFeesAndPositionsData(
         address user,
         bool includePendingPremium,
         TokenId[] calldata positionIdList

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -166,8 +166,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
     // The position of the bit codon from most to least significant is the ordering of the
     // tick index it points to from least to greatest.
     //
-    // [7] [5] [3] [1] [0] [2] [4] [6]
-    // 111 101 011 001 000 010 100 110
+    // rank:  0   1   2   3   4   5   6   7
+    // slot: [7] [5] [3] [1] [0] [2] [4] [6]
+    //       111 101 011 001 000 010 100 110
     //
     // [Constants.MIN_V3POOL_TICK-1] [7]
     // 111100100111011000010111
@@ -278,8 +279,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 // magic number which adds (7,5,3,1,0,2,4,6) order and minTick in positions 7, 5, 3 and maxTick in 6, 4, 2
                 // see comment on s_miniMedian initialization for format of this magic number
                 (uint256(0xF590A6F276170D89E9F276170D89E9F276170D89E9000000000000)) +
-                (uint256(uint24(currentTick)) << 24) + // add to slot 4
-                (uint256(uint24(currentTick))); // add to slot 3
+                (uint256(uint24(currentTick)) << 24) + // add to slot 1 (rank 3)
+                (uint256(uint24(currentTick))); // add to slot 0 (rank 4)
         }
 
         // Store the collateral token0

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -651,7 +651,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
             effectiveLiquidityLimitX32
         );
 
-        uint32 poolUtilizations = _payCommissionAndWriteData(tokenId, positionSize, totalSwapped);
+        uint32 poolUtilizations = _payCommissionAndWriteData(
+            tokenId,
+            positionSize,
+            totalSwapped,
+            tickLimitLow < tickLimitHigh
+        );
 
         if (safeMode) {
             return uint32(10_000 + (10_000 << 16));
@@ -664,13 +669,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tokenId The option position
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param totalSwapped The amount of tokens moved during creation of the option position
+    /// @param isCovered Whether the option was minted as covered (no swap occured if ITM)
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
-        LeftRightSigned totalSwapped
+        LeftRightSigned totalSwapped,
+        bool isCovered
     ) internal returns (uint32) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
@@ -680,13 +687,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
             msg.sender,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
-            totalSwapped.rightSlot()
+            totalSwapped.rightSlot(),
+            isCovered
         );
         uint32 utilization1 = s_collateralToken1.takeCommissionAddData(
             msg.sender,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
-            totalSwapped.leftSlot()
+            totalSwapped.leftSlot(),
+            isCovered
         );
 
         // return pool utilizations as two uint16 (pool Utilization is always < 10000)

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1147,7 +1147,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Check whether an account is solvent at a given `atTick` with a collateral requirement of `buffer/10_000` multiplied by the requirement of `positionIdList`.
-    /// @dev This will return true if solvent at any of the provided tick, and return false iff the account is insolvent at all ticks.
+    /// @dev This will revert if `account` is not solvent at all provided ticks and `expectedSolvent == true`, or if `account` is solvent at all ticks and `expectedSolvent == false`.
     /// @param account The account to check solvency for
     /// @param positionIdList The list of positions to check solvency for
     /// @param currentTick The current tick of the Uniswap pool (needed for fee calculations)

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -310,7 +310,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
 
         // return if the pool has already been initialized in SFPM
         // pools can be initialized from the Panoptic Factory or by calling initializeAMMPool directly, so reverting
-        // could prevent a PanopticPool from being deployed on a previously initialized but otherwise valid pools
+        // could prevent a PanopticPool from being deployed on a previously initialized but otherwise valid pool
         // if poolId == 0, we have a bit on the left set if it was initialized, so this will still return properly
         if (s_AddrToPoolIdData[univ3pool] != 0) return;
 
@@ -414,20 +414,18 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     /// @param slippageTickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param slippageTickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @return An array of LeftRight encoded words containing the amount of token0 and token1 collected as fees for each leg
-    /// @return A LeftRight encoded word containing the total amount of token0 and token1 swapped if minting ITM
+    /// @return The net amount of token0 and token1 moved to/from the Uniswap V3 pool
+
     function burnTokenizedPosition(
         TokenId tokenId,
         uint128 positionSize,
         int24 slippageTickLimitLow,
         int24 slippageTickLimitHigh
     ) external nonReentrant returns (LeftRightUnsigned[4] memory, LeftRightSigned) {
-        // burn this ERC1155 token id
         _burn(msg.sender, TokenId.unwrap(tokenId), positionSize);
 
-        // emit event
         emit TokenizedPositionBurnt(msg.sender, tokenId, positionSize);
 
-        // Call a function that contains other functions to mint/burn position, collect amounts, swap if necessary
         return
             _createPositionInAMM(
                 slippageTickLimitLow,
@@ -444,14 +442,14 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     /// @param slippageTickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param slippageTickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @return An array of LeftRight encoded words containing the amount of token0 and token1 collected as fees for each leg
-    /// @return A LeftRight encoded word containing the total amount of token0 and token1 swapped if minting ITM
+    /// @return The net amount of token0 and token1 moved to/from the Uniswap V3 pool
+
     function mintTokenizedPosition(
         TokenId tokenId,
         uint128 positionSize,
         int24 slippageTickLimitLow,
         int24 slippageTickLimitHigh
     ) external nonReentrant returns (LeftRightUnsigned[4] memory, LeftRightSigned) {
-        // create the option position via its ID in this erc1155
         _mint(msg.sender, TokenId.unwrap(tokenId), positionSize);
 
         emit TokenizedPositionMinted(msg.sender, tokenId, positionSize);
@@ -459,7 +457,6 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         // verify that the tokenId is correctly formatted and conforms to all enforced constraints
         tokenId.validate();
 
-        // validate the incoming option position, then forward to the AMM for minting/burning required liquidity chunks
         return
             _createPositionInAMM(
                 slippageTickLimitLow,
@@ -703,7 +700,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         }
     }
 
-    /// @notice Create the position in the AMM given in the tokenId.
+    /// @notice Create the position in the AMM defined by `tokenId`.
     /// @dev Loops over each leg in the tokenId and calls _createLegInAMM for each, which does the mint/burn in the AMM.
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
@@ -826,10 +823,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         );
 
         // update our internal bookkeeping of how much liquidity we have deployed in the AMM
-        // for example: if this _leg is short, we add liquidity to the amm, make sure to add that to our tracking
+        // for example: if this leg is short, we add liquidity to the amm, make sure to add that to our tracking
         uint128 updatedLiquidity;
         uint256 isLong = tokenId.isLong(leg);
-        LeftRightUnsigned currentLiquidity = s_accountLiquidity[positionKey]; //cache
+        LeftRightUnsigned currentLiquidity = s_accountLiquidity[positionKey];
         {
             // did we have liquidity already deployed in Uniswap for this chunk range from some past mint?
 
@@ -898,7 +895,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
             └──┴───────┴──►                      └──────┘
                 Uniswap V3                      msg.sender
         
-            else: the position is long (buying a put or a call), then _burnLiquidity to remove liquidity from univ3
+            else: the position is long (buying a put or a call), then _burnLiquidity to remove liquidity from Uniswap V3
             Buying(isLong=1): Burn in Uniswap
                    ┌─────────────────┐
             ▲     ┌┼┐                │

--- a/contracts/base/FactoryNFT.sol
+++ b/contracts/base/FactoryNFT.sol
@@ -30,7 +30,7 @@ contract FactoryNFT is MetadataStore, ERC721 {
         Pointer[][] memory pointers
     )
         MetadataStore(properties, indices, pointers)
-        ERC721("Panoptic Factory Deployer NFTs", "PANOPTIC-NFT")
+        ERC721("Panoptic V1 Factory Deployer NFTs", "PANOPTIC-NFT")
     {}
 
     /// @notice Returns the metadata URI for a given `tokenId`.

--- a/contracts/types/LiquidityChunk.sol
+++ b/contracts/types/LiquidityChunk.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
 
-// Custom types
-import {TokenId} from "@types/TokenId.sol";
-
 type LiquidityChunk is uint256;
 using LiquidityChunkLibrary for LiquidityChunk global;
 

--- a/contracts/types/LiquidityChunk.sol
+++ b/contracts/types/LiquidityChunk.sol
@@ -7,7 +7,7 @@ using LiquidityChunkLibrary for LiquidityChunk global;
 /// @title A Panoptic Liquidity Chunk. Tracks Tick Range and Liquidity Information for a "chunk." Used to track movement of chunks.
 /// @author Axicon Labs Limited
 ///
-/// @notice A liquidity chunk is an amount of `liquidity` (an amount of WETH, e.g.) deployed between two ticks: `tickLower` and `tickUpper`
+/// @notice A liquidity chunk is an amount of `liquidity` deployed between two ticks: `tickLower` and `tickUpper`
 /// into a concentrated liquidity AMM.
 //
 //                liquidity

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -448,39 +448,39 @@ library TokenIdLibrary {
         return 4;
     }
 
-    /// @notice Clear a leg in an option position with index `i`.
+    /// @notice Clear a leg in an option position at `legIndex`.
     /// @dev set bits of the leg to zero. Also sets the optionRatio and asset to zero of that leg.
     /// @dev NOTE: it's important that the caller fills in the leg details after.
     //  - optionRatio is zeroed
     //  - asset is zeroed
     //  - width is zeroed
-    // - strike is zeroed
+    //  - strike is zeroed
     //  - tokenType is zeroed
     //  - isLong is zeroed
     //  - riskPartner is zeroed
     /// @param self The TokenId to clear the leg from
-    /// @param i The leg index to reset, in {0,1,2,3}
-    /// @return `self` with the `i`th leg zeroed including optionRatio and asset
-    function clearLeg(TokenId self, uint256 i) internal pure returns (TokenId) {
-        if (i == 0)
+    /// @param legIndex The leg index to reset, in {0,1,2,3}
+    /// @return `self` with the `legIndex`th leg zeroed including optionRatio and asset
+    function clearLeg(TokenId self, uint256 legIndex) internal pure returns (TokenId) {
+        if (legIndex == 0)
             return
                 TokenId.wrap(
                     TokenId.unwrap(self) &
                         0xFFFFFFFFFFFF_FFFFFFFFFFFF_FFFFFFFFFFFF_000000000000_FFFFFFFFFFFFFFFF
                 );
-        if (i == 1)
+        if (legIndex == 1)
             return
                 TokenId.wrap(
                     TokenId.unwrap(self) &
                         0xFFFFFFFFFFFF_FFFFFFFFFFFF_000000000000_FFFFFFFFFFFF_FFFFFFFFFFFFFFFF
                 );
-        if (i == 2)
+        if (legIndex == 2)
             return
                 TokenId.wrap(
                     TokenId.unwrap(self) &
                         0xFFFFFFFFFFFF_000000000000_FFFFFFFFFFFF_FFFFFFFFFFFF_FFFFFFFFFFFFFFFF
                 );
-        if (i == 3)
+        if (legIndex == 3)
             return
                 TokenId.wrap(
                     TokenId.unwrap(self) &

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -566,7 +566,7 @@ library TokenIdLibrary {
                     if (((_isLong != isLongP) || _isLong == 1) && (_tokenType != tokenTypeP))
                         revert Errors.InvalidTokenIdParameter(5);
                 }
-            } // end for loop over legs
+            }
         }
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1953,7 +1953,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -1992,7 +1992,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2134,7 +2134,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2193,7 +2193,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         {
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2340,7 +2340,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2400,7 +2400,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2548,7 +2548,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2609,7 +2609,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2788,7 +2788,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -2850,7 +2850,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3041,7 +3041,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3098,7 +3098,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3256,7 +3256,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3323,7 +3323,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3488,7 +3488,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3555,7 +3555,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3706,7 +3706,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3773,7 +3773,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Alice, false, positionIdList1);
+                .getAccumulatedFeesAndPositionsData(Alice, false, positionIdList1);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Alice,
@@ -3907,7 +3907,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -3958,7 +3958,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4085,7 +4085,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4157,7 +4157,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4283,7 +4283,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4350,7 +4350,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4475,7 +4475,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4542,7 +4542,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4664,7 +4664,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4718,7 +4718,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4838,7 +4838,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -4905,7 +4905,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -5006,7 +5006,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             atTick = (atTick / tickSpacing) * tickSpacing;
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,
@@ -5089,7 +5089,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, currentTick, , , , , ) = pool.slot0();
 
             ($shortPremia, $longPremia, posBalanceArray) = panopticPool
-                .calculateAccumulatedFeesBatch(Bob, false, positionIdList);
+                .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
 
             LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
                 Bob,

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1817,7 +1817,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             address(0),
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            false
         );
 
         vm.expectRevert(Errors.NotPanopticPool.selector);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -705,7 +705,13 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(address(pp));
-        CollateralTracker(collateralReference).takeCommissionAddData(Alice, 0, 0, 1_000_000_000);
+        CollateralTracker(collateralReference).takeCommissionAddData(
+            Alice,
+            0,
+            0,
+            1_000_000_000,
+            false
+        );
         assertEq(
             1_000_000_000_000_000 -
                 1 -

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -3296,7 +3296,7 @@ contract Misctest is Test, PositionUtils {
 
         pp.mintOptions($posIdList, 2 ** 95, 0, int24(887272), int24(-887272));
 
-        (, , uint256[2][] memory positionBalanceArray) = pp.calculateAccumulatedFeesBatch(
+        (, , uint256[2][] memory positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Bob,
             false,
             $posIdList

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -2582,9 +2582,7 @@ contract PanopticPoolTest is PositionUtils {
 
             int256 notionalVal = amount0Moved - shortAmounts.rightSlot();
 
-            int256 ITMSpread = notionalVal > 0
-                ? (notionalVal * int24(2 * (fee / 100))) / 10_000
-                : -(notionalVal * int24(2 * (fee / 100))) / 10_000;
+            int256 ITMSpread = 0;
 
             assertApproxEqAbs(
                 ct0.balanceOf(Alice),
@@ -2601,12 +2599,7 @@ contract PanopticPoolTest is PositionUtils {
 
             assertApproxEqAbs(
                 ct1.balanceOf(Alice),
-                uint256(
-                    int256(uint256(type(uint104).max)) -
-                        amount1Moved -
-                        (amount1Moved * int24(2 * (fee / 100))) /
-                        10_000
-                ),
+                uint256(int256(uint256(type(uint104).max)) - amount1Moved),
                 10,
                 "alice balance 1"
             );
@@ -2906,14 +2899,7 @@ contract PanopticPoolTest is PositionUtils {
                 $amount0Moveds[0] + $amount0Moveds[1] - shortAmounts.rightSlot(),
                 $amount1Moveds[0] + $amount1Moveds[1] - shortAmounts.leftSlot()
             ];
-            int256[2] memory ITMSpreads = [
-                notionalVals[0] > 0
-                    ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-                    : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
-                notionalVals[1] > 0
-                    ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
-                    : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
-            ];
+            int256[2] memory ITMSpreads = [int256(0), int256(0)];
 
             assertApproxEqAbs(
                 ct0.balanceOf(Alice),
@@ -3266,14 +3252,7 @@ contract PanopticPoolTest is PositionUtils {
                 $amount1Moveds[1] + $amount1Moveds[2] - shortAmounts.leftSlot()
             ];
 
-            ITMSpreads = [
-                notionalVals[0] > 0
-                    ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-                    : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
-                notionalVals[1] > 0
-                    ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
-                    : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
-            ];
+            ITMSpreads = [int256(0), int256(0)];
 
             uint256 tokenToPay = uint256(
                 notionalVals[0] +
@@ -4527,13 +4506,9 @@ contract PanopticPoolTest is PositionUtils {
 
         int256[2] memory notionalVals1 = [-amount1Moveds[0], -amount1Moveds[1]];
 
-        int256 ITMSpread = notionalVals[0] > 0
-            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+        int256 ITMSpread = 0;
 
-        int256 ITMSpread1 = notionalVals1[0] > 0
-            ? (notionalVals1[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals1[0] * int24(2 * (fee / 100))) / 10_000);
+        int256 ITMSpread1 = 0;
 
         assertApproxEqAbs(
             int256(balanceBefores[0]) - int256(uint256(type(uint104).max)),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1539,7 +1539,7 @@ contract PanopticPoolTest is PositionUtils {
     }
 
     /// forge-config: default.fuzz.runs = 10
-    function test_Success_calculateAccumulatedFeesBatch_2xOTMShortCall(
+    function test_Success_getAccumulatedFeesAndPositionsData_2xOTMShortCall(
         uint256 x,
         uint256[2] memory widthSeeds,
         int256[2] memory strikeSeeds,
@@ -1674,7 +1674,7 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[1] = tokenId2;
 
             uint256[2][] memory posBalanceArray;
-            ($shortPremia, $longPremia, posBalanceArray) = pp.calculateAccumulatedFeesBatch(
+            ($shortPremia, $longPremia, posBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
                 Alice,
                 false,
                 posIdList
@@ -1702,7 +1702,7 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
-    function test_Success_calculateAccumulatedFeesBatch_VeryLargePremia(
+    function test_Success_getAccumulatedFeesAndPositionsData_VeryLargePremia(
         uint256 x,
         uint256 positionSizeSeed,
         uint256[2] memory premiaSeed
@@ -1741,7 +1741,7 @@ contract PanopticPoolTest is PositionUtils {
         premiaSeed[0] = bound(premiaSeed[0], 2 ** 64, 2 ** 120);
         premiaSeed[1] = bound(premiaSeed[1], 2 ** 64, 2 ** 120);
 
-        ($shortPremiaBefore, $longPremiaBefore, ) = pp.calculateAccumulatedFeesBatch(
+        ($shortPremiaBefore, $longPremiaBefore, ) = pp.getAccumulatedFeesAndPositionsData(
             Alice,
             true,
             posIdList
@@ -1752,14 +1752,22 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(address(sfpm));
         pool.burn(tickLower, tickUpper, 0);
 
-        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(Alice, false, posIdList);
+        ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(
+            Alice,
+            false,
+            posIdList
+        );
 
         // we have not settled any accrued premium yet, so the calculated amount (excluding pending premium) should be 0
         assertEq(LeftRightUnsigned.unwrap($shortPremia), 0);
         assertEq(LeftRightUnsigned.unwrap($longPremia), 0);
 
         // if we include pending premium, the amount should be the same as the accrued premium
-        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(Alice, true, posIdList);
+        ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(
+            Alice,
+            true,
+            posIdList
+        );
 
         assertApproxEqAbs(
             uint256(
@@ -5264,7 +5272,11 @@ contract PanopticPoolTest is PositionUtils {
 
         updateIntrinsicValueBurn(longAmounts, shortAmounts);
 
-        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(Alice, true, posIdList);
+        ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(
+            Alice,
+            true,
+            posIdList
+        );
 
         vm.startPrank(Bob);
         (currentSqrtPriceX96, currentTick, observationIndex, observationCardinality, , , ) = pool
@@ -6381,7 +6393,7 @@ contract PanopticPoolTest is PositionUtils {
         TWAPtick = pp.getUniV3TWAP_();
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-        ($shortPremia, $longPremia, $positionBalanceArray) = pp.calculateAccumulatedFeesBatch(
+        ($shortPremia, $longPremia, $positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Alice,
             false,
             $posIdLists[1]
@@ -6517,7 +6529,7 @@ contract PanopticPoolTest is PositionUtils {
         $liquidatorAssetBalance0 = IERC20Partial(token0).balanceOf(Charlie);
         $liquidatorAssetBalance1 = IERC20Partial(token1).balanceOf(Charlie);
 
-        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(
+        ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(
             Alice,
             false,
             $posIdLists[1]
@@ -6533,7 +6545,7 @@ contract PanopticPoolTest is PositionUtils {
                 $shortPremia
             );
 
-            ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(
+            ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(
                 Alice,
                 false,
                 $posIdLists[1]
@@ -6974,7 +6986,7 @@ contract PanopticPoolTest is PositionUtils {
         TWAPtick = pp.getUniV3TWAP_();
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-        ($shortPremia, $longPremia, $positionBalanceArray) = pp.calculateAccumulatedFeesBatch(
+        ($shortPremia, $longPremia, $positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Alice,
             false,
             $posIdLists[1]
@@ -7108,7 +7120,7 @@ contract PanopticPoolTest is PositionUtils {
         $liquidatorAssetBalance0 = IERC20Partial(token0).balanceOf(Charlie);
         $liquidatorAssetBalance1 = IERC20Partial(token1).balanceOf(Charlie);
 
-        ($shortPremia, $longPremia, ) = pp.calculateAccumulatedFeesBatch(
+        ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(
             Alice,
             false,
             $posIdLists[1]

--- a/test/foundry/test_periphery/PanopticHelper.sol
+++ b/test/foundry/test_periphery/PanopticHelper.sol
@@ -57,7 +57,7 @@ contract PanopticHelper {
             LeftRightUnsigned shortPremium,
             LeftRightUnsigned longPremium,
             uint256[2][] memory positionBalanceArray
-        ) = pool.calculateAccumulatedFeesBatch(account, false, positionIdList);
+        ) = pool.getAccumulatedFeesAndPositionsData(account, false, positionIdList);
 
         // Query the current and required collateral amounts for the two tokens
         LeftRightUnsigned tokenData0 = pool.collateralToken0().getAccountMarginDetails(
@@ -94,7 +94,7 @@ contract PanopticHelper {
         TokenId[] calldata positionIdList
     ) external view returns (int256 value0, int256 value1) {
         // Compute premia for all options (includes short+long premium)
-        (, , uint256[2][] memory positionBalanceArray) = pool.calculateAccumulatedFeesBatch(
+        (, , uint256[2][] memory positionBalanceArray) = pool.getAccumulatedFeesAndPositionsData(
             account,
             false,
             positionIdList
@@ -152,7 +152,7 @@ contract PanopticHelper {
         TokenId[] memory tokenIdList = new TokenId[](1);
         tokenIdList[0] = tokenId;
 
-        (, , uint256[2][] memory positionBalanceArray) = pool.calculateAccumulatedFeesBatch(
+        (, , uint256[2][] memory positionBalanceArray) = pool.getAccumulatedFeesAndPositionsData(
             account,
             false,
             tokenIdList


### PR DESCRIPTION
Past this commit, no logic changes can be deployed until they are re-audited and released as a new version. 

A few very minor changes in response to our final C4 audited are included in the diff here. The size of the diff is six (significant) lines of code. The only change that will have effects post-deployment(`maxWithdraw`/`maxRedeem`) is not within the scope of changes for our Uniswap V4 port (v1.1), so that will be reviewed in our upcoming Cantina audit.

Changelog:
- Return 0 instead of reverting when `s_poolAssets == 0` to comply with EIP-4626. I wanted to see if I could get away with not handling this in #134 because as far as I was aware it was impossible for `s_poolAssets` to reach zero. It is true that withdrawing the 1 virtual asset is impossible, however, one of our auditors made the valid point that it *can* be moved to `s_inAMM` temporarily if someone donates one asset to the pool and creates a position collateralized in the other token borrowing the entire stock of `s_poolAssets`. The only impacts this has are:
	- `maxRedeem` and `maxWithdraw` revert instead of returning zero in a few edge cases when no assets are available to withdraw, which could potentially confuse integrating contracts or frontends (though this could be easily resolved by depositing 1 token or creating a long position)
	- The *standard* ERC-4626 functions `redeem` and `withdraw` will revert with a different error than usual when this is the case. EIP-4626 does not define standard errors, so this is not a problem.
- Deploy the `CollateralTracker` instances in the factory using CREATE2 to ensure all system contracts have address spaces segregated by Uniswap pool. 
	- This was actually a reiteration of [this QA finding](https://github.com/code-423n4/2024-04-panoptic-findings/issues/573) from our April audit describing an extraordinarily unlikely scenario involving a large reorg redirecting a user's collateral deposit into a CollateralTracker with the same address, but owned by a different (malicious) Panoptic pool. 	
	- The attack remains extremely unlikely, but while writing my rebuttal I realized that a far more likely scenario involves a user submitting a collateral deposit and a pool deployment (perhaps a token launcher) in the same transaction and having their transaction fail because someone else deployed an unrelated pool first.
	- Or, someone could submit an underpriced pair deployment + collateral deposit transactions to the mempool and have their deployment frontrun by a malicious pool.
	- These aren't really realistic scenarios (and impacts are limited to interception of one or two (likely small) collateral deposits) with our current frontend setup, but might affect UX at some unspecified point in the future and I'm tired of auditors bugging me about it.
- Fixed an incorrect/outdated docstring.