### PR TITLE
feat: improve premium settlement, force exercise, and haircut APIs

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1002,20 +1002,20 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
     /// @param isCovered Whether the option was minted as covered (no swap occured if ITM)
-    /// @return utilization The final utilization of the collateral vault
+    /// @return The final utilization of the collateral vault
+    /// @return The total amount of commission (base rate + ITM spread) paid
     function takeCommissionAddData(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount,
         bool isCovered
-    ) external onlyPanopticPool returns (uint32 utilization) {
+    ) external onlyPanopticPool returns (uint32, uint128) {
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
-            // constrict premium to only assets not belonging to PLPs (i.e premium paid by sellers or collected from the pool earlier)
-            int256 tokenToPay = _getExchangedAmount(
+            (int256 tokenToPay, uint128 commission) = _getExchangedAmount(
                 longAmount,
                 shortAmount,
                 swappedAmount,
@@ -1045,7 +1045,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_poolAssets = uint256(updatedAssets).toUint128();
             s_inAMM = uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)).toUint128();
 
-            utilization = uint32(_poolUtilization());
+            return (uint32(_poolUtilization()), commission);
         }
     }
 
@@ -1103,38 +1103,31 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param swappedAmount The amount of tokens moved during creation of the option position
     /// @param isCovered Whether the option was minted as covered (no swap occured if ITM)
     /// @return exchangedAmount The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
+    /// @return commission The total commission (base rate + ITM spread) paid for minting the option
     function _getExchangedAmount(
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount,
         bool isCovered
-    ) internal view returns (int256 exchangedAmount) {
-        // If amount swapped is positive, the amount of tokens to pay is the ITM amount
-
+    ) internal view returns (int256, uint128) {
         unchecked {
-            // intrinsic value is the amount that need to be exchanged due to minting in-the-money
             int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
 
-            if (intrinsicValue != 0) {
-                // the swap commission is paid on the intrinsic value (if a swap occured -- users who mint covered options with their own collateral do not pay this fee)
-                uint256 swapCommission = isCovered
-                    ? 0
-                    : Math.unsafeDivRoundingUp(
-                        s_ITMSpreadFee * uint256(Math.abs(intrinsicValue)),
-                        DECIMALS * 100
-                    );
+            // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
+            uint256 commission = Math.unsafeDivRoundingUp(
+                uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
+                DECIMALS
+            ) +
+                (
+                    intrinsicValue == 0 || isCovered
+                        ? 0
+                        : Math.unsafeDivRoundingUp(
+                            s_ITMSpreadFee * uint256(Math.abs(intrinsicValue)),
+                            DECIMALS * 100
+                        )
+                );
 
-                // set the exchanged amount to the sum of the intrinsic value and swapCommission
-                exchangedAmount = intrinsicValue + int256(swapCommission);
-            }
-
-            // compute total commission amount = commission rate + spread fee
-            exchangedAmount += int256(
-                Math.unsafeDivRoundingUp(
-                    uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
-                    DECIMALS
-                )
-            );
+            return (intrinsicValue + int256(commission), uint128(commission));
         }
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1102,8 +1102,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param shortAmount The amount of short options held
     /// @param swappedAmount The amount of tokens moved during creation of the option position
     /// @param isCovered Whether the option was minted as covered (no swap occured if ITM)
-    /// @return exchangedAmount The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
-    /// @return commission The total commission (base rate + ITM spread) paid for minting the option
+    /// @return The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
+    /// @return The total commission (base rate + ITM spread) paid for minting the option
     function _getExchangedAmount(
         int128 longAmount,
         int128 shortAmount,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -721,7 +721,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @param positionIdList The list of option positions to close
     /// @return netPaid The net amount of tokens paid after closing the positions
-    /// @return premiasByLeg The amount of premia paid by the user for each leg of the position
+    /// @return premiasByLeg The amount of premia settled by the user for each leg of the position
     function _burnAllOptionsFrom(
         address owner,
         int24 tickLimitLow,
@@ -753,7 +753,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @return paidAmounts The net amount of tokens paid after closing the position
-    /// @return premiaByLeg The amount of premia paid by the user for each leg of the position
+    /// @return premiaByLeg The amount of premia settled by the user for each leg of the position
     function _burnOptions(
         bool commitLongSettled,
         TokenId tokenId,
@@ -763,9 +763,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
         uint128 positionSize = s_positionBalance[owner][tokenId].positionSize();
 
-        LeftRightSigned premiaOwed;
         // burn position and do exercise checks
-        (premiaOwed, premiaByLeg, paidAmounts) = _burnAndHandleExercise(
+        (premiaByLeg, paidAmounts) = _burnAndHandleExercise(
             commitLongSettled,
             tickLimitLow,
             tickLimitHigh,
@@ -863,8 +862,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tokenId The option position to burn
     /// @param positionSize The size of the option position, expressed in terms of the asset
     /// @param owner The owner of the option position
-    /// @return realizedPremia The net premia paid/received from the option position
-    /// @return premiaByLeg The premia paid by the user for each leg of the option position
+    /// @return premiaByLeg The premia settled by the user for each leg of the option position
     /// @return paidAmounts The net amount of tokens paid after closing the position
     function _burnAndHandleExercise(
         bool commitLongSettled,
@@ -873,14 +871,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         TokenId tokenId,
         uint128 positionSize,
         address owner
-    )
-        internal
-        returns (
-            LeftRightSigned realizedPremia,
-            LeftRightSigned[4] memory premiaByLeg,
-            LeftRightSigned paidAmounts
-        )
-    {
+    ) internal returns (LeftRightSigned[4] memory premiaByLeg, LeftRightSigned paidAmounts) {
         // if safeMode, enforce covered at assignment
         if (isSafeMode()) {
             if (tickLimitLow > tickLimitHigh) {
@@ -891,6 +882,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .burnTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
+        LeftRightSigned realizedPremia;
         (realizedPremia, premiaByLeg) = _updateSettlementPostBurn(
             owner,
             tokenId,
@@ -1797,8 +1789,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param collectedByLeg The amount of tokens collected in the corresponding chunk for each leg of the position
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage
-    /// @return realizedPremia The amount of premia owed to the user
-    /// @return premiaByLeg The amount of premia owed to the user for each leg of the position
+    /// @return realizedPremia The amount of premia settled by the user
+    /// @return premiaByLeg The amount of premia settled by the user for each leg of the position
     function _updateSettlementPostBurn(
         address owner,
         TokenId tokenId,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -76,17 +76,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
     /// @notice Emitted when an option is minted.
     /// @param recipient User that minted the option
-    /// @param positionSize The number of contracts minted, expressed in terms of the asset
     /// @param tokenId TokenId of the created option
-    /// @param poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
-    /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
-    /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
+    /// @param balanceData The `PositionBalance` data for `tokenId` containing the number of contracts, pool utilizations, and ticks at mint
     /// @param commissions The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
     event OptionMinted(
         address indexed recipient,
-        uint128 positionSize,
         TokenId indexed tokenId,
-        uint128 poolUtilizations,
+        PositionBalance balanceData,
         LeftRightUnsigned commissions
     );
 
@@ -607,20 +603,21 @@ contract PanopticPool is ERC1155Holder, Multicall {
             if (medianData != 0) s_miniMedian = medianData;
         }
 
-        // update the users options balance of position `tokenId`
-        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
-        // NOTE: cannot add the tickData yet because it is computed in _validateSolvency
-        s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
+        PositionBalance balanceData = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
             tickData
         );
 
+        // update the users options balance of position `tokenId`
+        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
+        s_positionBalance[msg.sender][tokenId] = balanceData;
+
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         _checkSolvency(msg.sender, positionIdList, tickData, BP_DECREASE_BUFFER);
 
-        emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations, commissions);
+        emit OptionMinted(msg.sender, tokenId, balanceData, commissions);
     }
 
     /// @notice Move all the required liquidity to/from the AMM and settle any required collateral deltas.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -81,11 +81,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
+    /// @param commissions The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
     event OptionMinted(
         address indexed recipient,
         uint128 positionSize,
         TokenId indexed tokenId,
-        uint128 poolUtilizations
+        uint128 poolUtilizations,
+        LeftRightUnsigned commissions
     );
 
     /*//////////////////////////////////////////////////////////////
@@ -576,7 +578,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             revert Errors.PositionAlreadyMinted();
 
         // Mint in the SFPM and update state of collateral
-        uint32 poolUtilizations = _mintInSFPMAndUpdateCollateral(
+        (uint32 poolUtilizations, LeftRightUnsigned commissions) = _mintInSFPMAndUpdateCollateral(
             tokenId,
             positionSize,
             effectiveLiquidityLimitX32,
@@ -584,23 +586,26 @@ contract PanopticPool is ERC1155Holder, Multicall {
             tickLimitHigh
         );
 
-        (
-            int24 currentTick,
-            int24 fastOracleTick,
-            int24 slowOracleTick,
-            int24 lastObservedTick,
-            uint256 medianData
-        ) = PanopticMath.getOracleTicks(s_univ3pool, s_miniMedian);
+        uint96 tickData;
+        {
+            (
+                int24 currentTick,
+                int24 fastOracleTick,
+                int24 slowOracleTick,
+                int24 lastObservedTick,
+                uint256 medianData
+            ) = PanopticMath.getOracleTicks(s_univ3pool, s_miniMedian);
 
-        uint96 tickData = PositionBalanceLibrary.packTickData(
-            currentTick,
-            fastOracleTick,
-            slowOracleTick,
-            lastObservedTick
-        );
+            tickData = PositionBalanceLibrary.packTickData(
+                currentTick,
+                fastOracleTick,
+                slowOracleTick,
+                lastObservedTick
+            );
 
-        // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
-        if (medianData != 0) s_miniMedian = medianData;
+            // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
+            if (medianData != 0) s_miniMedian = medianData;
+        }
 
         // update the users options balance of position `tokenId`
         // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
@@ -608,14 +613,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
         s_positionBalance[msg.sender][tokenId] = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
-            uint96(tickData)
+            tickData
         );
 
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         _checkSolvency(msg.sender, positionIdList, tickData, BP_DECREASE_BUFFER);
 
-        emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations);
+        emit OptionMinted(msg.sender, positionSize, tokenId, poolUtilizations, commissions);
     }
 
     /// @notice Move all the required liquidity to/from the AMM and settle any required collateral deltas.
@@ -624,15 +629,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity`
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
-    /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool) at the time of minting,
+    /// @return poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool) at the time of minting,
     /// right 64bits for token0 and left 64bits for token1. When safeMode is active, it returns 100% pool utilization for both tokens
+    /// @return commissions The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
     function _mintInSFPMAndUpdateCollateral(
         TokenId tokenId,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
         int24 tickLimitLow,
         int24 tickLimitHigh
-    ) internal returns (uint32) {
+    ) internal returns (uint32 poolUtilizations, LeftRightUnsigned commissions) {
         bool safeMode = isSafeMode();
 
         // if safeMode, enforce covered deployment
@@ -652,18 +658,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
             effectiveLiquidityLimitX32
         );
 
-        uint32 poolUtilizations = _payCommissionAndWriteData(
+        (poolUtilizations, commissions) = _payCommissionAndWriteData(
             tokenId,
             positionSize,
             totalSwapped,
             tickLimitLow < tickLimitHigh
         );
 
-        if (safeMode) {
-            return uint32(10_000 + (10_000 << 16));
-        } else {
-            return poolUtilizations;
-        }
+        if (safeMode) poolUtilizations = uint32(10_000 + (10_000 << 16));
     }
 
     /// @notice Take the commission fees for minting `tokenId` and settle any other required collateral deltas.
@@ -674,24 +676,25 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
+    /// @return The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
         LeftRightSigned totalSwapped,
         bool isCovered
-    ) internal returns (uint32) {
+    ) internal returns (uint32, LeftRightUnsigned) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        uint32 utilization0 = s_collateralToken0.takeCommissionAddData(
+        (uint32 utilization0, uint128 commission0) = s_collateralToken0.takeCommissionAddData(
             msg.sender,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
             totalSwapped.rightSlot(),
             isCovered
         );
-        uint32 utilization1 = s_collateralToken1.takeCommissionAddData(
+        (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
             msg.sender,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
@@ -701,7 +704,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // return pool utilizations as two uint16 (pool Utilization is always < 10000)
         unchecked {
-            return utilization0 + (utilization1 << 16);
+            return (
+                utilization0 + (utilization1 << 16),
+                LeftRightUnsigned.wrap(commission0).toLeftSlot(commission1)
+            );
         }
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -55,10 +55,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @notice Emitted when premium is settled independent of a mint/burn (e.g. during `settleLongPremium`).
     /// @param user Address of the owner of the settled position
     /// @param tokenId TokenId of the settled position
+    /// @param legIndex The leg index of `tokenId` that the premium was settled for
     /// @param settledAmounts LeftRight encoding for the amount of premium settled for token0 (right slot) and token1 (left slot)
     event PremiumSettled(
         address indexed user,
         TokenId indexed tokenId,
+        uint256 legIndex,
         LeftRightSigned settledAmounts
     );
 
@@ -66,12 +68,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param recipient User that burnt the option
     /// @param positionSize The number of contracts burnt, expressed in terms of the asset
     /// @param tokenId TokenId of the burnt option
-    /// @param premia LeftRight packing for the amount of premia collected for token0 (right) and token1 (left)
+    /// @param premiaByLeg LeftRight packing for the amount of premia settled for token0 (right) and token1 (left) for each leg of `tokenId`
     event OptionBurnt(
         address indexed recipient,
         uint128 positionSize,
         TokenId indexed tokenId,
-        LeftRightSigned premia
+        LeftRightSigned[4] premiaByLeg
     );
 
     /// @notice Emitted when an option is minted.
@@ -719,7 +721,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @param positionIdList The list of option positions to close
     /// @return netPaid The net amount of tokens paid after closing the positions
-    /// @return premiasByLeg The amount of premia owed to the user for each leg of the position
+    /// @return premiasByLeg The amount of premia paid by the user for each leg of the position
     function _burnAllOptionsFrom(
         address owner,
         int24 tickLimitLow,
@@ -751,7 +753,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @return paidAmounts The net amount of tokens paid after closing the position
-    /// @return premiaByLeg The amount of premia owed to the user for each leg of the position
+    /// @return premiaByLeg The amount of premia paid by the user for each leg of the position
     function _burnOptions(
         bool commitLongSettled,
         TokenId tokenId,
@@ -772,7 +774,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             owner
         );
 
-        emit OptionBurnt(owner, positionSize, tokenId, premiaOwed);
+        emit OptionBurnt(owner, positionSize, tokenId, premiaByLeg);
     }
 
     /// @notice Validates the solvency of `user`.
@@ -862,7 +864,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param positionSize The size of the option position, expressed in terms of the asset
     /// @param owner The owner of the option position
     /// @return realizedPremia The net premia paid/received from the option position
-    /// @return premiaByLeg The premia owed to the user for each leg of the option position
+    /// @return premiaByLeg The premia paid by the user for each leg of the option position
     /// @return paidAmounts The net amount of tokens paid after closing the position
     function _burnAndHandleExercise(
         bool commitLongSettled,
@@ -1074,36 +1076,31 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
     /// @notice Force the exercise of a single position. Exercisor will have to pay a fee to the force exercisee.
     /// @param account Address of the distressed account
-    /// @param touchedId List of position to be force exercised. Can only contain one tokenId, written as `[tokenId]`
+    /// @param tokenId The position to be force exercised; this position must contain at least one out-of-range long leg
     /// @param positionIdListExercisee Post-burn list of open positions in the exercisee's (`account`) account
     /// @param positionIdListExercisor List of open positions in the exercisor's (`msg.sender`) account
     function forceExercise(
         address account,
-        TokenId[] calldata touchedId,
+        TokenId tokenId,
         TokenId[] calldata positionIdListExercisee,
         TokenId[] calldata positionIdListExercisor
     ) external {
-        // revert if multiple positions are specified
-        // the reason why the singular touchedId is an array is so it composes well with the rest of the system
-        // `_calculateAccumulatedPremia` expects a list of positions to be touched, and this is the only way to pass a single position
-        if (touchedId.length != 1) revert Errors.InputListFail();
-
         // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
         _validatePositionList(msg.sender, positionIdListExercisor, 0);
 
         int24 twapTick = getUniV3TWAP();
 
         // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-        touchedId[0].validateIsExercisable(twapTick);
+        tokenId.validateIsExercisable(twapTick);
 
         LeftRightSigned exerciseFees;
         {
             (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
 
-            uint128 positionSize = s_positionBalance[account][touchedId[0]].positionSize();
+            uint128 positionSize = s_positionBalance[account][tokenId].positionSize();
 
             (LeftRightSigned longAmounts, ) = PanopticMath.computeExercisedAmounts(
-                touchedId[0],
+                tokenId,
                 positionSize
             );
 
@@ -1112,7 +1109,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             exerciseFees = s_collateralToken0.exerciseCost(
                 currentTick,
                 twapTick,
-                touchedId[0],
+                tokenId,
                 positionSize,
                 longAmounts
             );
@@ -1124,7 +1121,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // Exercise the option
         // Turn off ITM swapping to prevent swap at potentially unfavorable price
-        _burnAllOptionsFrom(account, MIN_SWAP_TICK, MAX_SWAP_TICK, COMMIT_LONG_SETTLED, touchedId);
+        _burnOptions(COMMIT_LONG_SETTLED, tokenId, account, MIN_SWAP_TICK, MAX_SWAP_TICK);
 
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
@@ -1152,7 +1149,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         if (positionIdListExercisor.length > 0)
             _validateSolvency(msg.sender, positionIdListExercisor, BP_DECREASE_BUFFER);
 
-        emit ForcedExercised(msg.sender, account, touchedId[0], exerciseFees);
+        emit ForcedExercised(msg.sender, account, tokenId, exerciseFees);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1595,7 +1592,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(realizedPremia)))
             );
 
-            emit PremiumSettled(owner, tokenId, realizedPremia);
+            emit PremiumSettled(owner, tokenId, legIndex, realizedPremia);
         }
 
         // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
@@ -1878,6 +1875,11 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 // add available premium to amount that should be settled
                 realizedPremia = realizedPremia.add(
                     LeftRightSigned.wrap(int256(LeftRightUnsigned.unwrap(availablePremium)))
+                );
+
+                // update the base `premiaByLeg` value to reflect the amount of premium that will actually be settled
+                premiaByLeg[leg] = LeftRightSigned.wrap(
+                    int256(LeftRightUnsigned.unwrap(availablePremium))
                 );
 
                 // We need to adjust the grossPremiumLast value such that the result of

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1235,7 +1235,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         // If the current feesBase is close or identical to the stored one, the amountToCollect can be negative.
         // This is because the stored feesBase is rounded up, and the current feesBase is rounded down.
         // When this is the case, we want to behave as if there are 0 fees, so we just rectify the values.
-        LeftRightSigned amountToCollect = _getFeesBase(
+        LeftRightUnsigned amountToCollect = _getFeesBase(
             univ3pool,
             startingLiquidity,
             liquidityChunk,
@@ -1243,10 +1243,18 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         ).subRect(s_accountFeesBase[positionKey]);
 
         if (isLong == 1) {
-            amountToCollect = amountToCollect.sub(movedInLeg);
+            amountToCollect = LeftRightUnsigned.wrap(
+                uint256(
+                    LeftRightSigned.unwrap(
+                        LeftRightSigned.wrap(int256(LeftRightUnsigned.unwrap(amountToCollect))).sub(
+                            movedInLeg
+                        )
+                    )
+                )
+            );
         }
 
-        if (LeftRightSigned.unwrap(amountToCollect) != 0) {
+        if (LeftRightUnsigned.unwrap(amountToCollect) != 0) {
             // first collect amounts from Uniswap corresponding to this position
             // Collect only if there was existing startingLiquidity=liquidities.rightSlot() at that position: collect all fees
 
@@ -1255,8 +1263,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                 msg.sender,
                 liquidityChunk.tickLower(),
                 liquidityChunk.tickUpper(),
-                uint128(amountToCollect.rightSlot()),
-                uint128(amountToCollect.leftSlot())
+                amountToCollect.rightSlot(),
+                amountToCollect.leftSlot()
             );
 
             // moved will be negative if the leg was long (funds left the caller, don't count it in collected fees)
@@ -1453,11 +1461,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                 // This is because the stored feesBase is rounded up, and the current feesBase is rounded down.
                 // When this is the case, we want to behave as if there are 0 fees, so we just rectify the values.
                 // Guaranteed to be positive, so swap to unsigned type
-                amountToCollect = LeftRightUnsigned.wrap(
-                    uint256(
-                        LeftRightSigned.unwrap(feesBase.subRect(s_accountFeesBase[positionKey]))
-                    )
-                );
+                amountToCollect = feesBase.subRect(s_accountFeesBase[positionKey]);
             }
 
             (LeftRightUnsigned premiumOwed, LeftRightUnsigned premiumGross) = _getPremiaDeltas(

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 // Interfaces
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
+import {PanopticPool} from "@contracts/PanopticPool.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IUniswapV3Pool} from "univ3-core/interfaces/IUniswapV3Pool.sol";
 // Libraries
@@ -884,8 +885,7 @@ library PanopticMath {
             // Ignore any surplus collateral - the liquidatee is either solvent or it converts to <1 unit of the other token
             int256 collateralDelta0 = -Math.min(collateralRemaining.rightSlot(), 0);
             int256 collateralDelta1 = -Math.min(collateralRemaining.leftSlot(), 0);
-            int256 haircut0;
-            int256 haircut1;
+            LeftRightSigned haircutBase;
 
             // if the premium in the same token is not enough to cover the loss and there is a surplus of the other token,
             // the liquidator will provide the tokens (reflected in the bonus amount) & receive compensation in the other token
@@ -911,8 +911,9 @@ library PanopticMath {
                     )
                 );
 
-                haircut0 = longPremium.rightSlot();
-                haircut1 = protocolLoss1 + collateralDelta1;
+                haircutBase = LeftRightSigned.wrap(longPremium.rightSlot()).toLeftSlot(
+                    int128(protocolLoss1 + collateralDelta1)
+                );
             } else if (
                 longPremium.leftSlot() < collateralDelta1 &&
                 longPremium.rightSlot() > collateralDelta0
@@ -935,39 +936,61 @@ library PanopticMath {
                     )
                 );
 
-                haircut0 = collateralDelta0 + protocolLoss0;
-                haircut1 = longPremium.leftSlot();
+                haircutBase = LeftRightSigned
+                    .wrap(int128(protocolLoss0 + collateralDelta0))
+                    .toLeftSlot(longPremium.leftSlot());
             } else {
                 // for each token, haircut until the protocol loss is mitigated or the premium paid is exhausted
-                haircut0 = Math.min(collateralDelta0, longPremium.rightSlot());
-                haircut1 = Math.min(collateralDelta1, longPremium.leftSlot());
+                haircutBase = LeftRightSigned
+                    .wrap(int128(Math.min(collateralDelta0, longPremium.rightSlot())))
+                    .toLeftSlot(int128(Math.min(collateralDelta1, longPremium.leftSlot())));
 
                 collateralDelta0 = 0;
                 collateralDelta1 = 0;
             }
 
-            {
-                address _liquidatee = liquidatee;
-                if (haircut0 != 0) collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircut0));
-                if (haircut1 != 0) collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircut1));
-            }
-
+            // total haircut after rounding up prorated haircut amounts for each leg
+            LeftRightUnsigned haircutTotal;
+            address _liquidatee = liquidatee;
             for (uint256 i = 0; i < positionIdList.length; i++) {
                 TokenId tokenId = positionIdList[i];
                 LeftRightSigned[4][] memory _premiasByLeg = premiasByLeg;
                 for (uint256 leg = 0; leg < tokenId.countLegs(); ++leg) {
                     if (tokenId.isLong(leg) == 1) {
-                        mapping(bytes32 chunkKey => LeftRightUnsigned settledTokens)
-                            storage _settledTokens = settledTokens;
+                        // calculate prorated haircut amounts to revoke from settled and subtract from haircut req
+                        LeftRightSigned haircutAmounts = LeftRightSigned
+                            .wrap(
+                                int128(
+                                    uint128(
+                                        Math.unsafeDivRoundingUp(
+                                            uint128(-_premiasByLeg[i][leg].rightSlot()) *
+                                                uint256(uint128(haircutBase.rightSlot())),
+                                            uint128(longPremium.rightSlot())
+                                        )
+                                    )
+                                )
+                            )
+                            .toLeftSlot(
+                                int128(
+                                    uint128(
+                                        Math.unsafeDivRoundingUp(
+                                            uint128(-_premiasByLeg[i][leg].leftSlot()) *
+                                                uint256(uint128(haircutBase.leftSlot())),
+                                            uint128(longPremium.leftSlot())
+                                        )
+                                    )
+                                )
+                            );
 
-                        // calculate amounts to revoke from settled and subtract from haircut req
-                        uint256 settled0 = Math.unsafeDivRoundingUp(
-                            uint128(-_premiasByLeg[i][leg].rightSlot()) * uint256(haircut0),
-                            uint128(longPremium.rightSlot())
+                        haircutTotal = haircutTotal.add(
+                            LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(haircutAmounts)))
                         );
-                        uint256 settled1 = Math.unsafeDivRoundingUp(
-                            uint128(-_premiasByLeg[i][leg].leftSlot()) * uint256(haircut1),
-                            uint128(longPremium.leftSlot())
+
+                        emit PanopticPool.PremiumSettled(
+                            _liquidatee,
+                            tokenId,
+                            leg,
+                            LeftRightSigned.wrap(0).sub(haircutAmounts)
                         );
 
                         bytes32 chunkKey = keccak256(
@@ -980,21 +1003,19 @@ library PanopticMath {
 
                         // The long premium is not commited to storage during the liquidation, so we add the entire adjusted amount
                         // for the haircut directly to the accumulator
-                        settled0 = Math.max(
-                            0,
-                            uint128(-_premiasByLeg[i][leg].rightSlot()) - settled0
-                        );
-                        settled1 = Math.max(
-                            0,
-                            uint128(-_premiasByLeg[i][leg].leftSlot()) - settled1
-                        );
-
-                        _settledTokens[chunkKey] = _settledTokens[chunkKey].add(
-                            LeftRightUnsigned.wrap(uint128(settled0)).toLeftSlot(uint128(settled1))
+                        settledTokens[chunkKey] = settledTokens[chunkKey].add(
+                            (LeftRightSigned.wrap(0).sub(_premiasByLeg[i][leg])).subRect(
+                                haircutAmounts
+                            )
                         );
                     }
                 }
             }
+
+            if (haircutTotal.rightSlot() != 0)
+                collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
+            if (haircutTotal.leftSlot() != 0)
+                collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
 
             return
                 LeftRightSigned.wrap(0).toRightSlot(int128(collateralDelta0)).toLeftSlot(

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -956,7 +956,10 @@ library PanopticMath {
                 TokenId tokenId = positionIdList[i];
                 LeftRightSigned[4][] memory _premiasByLeg = premiasByLeg;
                 for (uint256 leg = 0; leg < tokenId.countLegs(); ++leg) {
-                    if (tokenId.isLong(leg) == 1) {
+                    if (
+                        tokenId.isLong(leg) == 1 &&
+                        LeftRightSigned.unwrap(_premiasByLeg[i][leg]) != 0
+                    ) {
                         // calculate prorated haircut amounts to revoke from settled and subtract from haircut req
                         LeftRightSigned haircutAmounts = LeftRightSigned
                             .wrap(

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -250,7 +250,7 @@ library LeftRightLibrary {
     function subRect(
         LeftRightSigned x,
         LeftRightSigned y
-    ) internal pure returns (LeftRightSigned z) {
+    ) internal pure returns (LeftRightUnsigned z) {
         unchecked {
             int256 left256 = int256(x.leftSlot()) - y.leftSlot();
             int128 left128 = int128(left256);
@@ -261,8 +261,8 @@ library LeftRightLibrary {
             if (left128 != left256 || right128 != right256) revert Errors.UnderOverFlow();
 
             return
-                z.toRightSlot(int128(Math.max(right128, 0))).toLeftSlot(
-                    int128(Math.max(left128, 0))
+                z.toRightSlot(uint128(uint256((Math.max(right128, 0))))).toLeftSlot(
+                    uint128(uint256((Math.max(left128, 0))))
                 );
         }
     }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -642,7 +642,7 @@ contract Misctest is Test, PositionUtils {
         PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        pp.forceExercise(Alice, $posIdList, new TokenId[](0), new TokenId[](0));
+        pp.forceExercise(Alice, $posIdList[0], new TokenId[](0), new TokenId[](0));
     }
 
     function test_success_ITMspreadfee_0_01bp() public {

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5339,7 +5339,7 @@ contract PanopticPoolTest is PositionUtils {
         exerciseFeeAmounts[0] += (longAmounts.rightSlot() * (-exerciseFee)) / 10_000;
         exerciseFeeAmounts[1] += (longAmounts.leftSlot() * (-exerciseFee)) / 10_000;
 
-        pp.forceExercise(Alice, posIdList, new TokenId[](0), new TokenId[](0));
+        pp.forceExercise(Alice, posIdList[0], new TokenId[](0), new TokenId[](0));
 
         assertApproxEqAbs(
             int256(ct0.balanceOf(Bob)) - int256(uint256(type(uint104).max)),
@@ -5678,7 +5678,7 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             vm.startPrank(Bob);
-            pp.forceExercise(Alice, $posIdLists[2], $posIdLists[3], $posIdLists[0]);
+            pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], $posIdLists[0]);
 
             int256 balanceDelta0 = int256(ct0.balanceOf(Alice)) -
                 int256(lastCollateralBalance0[Alice]);
@@ -5745,7 +5745,7 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert();
-        pp.forceExercise(Alice, $posIdLists[2], $posIdLists[3], $posIdLists[0]);
+        pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], $posIdLists[0]);
     }
 
     function test_Fail_forceExercise_ExerciseeNotSolvent(
@@ -5889,7 +5889,7 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             vm.startPrank(Bob);
-            pp.forceExercise(Alice, $posIdLists[2], $posIdLists[3], new TokenId[](0));
+            pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], new TokenId[](0));
 
             int256 balanceDelta0 = int256(ct0.balanceOf(Alice)) -
                 int256(lastCollateralBalance0[Alice]);
@@ -5955,7 +5955,7 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert();
-        pp.forceExercise(Alice, $posIdLists[2], $posIdLists[3], new TokenId[](0));
+        pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], new TokenId[](0));
     }
 
     function test_Fail_forceExercise_InvalidExerciseeList(
@@ -6094,7 +6094,7 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.forceExercise(Alice, new TokenId[](0), $posIdLists[3], new TokenId[](0));
+        pp.forceExercise(Alice, TokenId.wrap(0), $posIdLists[3], new TokenId[](0));
     }
 
     function test_Fail_forceExercise_InvalidExercisorList(
@@ -6176,20 +6176,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId2;
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.forceExercise(Alice, new TokenId[](1), new TokenId[](0), posIdList);
-    }
-
-    function test_Fail_forceExercise_1PositionNotSpecified(
-        uint256 x,
-        TokenId[] memory touchedIds
-    ) public {
-        _initPool(x);
-
-        vm.assume(touchedIds.length != 1);
-
-        vm.expectRevert(Errors.InputListFail.selector);
-
-        pp.forceExercise(Alice, touchedIds, new TokenId[](0), new TokenId[](0));
+        pp.forceExercise(Alice, TokenId.wrap(0), new TokenId[](0), posIdList);
     }
 
     function test_Fail_forceExercise_PositionNotExercisable(uint256 x) public {
@@ -6229,7 +6216,7 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.NoLegsExercisable.selector);
-        pp.forceExercise(Alice, touchedIds, touchedIds, new TokenId[](0));
+        pp.forceExercise(Alice, touchedIds[0], touchedIds, new TokenId[](0));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -6053,48 +6053,35 @@ contract PanopticPoolTest is PositionUtils {
 
         // now we can mint the long option we are force exercising
         vm.startPrank(Alice);
+        $posIdLists[1].push(TokenId.wrap(0).addPoolId(poolId));
 
         for (uint256 i = 0; i < numLegs; ++i) {
-            $posIdLists[1].push(
-                TokenId.wrap(0).addPoolId(poolId).addLeg(
-                    0,
-                    1,
-                    isWETH,
-                    isLongs[i],
-                    tokenTypes[i],
-                    0,
-                    strikes[i],
-                    widths[i]
-                )
-            );
-
-            $posIdLists[3].push($posIdLists[1][$posIdLists[1].length - 1]);
-
-            if (
-                (TWAPtick < (numLegs == 1 ? tickLower : tickLowers[i]) ||
-                    TWAPtick >= (numLegs == 1 ? tickUpper : tickUppers[i])) &&
-                isLongs[i] == 1 &&
-                $posIdLists[2].length == 0
-            ) {
-                $posIdLists[2].push($posIdLists[1][$posIdLists[1].length - 1]);
-                $posIdLists[3].pop();
-            }
-
-            pp.mintOptions(
-                $posIdLists[1],
-                positionSize,
-                type(uint64).max,
-                Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+            $posIdLists[1][0] = $posIdLists[1][0].addLeg(
+                i,
+                1,
+                isWETH,
+                isLongs[i],
+                tokenTypes[i],
+                i,
+                strikes[i],
+                widths[i]
             );
         }
+
+        pp.mintOptions(
+            $posIdLists[1],
+            positionSize,
+            type(uint64).max,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
 
         twoWaySwap(swapSizeSeed);
 
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.forceExercise(Alice, TokenId.wrap(0), $posIdLists[3], new TokenId[](0));
+        pp.forceExercise(Alice, $posIdLists[1][0], $posIdLists[0], new TokenId[](0));
     }
 
     function test_Fail_forceExercise_InvalidExercisorList(

--- a/test/foundry/types/LeftRight.t.sol
+++ b/test/foundry/types/LeftRight.t.sol
@@ -319,7 +319,7 @@ contract LeftRightTest is Test {
                 harness.subRect(x, xx);
             } else {
                 // normal case
-                LeftRightSigned other = harness.subRect(x, xx);
+                LeftRightUnsigned other = harness.subRect(x, xx);
                 assertEq(int128(harness.leftSlot(other)), y - u > 0 ? y - u : int128(0));
                 assertEq(int128(harness.rightSlot(other)), z - v > 0 ? z - v : int128(0));
             }

--- a/test/foundry/types/harnesses/LeftRightHarness.sol
+++ b/test/foundry/types/harnesses/LeftRightHarness.sol
@@ -178,8 +178,8 @@ contract LeftRightHarness {
      * @param y the subtrahend
      * @return z the difference x - y
      */
-    function subRect(LeftRightSigned x, LeftRightSigned y) public pure returns (LeftRightSigned) {
-        LeftRightSigned r = LeftRightLibrary.subRect(x, y);
+    function subRect(LeftRightSigned x, LeftRightSigned y) public pure returns (LeftRightUnsigned) {
+        LeftRightUnsigned r = LeftRightLibrary.subRect(x, y);
         return r;
     }
 


### PR DESCRIPTION
@0xTARC and I were working through some subgraph sync issues, and I realized that we weren't emitting enough information to track the premium settlement state.

This PR adds the following event changes to allow tracking of per-chunk settlement states. Closing the loop here will also enable correct handling of premium haircuts on the subgraph:
- Emit premium by leg in `OptionBurned`
- Emit leg in `PremiumSettled` event for `settleLongPremium(user, tokenId, leg)`
- Emit a `PremiumSettled` event with *negative* for every leg haircut in `haircutPremia` during a liquidation

Also, `forceExercise` was still working with the exercised position in the format `TokenId[touchedId]`. The original reasoning behind that design decision is no longer valid (i.e., we no longer compute the fees for the singular force exercised position, which would require an array of positions in `calldata` to be passed into `calculateAccumulatedFeesBatch`), so we can save some gas and clean up the interface there a little by operating on `touchedId` directly.