### PR TITLE
Feat: More efficient uint128 packing using PackedUint.sol

### DIFF
--- a/contracts/types/PackedUint.sol
+++ b/contracts/types/PackedUint.sol
@@ -12,6 +12,7 @@ import "forge-std/Test.sol";
 library PackedUintLibrary {
     uint256 constant TWO_POW_119 = 2 ** 119;
     using PackedUintLibrary for uint256;
+
     /*//////////////////////////////////////////////////////////////
                               PACKING
     //////////////////////////////////////////////////////////////*/

--- a/contracts/types/PackedUint.sol
+++ b/contracts/types/PackedUint.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.24;
+
+// Libraries
+import {Errors} from "@libraries/Errors.sol";
+import {Math} from "@libraries/Math.sol";
+import "forge-std/Test.sol";
+
+/// @title Pack two separate data (each of 128bit) into a single 256-bit slot; 256bit-to-128bit packing methods.
+/// @author Axicon Labs Limited
+/// @notice Simple data type that divides a 256-bit word into two 128-bit slots.
+library PackedUintLibrary {
+    uint256 constant TWO_POW_119 = 2 ** 119;
+    using PackedUintLibrary for uint256;
+    /*//////////////////////////////////////////////////////////////
+                              PACKING
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Pack a uint256 into a uint128 using compression
+    /// @dev Stores the uint256 N as N = e * 2^n,
+    ///    where n is most significant bit and
+    ///    e is a X119 number
+    ///    we can recover N as:
+    ///        N = (e << n) >> 119
+    ///    We pack the value of n and e in a uint128 with:
+    ///        -n in the lower 8 bits
+    ///        -e in bits 8 to 128
+    /// @param self The uint256 value to be packed
+    /// @return The packed value in a uint128
+    function pack(uint256 self) internal pure returns (uint128) {
+        if (self == 0) return 0;
+        uint8 n = self.mostSignificantBit();
+        uint256 e = self.getMantissaX119(n);
+        return uint128((e << 8) + n);
+    }
+
+    /// @notice Unpack a uint128 into a uint256
+    /// @param self The packed uint128 value
+    /// @return The unpacked uint256 value
+    function unpack(uint128 self) internal pure returns (uint256) {
+        if (self == 0) return 0;
+        uint8 n = uint8(self & 0xFF);
+        uint120 e = uint120(self >> 8);
+        return Math.mulDiv(uint256(e), 2 ** n, TWO_POW_119);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                       Arithmetic Operations
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Add two packed uint128 numbers; revert on overflow
+    /// @param x The first packed uint128 addend
+    /// @param y The second packed uint128 addend
+    /// @return The packed uint128 sum of x and y
+    function add(uint128 x, uint128 y) internal pure returns (uint128) {
+        uint256 unpackedX = unpack(x);
+        uint256 unpackedY = unpack(y);
+        require((unpackedX < type(uint256).max - unpackedY), "Addition overflow");
+        uint256 sum = unpackedX + unpackedY;
+        return pack(sum);
+    }
+
+    /// @notice Subtract two packed uint128 numbers; revert on underflow
+    /// @param x The packed uint128 minuend
+    /// @param y The packed uint128 subtrahend
+    /// @return The packed uint128 difference of x and y
+    function sub(uint128 x, uint128 y) internal pure returns (uint128) {
+        uint256 unpackedX = unpack(x);
+        uint256 unpackedY = unpack(y);
+        require(unpackedX >= unpackedY, "Underflow");
+        uint256 difference;
+        unchecked {
+            difference = unpackedX - unpackedY;
+        }
+        return pack(difference);
+    }
+
+    /// @notice Multiply two packed uint128 numbers; revert on overflow
+    /// @param x The first packed uint128 factor
+    /// @param y The second packed uint128 factor
+    /// @return The packed uint128 product of x and y
+    function mul(uint128 x, uint128 y) internal pure returns (uint128) {
+        if ((unpack(x) == 0) || (unpack(y) == 0)) return 0;
+        uint256 unpackedX = unpack(x);
+        uint256 unpackedY = unpack(y);
+        require(
+            (unpackedY > 0 && unpackedX <= type(uint256).max / unpackedY) ||
+                (unpackedX > 0 && unpackedY <= type(uint256).max / unpackedX),
+            "Multiplication overflow"
+        );
+        uint256 product = unpackedX * unpackedY;
+        return pack(product);
+    }
+
+    /// @notice Divide two packed uint128 numbers; revert on division by zero
+    /// @param x The packed uint128 dividend
+    /// @param y The packed uint128 divisor
+    /// @return The packed uint128 quotient of x divided by y
+    function div(uint128 x, uint128 y) internal pure returns (uint128) {
+        uint256 unpackedX = unpack(x);
+        uint256 unpackedY = unpack(y);
+        require(unpackedY != 0, "Division by zero");
+        uint256 quotient = unpackedX / unpackedY;
+        return pack(quotient);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              MATH HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Find the position of the most significant bit in a uint256
+    /// @param self The uint256 value to analyze
+    /// @return r The position of the most significant bit (0-255)
+    function mostSignificantBit(uint256 self) internal pure returns (uint8 r) {
+        unchecked {
+            if (self >= 0x100000000000000000000000000000000) {
+                self >>= 128;
+                r += 128;
+            }
+            if (self >= 0x10000000000000000) {
+                self >>= 64;
+                r += 64;
+            }
+            if (self >= 0x100000000) {
+                self >>= 32;
+                r += 32;
+            }
+            if (self >= 0x10000) {
+                self >>= 16;
+                r += 16;
+            }
+            if (self >= 0x100) {
+                self >>= 8;
+                r += 8;
+            }
+            if (self >= 0x10) {
+                self >>= 4;
+                r += 4;
+            }
+            if (self >= 0x4) {
+                self >>= 2;
+                r += 2;
+            }
+            if (self >= 0x2) r += 1;
+        }
+    }
+
+    /// @notice compute the mantissa of the input N, where the mantissa is a X119 number
+    /// @dev uses Math.mulDiv, which allows for overflow as long as the final value is less than type(uint256).max
+    /// @param self The uint256 value to get the mantissa from
+    /// @param n The exponent of that number
+    /// @return e The mantissa
+    function getMantissaX119(uint256 self, uint8 n) internal pure returns (uint128) {
+        return uint128(Math.mulDiv(self, TWO_POW_119, 2 ** n));
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "panoptic-v1-core-private",
+  "name": "panoptic-next-core-private",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/test/foundry/types/PackedUint.t.sol
+++ b/test/foundry/types/PackedUint.t.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {PackedUintLibrary} from "@types/PackedUint.sol";
+
+contract PackedUintTest is Test {
+    using PackedUintLibrary for uint256;
+    using PackedUintLibrary for uint128;
+
+    function testPack256To128() public {
+        assertEq(uint256(0).pack(), 0);
+        assertEq(uint256(1).pack(), (2 ** 119) << (8 + 0));
+        assertEq(uint256(type(uint256).max).pack(), (uint128(type(uint120).max) << 8) + 255);
+
+        // Test some random values
+        for (uint i = 0; i < 100; i++) {
+            uint256 value = uint256(keccak256(abi.encode(i)));
+            uint128 packed = value.pack();
+            uint8 n = value.mostSignificantBit();
+            uint128 e = value.getMantissaX119(n);
+            assertEq(uint128(packed), (e << 8) + n);
+        }
+    }
+
+    function testPack256To128_packFuzz(uint256 x) public {
+        uint128 packed = x.pack();
+        uint8 n = x.mostSignificantBit();
+        uint128 e = x.getMantissaX119(n);
+        if (x == 0) {
+            assertEq(packed, 0);
+        } else {
+            assertEq(uint128(packed), (e << 8) + n);
+        }
+
+        uint256 newX = uint256(keccak256(abi.encode(x)));
+        packed = newX.pack();
+        n = newX.mostSignificantBit();
+        e = newX.getMantissaX119(n);
+        assertEq(uint128(packed), (e << 8) + n);
+    }
+
+    function testPackUnpack() public {
+        uint128 packed = uint256(0).pack();
+        assertEq(packed.unpack(), 0);
+        packed = uint256(1).pack();
+        assertEq(packed.unpack(), 1);
+        packed = uint256(type(uint256).max).pack();
+        assertApproxEqAbs(packed.unpack(), type(uint256).max, 2 ** (256 - 120) - 1);
+    }
+
+    function testPackUnpack_packFuzz(uint256 x) public {
+        uint128 packed = uint256(x).pack();
+        uint8 n = x.mostSignificantBit();
+        if (n >= 119) {
+            uint256 ppp = packed.unpack();
+            assertApproxEqAbs(packed.unpack(), x, 2 ** (n - 119));
+            assertApproxEqRel(packed.unpack(), x, 1); // accurate within 1/1e18
+        } else {
+            assertEq(packed.unpack(), x);
+        }
+    }
+
+    function testAdd() public {
+        uint128 a = uint256(1).pack();
+        uint128 b = uint128(2).pack();
+        assertEq(PackedUintLibrary.add(a, b).unpack(), 3);
+
+        a = uint256(type(uint256).max).pack();
+        b = uint256(70000 + uint256(type(uint136).max)).pack();
+
+        vm.expectRevert("Addition overflow");
+        PackedUintLibrary.add(a, b);
+    }
+
+    function testAdd_packFuzz(uint128 x, uint128 y) public {
+        x = (x % 256) + uint128(uint256(keccak256(abi.encode(x))) << 8);
+        y = (y % 256) + uint128(uint256(keccak256(abi.encode(y))) << 8);
+        vm.assume((x > 256) && (y > 256));
+        if (x.unpack() > type(uint256).max - y.unpack()) {
+            vm.expectRevert("Addition overflow");
+            PackedUintLibrary.add(x, y);
+        } else {
+            uint128 add0 = PackedUintLibrary.add(x, y);
+            assertApproxEqRel(add0.unpack(), x.unpack() + y.unpack(), 1);
+        }
+    }
+
+    function testSub() public {
+        uint128 a = uint128(3).pack();
+        uint128 b = uint128(2).pack();
+        assertEq(PackedUintLibrary.sub(a, b).unpack(), 1);
+
+        a = uint128(1).pack();
+        b = uint128(2).pack();
+        vm.expectRevert("Underflow");
+        PackedUintLibrary.sub(a, b);
+    }
+
+    function testSub_packFuzz(uint128 x, uint128 y) public {
+        x = (x % 256) + uint128(uint256(keccak256(abi.encode(x))) << 8);
+        y = (y % 256) + uint128(uint256(keccak256(abi.encode(y))) << 8);
+        vm.assume((x > 256) && (y > 256));
+
+        if (x.unpack() < y.unpack()) {
+            vm.expectRevert("Underflow");
+            PackedUintLibrary.sub(x, y);
+        } else {
+            uint128 sub0 = PackedUintLibrary.sub(x, y);
+            assertApproxEqRel(sub0.unpack(), x.unpack() - y.unpack(), 1);
+        }
+    }
+
+    function testMul() public {
+        uint128 a = uint128(3).pack();
+        uint128 b = uint128(2).pack();
+        assertEq(PackedUintLibrary.mul(a, b).unpack(), 6);
+
+        a = (type(uint256).max).pack();
+        b = (type(uint256).max).pack();
+        vm.expectRevert("Multiplication overflow");
+        PackedUintLibrary.mul(a, b);
+    }
+
+    function testMul_packFuzz(uint128 x, uint128 y) public {
+        x = (x % 256) + uint128(uint256(keccak256(abi.encode(x))) << 8);
+        y = (y % 256) + uint128(uint256(keccak256(abi.encode(y))) << 8);
+        console.log("xu, yu", x.unpack(), y.unpack());
+        vm.assume((x > 256) && (y > 256));
+        if (x.unpack() == 0 || y.unpack() == 0) {
+            assertEq(PackedUintLibrary.mul(x, y).unpack(), 0);
+        } else if (
+            (x.unpack() > type(uint256).max / y.unpack()) ||
+            (y.unpack() > type(uint256).max / x.unpack())
+        ) {
+            console2.log("expect overflox");
+            vm.expectRevert("Multiplication overflow");
+            PackedUintLibrary.mul(x, y);
+        } else {
+            console2.log("expect NO overflox");
+            assertApproxEqRel(PackedUintLibrary.mul(x, y).unpack(), x.unpack() * y.unpack(), 1);
+        }
+    }
+
+    function testDiv() public {
+        uint128 a = uint256(6).pack();
+        uint128 b = uint256(2).pack();
+        assertEq(PackedUintLibrary.div(a, b).unpack(), 3);
+
+        a = uint256(7).pack();
+        b = uint256(2).pack();
+        assertEq(PackedUintLibrary.div(a, b).unpack(), 3); // Integer division rounds down
+
+        a = uint128(1).pack();
+        b = uint128(0).pack();
+        vm.expectRevert("Division by zero");
+        PackedUintLibrary.div(a, b);
+    }
+
+    function testDiv_packFuzz(uint128 x, uint128 y) public {
+        x = (x % 256) + uint128(uint256(keccak256(abi.encode(x))) << 8);
+        y = (y % 256) + uint128(uint256(keccak256(abi.encode(y))) << 8);
+        vm.assume((x > 256) && (y > 256));
+
+        if (y.unpack() == 0) {
+            vm.expectRevert("Division by zero");
+            PackedUintLibrary.div(x, y);
+        } else {
+            assertApproxEqRel(PackedUintLibrary.div(x, y).unpack(), x.unpack() / y.unpack(), 1);
+        }
+    }
+
+    function testMostSignificantBit() public {
+        assertEq(PackedUintLibrary.mostSignificantBit(0), 0);
+        assertEq(PackedUintLibrary.mostSignificantBit(1), 0);
+        assertEq(PackedUintLibrary.mostSignificantBit(2), 1);
+        assertEq(PackedUintLibrary.mostSignificantBit(3), 1);
+        assertEq(PackedUintLibrary.mostSignificantBit(4), 2);
+        assertEq(PackedUintLibrary.mostSignificantBit(7), 2);
+        assertEq(PackedUintLibrary.mostSignificantBit(8), 3);
+        assertEq(PackedUintLibrary.mostSignificantBit(type(uint256).max), 255);
+    }
+}


### PR DESCRIPTION
## Intro

The current smart contract store various pieces of information inside a `LeftRight` packing -- ie. explicitly storing two `uint128` numbers into a single `uint256` word.

This works most of the time because we make sure the numbers being pcked are both smaller than `uint128`.

One location where the `uint128` get packed in a sub-optimal manner is in the SFPM's premiaDelta calculations, which packs two `uint128` numbers as `X64` to keep track of the `base` and `gross` premia accumulated.

Eg:
https://github.com/panoptic-labs/panoptic-next-core-private/blob/c9102e591a558977e1c6e94daf81f74a598ded74/contracts/SemiFungiblePositionManager.sol#L1317-L1328

## Problem

The `X64` packing results in a loss of precision and could grow faster than needed, which led us to implement the `LeftRightLibrary.addCapped` method to account for a large accumulation of premia.

Similarly, storing `s_grossPremiumLast` and `s_settledTokens` was also done in a way that could in theory result in overflow and loss of precision.

## Solution

This PR creates a PackedUint type which will store numbers with *at most* a `2**120` precision loss. 

It stores any `uint256` as a number of the form: `N = e * 2^n`, where the exponent `n` is the most significant bit of `N` and the mantissa `e` is stored as a `X119` number (ie. `e/2**119` is between 0 and 2).

I've also added methods to add, subtract, multiply, and divide two packed numbers, again in a way that minimizes the precision loss.

All methods have been extensively tested, but more tests could still be added.

## TODO

- [ ] Merge this into the v4-support branch, work off of that one
- [ ] Incorporate PackedUint into SFPM's premia deltas
- [ ] Incorporate PackedUint into PanopticPool's gross premia and settle tokens
- [ ] Update this where we were using with a `X128` encoding as well
- [ ] Potentially add methods for storing four uint128s into a uint258 as 4 `uint64` PackedUint with mantissa as a `X63` for eg. `collectedByLeg[4]`
