### PR TITLE
Feat1: add per-block interest accrual system to CollateralTracker

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
-
+import "forge-std/Test.sol";
 // Interfaces
 import {PanopticPool} from "./PanopticPool.sol";
 // Inherited implementations
@@ -110,7 +110,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Cached amount of assets accounted to be held by the Panoptic Pool — ignores donations, pending fee payouts, and other untracked balance changes.
     uint128 internal s_poolAssets;
 
-    /// @notice Amount of assets moved from the Panoptic Pool to the AMM.
+    /// @notice Amount of assets moved from the Panoptic Pool to the AMM, scaled with the current borrow index.
     uint128 internal s_inAMM;
 
     /// @notice Additional risk premium charged on intrinsic value of ITM positions,
@@ -123,6 +123,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Interest rate accumulator, contains the last block timestamp in the upper 32 bits, the () in the next 96 bits, and the accumulator itself in the lower 128 bits in Wad.
     ///
     uint256 internal s_interestRateAccumulator;
+
+    /// @notice Mapping that tracks the collateral tracker's baseIndex at mint
+    /// @dev baseIndex is taking a snapshot of the interest rate accumulator in the collateral trackers, which is measuring the basis upon which
+    /// the interest rate will be computed
+    mapping(address account => LeftRightUnsigned interestState) internal s_interestState;
 
     /*//////////////////////////////////////////////////////////////
                             RISK PARAMETERS
@@ -264,7 +269,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         returns (uint256 poolAssets, uint256 insideAMM, uint256 currentPoolUtilization)
     {
         poolAssets = s_poolAssets;
-        insideAMM = Math.mulDivWad(s_inAMM, uint128(s_interestRateAccumulator));
+        insideAMM = s_inAMM;
         currentPoolUtilization = _poolUtilization();
         //TODO add: currentBorrowIndexWad = uint128(s_interestRateAccumulator);
     }
@@ -354,8 +359,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return The total amount of assets managed by the CollateralTracker vault
     function totalAssets() public view returns (uint256) {
         unchecked {
-            return
-                uint256(s_poolAssets) + Math.mulDivWad(s_inAMM, uint128(s_interestRateAccumulator));
+            return uint256(s_poolAssets) + s_inAMM;
         }
     }
 
@@ -401,7 +405,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        accrueInterest();
+        accrueInterest(receiver);
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
         shares = previewDeposit(assets);
 
@@ -457,7 +461,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return assets The amount of assets deposited to mint the desired amount of shares
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
-        accrueInterest();
+        accrueInterest(receiver);
         assets = previewMint(shares);
 
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
@@ -515,7 +519,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 shares) {
-        accrueInterest();
+        accrueInterest(owner);
         if (assets > maxWithdraw(owner)) revert Errors.ExceedsMaximumRedemption();
 
         shares = previewWithdraw(assets);
@@ -560,7 +564,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address owner,
         TokenId[] calldata positionIdList
     ) external returns (uint256 shares) {
-        accrueInterest();
+        accrueInterest(owner);
         shares = previewWithdraw(assets);
 
         // check/update allowance for approved withdraw
@@ -621,7 +625,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 assets) {
-        accrueInterest();
+        accrueInterest(owner);
         if (shares > maxRedeem(owner)) revert Errors.ExceedsMaximumRedemption();
 
         // check/update allowance for approved redeem
@@ -652,15 +656,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
-    function accrueInterest() public {
+    function accrueInterest(address user) public {
         // Get block delta
         uint256 currentBlock = block.number;
         uint256 previousBlock = s_interestRateAccumulator >> 224;
+        uint128 deltaBlock = uint128(currentBlock - previousBlock);
 
         // return if same block
         if (currentBlock == previousBlock) return;
-
-        uint128 deltaBlock = uint128(currentBlock - previousBlock);
 
         //  extract interest rate owed during that period
         //uint128 inAmm = s_inAmm;
@@ -681,9 +684,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     function interestRate() public view returns (uint128) {
-        //uint256 utilization = _poolUtilization();
-
-        return uint128(76103500761); // 0.2 * 10**18/(365*24*60*5) = 20% per year;
+        uint256 utilization = _poolUtilization();
+        return utilization == 0 ? uint128(0) : uint128(76103500761); // 0.2 * 10**18/(365*24*60*5) = 20% per year;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -793,9 +795,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return poolUtilization The pool utilization in basis points
     function _poolUtilization() internal view returns (uint256 poolUtilization) {
         unchecked {
-            return
-                (Math.mulDivWad(s_inAMM * DECIMALS, uint128(s_interestRateAccumulator))) /
-                totalAssets();
+            return (s_inAMM * DECIMALS) / totalAssets();
         }
     }
 
@@ -1045,8 +1045,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 shortAmount,
         int128 swappedAmount,
         bool isCovered
-    ) external onlyPanopticPool returns (uint32, LeftRightUnsigned) {
-        accrueInterest();
+    ) external onlyPanopticPool returns (uint32, uint128) {
+        accrueInterest(optionOwner);
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
@@ -1079,12 +1079,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // however, any intrinsic value is paid for by the users, so we only add the portion that comes from PLPs: the short/long amounts
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets).toUint128();
-            s_inAMM = uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)).toUint128();
 
-            return (
-                uint32(_poolUtilization()),
-                LeftRightUnsigned.wrap(commission).toLeftSlot(uint128(s_interestRateAccumulator))
-            );
+            {
+                int128 currentIndex = int128(uint128(s_interestRateAccumulator));
+                s_inAMM = uint256(int256(uint256(s_inAMM)) + ((shortAmount - longAmount)))
+                    .toUint128();
+            }
+            return (uint32(_poolUtilization()), commission);
         }
     }
 
@@ -1095,23 +1096,21 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param shortAmount The notional value of the short legs of the position (if any)
     /// @param swappedAmount The amount of tokens moved during the option close
     /// @param realizedPremium Premium to settle on the current positions
-    /// @param interestSnapshot snapshot of the interest rate a mint
     /// @return The amount of tokens paid when closing that position
     function exercise(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount,
-        int128 realizedPremium,
-        uint128 interestSnapshot
+        int128 realizedPremium
     ) external onlyPanopticPool returns (int128) {
-        accrueInterest();
+        accrueInterest(optionOwner);
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
             uint128 netBorrows = uint128(uint256(Math.max(shortAmount - longAmount, 0)));
-
+            uint128 interestSnapshot = s_interestState[optionOwner].rightSlot();
             int128 netInterest = (netBorrows == 0 || interestSnapshot == 0)
                 ? int128(0)
                 : int128(
@@ -1123,6 +1122,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         )
                     )
                 );
+            console2.log("exerciseData", netInterest);
 
             // add premium and token deltas not covered by swap to be paid/collected on position close
             int256 tokenToPay = int256(swappedAmount) -
@@ -1150,8 +1150,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
 
             // update the inAMM value, removing the part that was paid as interest (CHECK Math)
-            s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
-
+            {
+                int128 currentIndex = int128(uint128(s_interestRateAccumulator));
+                s_inAMM = uint256(int256(uint256(s_inAMM)) - ((shortAmount - longAmount)))
+                    .toUint128();
+            }
             return (int128(tokenToPay));
         }
     }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -119,9 +119,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
 
-    /// @notice Interest rate accumulator, contains the last block timestamp in the upper 32 bits, the () in the next 96 bits, and the accumulator itself in the lower 128 bits in Wad.
+    /// @notice Interest rate accumulator, contains the net interest owed in the left slot, the last block timestamp in the upper 32 bits of the right slow and the accumulator itself in the lower 96 bits in Wad of the right slot.
     ///
-    uint256 internal s_interestRateAccumulator;
+    LeftRightUnsigned internal s_interestRateAccumulator;
 
     /// @notice Mapping that tracks the collateral tracker's baseIndex at mint
     /// @dev rightSlot: baseIndex is taking a snapshot of the interest rate accumulator in the collateral trackers, which is measuring the basis upon which
@@ -239,7 +239,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         s_poolFee = fee;
 
         // store the initial block and initialize the borrowIndex
-        s_interestRateAccumulator = (block.number << 224) + 1e18;
+        s_interestRateAccumulator = LeftRightUnsigned.wrap(0).toRightSlot(
+            uint128((block.number << 96) + 1e18)
+        );
 
         // Stores the addresses of the underlying tracked tokens.
         s_univ3token0 = token0;
@@ -277,13 +279,19 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Returns current borrowIndex.
     /// @return The borrowIndex
     function borrowIndex() external view returns (uint128) {
-        return uint128(s_interestRateAccumulator);
+        return uint96(s_interestRateAccumulator.rightSlot());
     }
 
     /// @notice Returns the last block at which interest rates were compounded.
     /// @return The last block at which the interest rates were compounded
     function lastInteractionBlock() external view returns (uint256) {
-        return (s_interestRateAccumulator >> 224);
+        return (s_interestRateAccumulator.rightSlot() >> 96);
+    }
+
+    /// @notice Returns the last block at which interest rates were compounded.
+    /// @return The last block at which the interest rates were compounded
+    function globalInterestOwed() external view returns (uint256) {
+        return s_interestRateAccumulator.leftSlot();
     }
 
     /// @notice Returns the baseIndex and the net borrows for the user
@@ -382,7 +390,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return The total amount of assets managed by the CollateralTracker vault
     function totalAssets() public view returns (uint256) {
         unchecked {
-            return uint256(s_poolAssets) + s_inAMM;
+            uint128 globalInterestOwed = s_interestRateAccumulator.leftSlot();
+            return uint256(s_poolAssets) + s_inAMM + globalInterestOwed;
         }
     }
 
@@ -686,26 +695,28 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function _accrueInterest(address owner) internal {
         // Get block delta
         uint256 currentBlock = block.number;
-        uint256 previousBlock = s_interestRateAccumulator >> 224;
+        uint256 previousBlock = s_interestRateAccumulator.rightSlot() >> 96;
         uint128 deltaBlock = uint128(currentBlock - previousBlock);
 
         // only update global quantities if not in the same block
-        uint128 currentBorrowIndex = uint128(s_interestRateAccumulator);
+        uint128 currentBorrowIndex = uint96(s_interestRateAccumulator.rightSlot());
+        uint128 globalInterestOwed = s_interestRateAccumulator.leftSlot();
         if (deltaBlock > 0) {
             // PROTOCOL
             //  extract interest rate owed during that period
             uint128 rawInterest = interestRate() * deltaBlock;
-            uint128 interestOwed = Math.mulDivWad(s_inAMM, rawInterest).toUint128();
+            uint128 interestOwed = Math
+                .mulDivWad(s_inAMM + globalInterestOwed, rawInterest)
+                .toUint128();
             // add that value to the "inAMM" tracker
-            s_inAMM += interestOwed;
+
+            globalInterestOwed += interestOwed;
 
             // Update the borrow index (check that math, it's probably wrong)
             uint128 borrowIndex = 10 ** 18 + rawInterest;
 
             // update current borrow index
             currentBorrowIndex = Math.mulDivWad(currentBorrowIndex, borrowIndex).toUint128();
-
-            s_interestRateAccumulator = (currentBlock << 224) + currentBorrowIndex;
         }
 
         // USER
@@ -715,13 +726,19 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
             uint256 shares = previewWithdraw(userInterestOwed);
             _burn(owner, shares);
-            s_inAMM -= userInterestOwed;
 
-            s_interestState[owner] = LeftRightSigned
-                .wrap(0)
-                .toRightSlot(int128(currentBorrowIndex))
-                .toLeftSlot(netBorrows);
+            globalInterestOwed = userInterestOwed < globalInterestOwed
+                ? globalInterestOwed - userInterestOwed
+                : 0;
         }
+        s_interestRateAccumulator = LeftRightUnsigned
+            .wrap(0)
+            .toLeftSlot(globalInterestOwed)
+            .toRightSlot(uint128((currentBlock << 96) + uint96(currentBorrowIndex)));
+        s_interestState[owner] = LeftRightSigned
+            .wrap(0)
+            .toRightSlot(int128(currentBorrowIndex))
+            .toLeftSlot(netBorrows);
     }
 
     function interestRate() public view returns (uint128) {
@@ -747,7 +764,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     function owedInterest(address owner) public view returns (uint128 interestOwed) {
         LeftRightSigned userState = s_interestState[owner];
-        uint256 borrowIndex = uint128(s_interestRateAccumulator);
+        uint256 borrowIndex = uint96(s_interestRateAccumulator.rightSlot());
         interestOwed = _getUserInterest(owner, userState, borrowIndex);
     }
 
@@ -858,7 +875,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return poolUtilization The pool utilization in basis points
     function _poolUtilization() internal view returns (uint256 poolUtilization) {
         unchecked {
-            return (s_inAMM * DECIMALS) / totalAssets();
+            uint128 globalInterestOwed = s_interestRateAccumulator.leftSlot();
+            return ((s_inAMM + globalInterestOwed) * DECIMALS) / totalAssets();
         }
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -241,7 +241,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         // store the initial block and initialize the borrowIndex
         s_interestRateAccumulator = LeftRightUnsigned.wrap(0).toRightSlot(
-            uint128((block.number << 96) + uint96(1e18))
+            uint128((block.timestamp << 96) + uint96(1e18))
         );
 
         // Stores the addresses of the underlying tracked tokens.
@@ -702,19 +702,19 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // Get block delta
             LeftRightUnsigned accumulator = s_interestRateAccumulator;
 
-            // keep uint32 to allow for wrapping inside unchecked scope
-            uint32 currentBlock = uint32(block.number);
-            uint32 previousBlock = uint32(accumulator.rightSlot() >> 96);
-            uint128 deltaBlock = uint32(currentBlock - previousBlock);
+            // keep uint32 to allow for wrapping inside unchecked scope, works as long as the deltaTime is less than 2**32 seconds  = 136 years
+            uint256 currentTime = block.timestamp;
+            uint256 previousTime = accumulator.rightSlot() >> 96;
+            uint128 deltaTime = uint32(currentTime - previousTime);
 
             uint128 currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
             uint128 unrealizedGlobalInterest = accumulator.leftSlot();
             uint128 inAMM = s_inAMM;
             // only update global quantities if not in the same block
-            if (deltaBlock > 0) {
+            if (deltaTime > 0) {
                 // PROTOCOL
-                //  extract interest rate owed during that period
-                uint128 rawInterest = interestRate() * uint128(deltaBlock);
+                //  extract interest rate owed during that period using: rawInterest = (exp(-interest * ∆t) - 1)
+                uint128 rawInterest = interestRate() * uint128(deltaTime);
                 uint128 interestOwed = Math
                     .mulDivWadRoundingUp(inAMM + unrealizedGlobalInterest, rawInterest)
                     .toUint128();
@@ -757,13 +757,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_interestRateAccumulator = LeftRightUnsigned
                 .wrap(0)
                 .toLeftSlot(unrealizedGlobalInterest)
-                .toRightSlot(uint128((currentBlock << 96) + uint96(currentBorrowIndex)));
+                .toRightSlot(uint128((currentTime << 96) + uint96(currentBorrowIndex)));
         }
     }
 
+    /// @notice returns the interest rate per second
     function interestRate() public view returns (uint128) {
         uint256 utilization = _poolUtilization();
-        return utilization == 0 ? uint128(0) : uint128(76103500761); // 0.2 * 10**18/(365*24*60*5) = 20% per year;
+        return utilization == 0 ? uint128(0) : uint128(6341958396); // 0.2 * 10**18/(365*24*60*60) = 20% per year;
     }
 
     function _getUserInterest(

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
+import "forge-std/Test.sol";
 // Interfaces
 import {PanopticPool} from "./PanopticPool.sol";
 // Inherited implementations
@@ -699,40 +700,41 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function _accrueInterest(address owner) internal {
         unchecked {
             // Get block delta
+            LeftRightUnsigned accumulator = s_interestRateAccumulator;
+
             uint256 currentBlock = block.number;
-            uint256 previousBlock = s_interestRateAccumulator.rightSlot() >> 96;
+            uint256 previousBlock = accumulator.rightSlot() >> 96;
             uint128 deltaBlock;
             deltaBlock = uint128(currentBlock - previousBlock);
-            LeftRightSigned userState = s_interestState[owner];
-            int128 netBorrows = userState.leftSlot();
-
             // return if in the same block and the user has no borrows
-            if (deltaBlock == 0 && netBorrows == 0) return;
+            //if (deltaBlock == 0 && netBorrows == 0) return;
 
-            LeftRightUnsigned accumulator = s_interestRateAccumulator;
             uint128 currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
             uint128 unrealizedGlobalInterest = accumulator.leftSlot();
-
             // only update global quantities if not in the same block
             if (deltaBlock > 0) {
                 // PROTOCOL
                 //  extract interest rate owed during that period
                 uint128 rawInterest = interestRate() * deltaBlock;
                 uint128 interestOwed = Math
-                    .mulDivWad(s_inAMM + unrealizedGlobalInterest, rawInterest)
+                    .mulDivWadRoundingUp(s_inAMM + unrealizedGlobalInterest, rawInterest)
                     .toUint128();
                 // add that value to the "inAMM" tracker
 
                 unrealizedGlobalInterest += interestOwed;
 
-                // Update the borrow index (check that math, it's probably wrong)
+                // Update the borrow index
                 uint128 borrowIndex = 10 ** 18 + rawInterest;
 
                 // update current borrow index
-                currentBorrowIndex = Math.mulDivWad(currentBorrowIndex, borrowIndex).toUint128();
+                currentBorrowIndex = Math
+                    .mulDivWadRoundingUp(currentBorrowIndex, borrowIndex)
+                    .toUint128();
             }
 
             // USER
+            LeftRightSigned userState = s_interestState[owner];
+            int128 netBorrows = userState.leftSlot();
             if (netBorrows != 0) {
                 uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
                 if (userInterestOwed != 0) {
@@ -741,18 +743,18 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         totalSupply,
                         s_poolAssets + s_inAMM + unrealizedGlobalInterest
                     );
-
                     if (shares > 0) _burn(owner, shares);
 
-                    unrealizedGlobalInterest = userInterestOwed < unrealizedGlobalInterest
-                        ? unrealizedGlobalInterest - userInterestOwed
-                        : 0;
+                    unrealizedGlobalInterest = userInterestOwed > unrealizedGlobalInterest
+                        ? 0
+                        : unrealizedGlobalInterest - userInterestOwed;
                 }
-                s_interestState[owner] = LeftRightSigned
-                    .wrap(0)
-                    .toRightSlot(int128(currentBorrowIndex))
-                    .toLeftSlot(netBorrows);
             }
+
+            s_interestState[owner] = LeftRightSigned.wrap(int128(currentBorrowIndex)).toLeftSlot(
+                netBorrows
+            );
+
             s_interestRateAccumulator = LeftRightUnsigned
                 .wrap(0)
                 .toLeftSlot(unrealizedGlobalInterest)
@@ -772,24 +774,28 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     ) internal view returns (uint128 interestOwed) {
         int128 netBorrows = userState.leftSlot();
         uint128 userBorrowIndex = uint128(userState.rightSlot());
-        if (netBorrows <= 0 || userBorrowIndex == 0) {
+        if (netBorrows <= 0 || userBorrowIndex == 0 || currentBorrowIndex == userBorrowIndex) {
             return 0;
         }
         unchecked {
             interestOwed = Math
-                .mulDiv(uint128(netBorrows), currentBorrowIndex - userBorrowIndex, userBorrowIndex)
+                .mulDivRoundingUp(
+                    uint128(netBorrows),
+                    currentBorrowIndex - userBorrowIndex,
+                    userBorrowIndex
+                )
                 .toUint128();
         }
     }
 
-    function owedInterest(address owner) public view returns (uint128 interestOwed) {
-        _owedInterest(owner);
+    function owedInterest(address owner) public view returns (uint128) {
+        return _owedInterest(owner);
     }
 
-    function _owedInterest(address owner) internal view returns (uint128 interestOwed) {
+    function _owedInterest(address owner) internal view returns (uint128) {
         LeftRightSigned userState = s_interestState[owner];
         uint256 borrowIndex = uint256(uint96(s_interestRateAccumulator.rightSlot()));
-        interestOwed = _getUserInterest(owner, userState, borrowIndex);
+        return _getUserInterest(owner, userState, borrowIndex);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -125,9 +125,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     uint256 internal s_interestRateAccumulator;
 
     /// @notice Mapping that tracks the collateral tracker's baseIndex at mint
-    /// @dev baseIndex is taking a snapshot of the interest rate accumulator in the collateral trackers, which is measuring the basis upon which
+    /// @dev rightSlot: baseIndex is taking a snapshot of the interest rate accumulator in the collateral trackers, which is measuring the basis upon which
     /// the interest rate will be computed
-    mapping(address account => LeftRightUnsigned interestState) internal s_interestState;
+    /// @dev leftSlot: netBorrows is the net amount of tokens that have been borrowed, taken as max(netShorts - netLongs, 0)
+    mapping(address account => LeftRightSigned interestState) internal s_interestState;
 
     /*//////////////////////////////////////////////////////////////
                             RISK PARAMETERS
@@ -405,7 +406,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        accrueInterest(receiver);
+        _accrueInterest(receiver);
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
         shares = previewDeposit(assets);
 
@@ -461,7 +462,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return assets The amount of assets deposited to mint the desired amount of shares
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
-        accrueInterest(receiver);
+        _accrueInterest(receiver);
         assets = previewMint(shares);
 
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
@@ -519,7 +520,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 shares) {
-        accrueInterest(owner);
+        _accrueInterest(owner);
         if (assets > maxWithdraw(owner)) revert Errors.ExceedsMaximumRedemption();
 
         shares = previewWithdraw(assets);
@@ -564,7 +565,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address owner,
         TokenId[] calldata positionIdList
     ) external returns (uint256 shares) {
-        accrueInterest(owner);
+        _accrueInterest(owner);
         shares = previewWithdraw(assets);
 
         // check/update allowance for approved withdraw
@@ -625,7 +626,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 assets) {
-        accrueInterest(owner);
+        _accrueInterest(owner);
         if (shares > maxRedeem(owner)) revert Errors.ExceedsMaximumRedemption();
 
         // check/update allowance for approved redeem
@@ -656,31 +657,58 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
-    function accrueInterest(address user) public {
+    function accrueInterest() public {
+        _accrueInterest(msg.sender);
+    }
+
+    function _accrueInterest(address owner) internal {
         // Get block delta
         uint256 currentBlock = block.number;
         uint256 previousBlock = s_interestRateAccumulator >> 224;
         uint128 deltaBlock = uint128(currentBlock - previousBlock);
 
-        // return if same block
-        if (currentBlock == previousBlock) return;
+        // only update global quantities if not in the same block
+        uint128 currentBorrowIndex = uint128(s_interestRateAccumulator);
+        if (deltaBlock > 0) {
+            // PROTOCOL
+            //  extract interest rate owed during that period
+            uint128 rawInterest = interestRate() * deltaBlock;
+            uint128 interestOwed = Math.mulDivWad(s_inAMM, rawInterest).toUint128();
+            // add that value to the "inAMM" tracker
+            s_inAMM += interestOwed;
 
-        //  extract interest rate owed during that period
-        //uint128 inAmm = s_inAmm;
-        //uint128 interestOwed = inAmm * interestRate() * deltaBlock
+            // Update the borrow index (check that math, it's probably wrong)
+            uint128 borrowIndex = 10 ** 18 + rawInterest;
 
-        // add that value to the "inAMM" tracker
-        //s_inAMM += interestOwed;
+            // update current borrow index
+            currentBorrowIndex = Math.mulDivWad(currentBorrowIndex, borrowIndex).toUint128();
 
-        // Update the borrow index (check that math, it's probably wrong)
-        uint128 borrowIndex = 10 ** 18 + interestRate() * deltaBlock;
+            s_interestRateAccumulator = (currentBlock << 224) + currentBorrowIndex;
+        }
 
-        // update the accumulator
-        uint128 oldBorrowIndex = uint128(s_interestRateAccumulator);
-
-        uint256 newBorrowIndex = Math.mulDivWad(oldBorrowIndex, borrowIndex);
-
-        s_interestRateAccumulator = (currentBlock << 224) + uint128(newBorrowIndex);
+        // USER
+        LeftRightSigned userState = s_interestState[owner];
+        int128 netBorrows = userState.leftSlot();
+        if (netBorrows != 0) {
+            uint256 shares;
+            {
+                uint128 userBorrowIndex = uint128(userState.rightSlot());
+                uint128 positiveNetBorrows = uint128(uint256(Math.max(netBorrows, 0)));
+                uint128 latestInterest = Math
+                    .mulDiv(
+                        positiveNetBorrows,
+                        currentBorrowIndex - userBorrowIndex,
+                        userBorrowIndex
+                    )
+                    .toUint128();
+                shares = previewWithdraw(latestInterest);
+            }
+            _burn(owner, shares);
+        }
+        s_interestState[owner] = LeftRightSigned
+            .wrap(0)
+            .toRightSlot(int128(currentBorrowIndex))
+            .toLeftSlot(netBorrows);
     }
 
     function interestRate() public view returns (uint128) {
@@ -1046,7 +1074,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 swappedAmount,
         bool isCovered
     ) external onlyPanopticPool returns (uint32, uint128) {
-        accrueInterest(optionOwner);
+        _accrueInterest(optionOwner);
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
@@ -1079,11 +1107,18 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // however, any intrinsic value is paid for by the users, so we only add the portion that comes from PLPs: the short/long amounts
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets).toUint128();
+            int128 netBorrows = shortAmount - longAmount;
+            s_inAMM = uint256(int256(uint256(s_inAMM)) + netBorrows).toUint128();
 
             {
-                int128 currentIndex = int128(uint128(s_interestRateAccumulator));
-                s_inAMM = uint256(int256(uint256(s_inAMM)) + ((shortAmount - longAmount)))
-                    .toUint128();
+                address _optionOwner = optionOwner;
+                s_interestState[_optionOwner] = s_interestState[_optionOwner].toLeftSlot(
+                    netBorrows
+                );
+                console2.log(
+                    "s_interestState[_optionOwner]",
+                    s_interestState[_optionOwner].leftSlot()
+                );
             }
             return (uint32(_poolUtilization()), commission);
         }
@@ -1104,31 +1139,15 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 swappedAmount,
         int128 realizedPremium
     ) external onlyPanopticPool returns (int128) {
-        accrueInterest(optionOwner);
+        _accrueInterest(optionOwner);
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
-            uint128 netBorrows = uint128(uint256(Math.max(shortAmount - longAmount, 0)));
-            uint128 interestSnapshot = s_interestState[optionOwner].rightSlot();
-            int128 netInterest = (netBorrows == 0 || interestSnapshot == 0)
-                ? int128(0)
-                : int128(
-                    uint128(
-                        Math.mulDiv(
-                            netBorrows,
-                            uint128(s_interestRateAccumulator) - interestSnapshot,
-                            interestSnapshot
-                        )
-                    )
-                );
-            console2.log("exerciseData", netInterest);
-
             // add premium and token deltas not covered by swap to be paid/collected on position close
             int256 tokenToPay = int256(swappedAmount) -
                 (longAmount - shortAmount) -
-                realizedPremium +
-                netInterest;
+                realizedPremium;
 
             if (tokenToPay > 0) {
                 // if user must pay tokens, burn them from user balance (revert if balance too small)
@@ -1151,9 +1170,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             // update the inAMM value, removing the part that was paid as interest (CHECK Math)
             {
-                int128 currentIndex = int128(uint128(s_interestRateAccumulator));
-                s_inAMM = uint256(int256(uint256(s_inAMM)) - ((shortAmount - longAmount)))
-                    .toUint128();
+                int128 netBorrows = shortAmount - longAmount;
+                s_inAMM = uint256(int256(uint256(s_inAMM)) - netBorrows).toUint128();
+                console2.log("netBorrows", netBorrows);
+                s_interestState[optionOwner] = s_interestState[optionOwner].toLeftSlot(netBorrows);
             }
             return (int128(tokenToPay));
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -233,6 +233,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // cache the pool fee in hundredths of basis points
         s_poolFee = fee;
 
+        // store the initial block and initialize the borrowIndex
+        s_interestRateAccumulator = (block.number << 224) + 1e18;
+
         // Stores the addresses of the underlying tracked tokens.
         s_univ3token0 = token0;
         s_univ3token1 = token1;
@@ -1109,7 +1112,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             uint128 netBorrows = uint128(uint256(Math.max(shortAmount - longAmount, 0)));
 
-            int128 netInterest = netBorrows == 0
+            int128 netInterest = (netBorrows == 0 || interestSnapshot == 0)
                 ? int128(0)
                 : int128(
                     uint128(

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1357,8 +1357,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             // update the inAMM value, removing the part that was paid as interest (CHECK Math)
             {
-                int128 netBorrows = shortAmount - longAmount;
-                s_inAMM = uint256(int256(uint256(s_inAMM)) - netBorrows).toUint128();
+                // flip the sign of netBorrows since this is closing the position
+                int128 netBorrows = longAmount - shortAmount;
+                s_inAMM = uint256(int256(uint256(s_inAMM)) + netBorrows).toUint128();
                 s_interestState[optionOwner] = s_interestState[optionOwner].toLeftSlot(netBorrows);
             }
             return (int128(tokenToPay));

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -664,7 +664,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         s_interestRateAccumulator = (currentBlock << 224) + uint128(newBorrowIndex);
     }
 
-    function interestRate() public pure returns (uint128) {
+    function interestRate() public view returns (uint128) {
+        uint256 utilization = _poolUtilization();
+
+        return uint128((utilization * utilization) / 16 / (DECIMALS - utilization)); // 2**64/(365*24*60*5*5;
         return uint128(1403861801652); // 2**64/(365*24*60*5*5;
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -240,7 +240,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         // store the initial block and initialize the borrowIndex
         s_interestRateAccumulator = LeftRightUnsigned.wrap(0).toRightSlot(
-            uint128((block.number << 96) + 1e18)
+            uint128((block.number << 96) + uint96(1e18))
         );
 
         // Stores the addresses of the underlying tracked tokens.
@@ -278,7 +278,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Returns current borrowIndex.
     /// @return The borrowIndex
-    function borrowIndex() external view returns (uint128) {
+    function borrowIndex() external view returns (uint96) {
         return uint96(s_interestRateAccumulator.rightSlot());
     }
 
@@ -699,7 +699,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint128 deltaBlock = uint128(currentBlock - previousBlock);
 
         // only update global quantities if not in the same block
-        uint128 currentBorrowIndex = uint96(s_interestRateAccumulator.rightSlot());
+        uint128 currentBorrowIndex = uint128(uint96(s_interestRateAccumulator.rightSlot()));
         uint128 globalInterestOwed = s_interestRateAccumulator.leftSlot();
         if (deltaBlock > 0) {
             // PROTOCOL
@@ -724,12 +724,19 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 netBorrows = userState.leftSlot();
         if (netBorrows != 0) {
             uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
-            uint256 shares = previewWithdraw(userInterestOwed);
-            _burn(owner, shares);
+            if (userInterestOwed != 0) {
+                uint256 shares = Math.mulDivRoundingUp(
+                    userInterestOwed,
+                    totalSupply,
+                    s_poolAssets + s_inAMM + globalInterestOwed
+                );
 
-            globalInterestOwed = userInterestOwed < globalInterestOwed
-                ? globalInterestOwed - userInterestOwed
-                : 0;
+                if (shares > 0) _burn(owner, shares);
+
+                globalInterestOwed = userInterestOwed < globalInterestOwed
+                    ? globalInterestOwed - userInterestOwed
+                    : 0;
+            }
         }
         s_interestRateAccumulator = LeftRightUnsigned
             .wrap(0)
@@ -753,7 +760,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     ) internal view returns (uint128 interestOwed) {
         int128 netBorrows = userState.leftSlot();
         uint128 userBorrowIndex = uint128(userState.rightSlot());
-
+        if (netBorrows <= 0 || userBorrowIndex == 0) {
+            return 0;
+        }
         uint128 positiveNetBorrows = uint128(uint256(Math.max(netBorrows, 0)));
         unchecked {
             interestOwed = Math
@@ -764,7 +773,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     function owedInterest(address owner) public view returns (uint128 interestOwed) {
         LeftRightSigned userState = s_interestState[owner];
-        uint256 borrowIndex = uint96(s_interestRateAccumulator.rightSlot());
+        uint256 borrowIndex = uint256(uint96(s_interestRateAccumulator.rightSlot()));
         interestOwed = _getUserInterest(owner, userState, borrowIndex);
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -702,10 +702,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // Get block delta
             LeftRightUnsigned accumulator = s_interestRateAccumulator;
 
-            uint256 currentBlock = block.number;
-            uint256 previousBlock = accumulator.rightSlot() >> 96;
-            uint128 deltaBlock;
-            deltaBlock = uint128(currentBlock - previousBlock);
+            // keep uint32 to allow for wrapping inside unchecked scope
+            uint32 currentBlock = uint32(block.number);
+            uint32 previousBlock = uint32(accumulator.rightSlot() >> 96);
+            uint128 deltaBlock = uint32(currentBlock - previousBlock);
 
             uint128 currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
             uint128 unrealizedGlobalInterest = accumulator.leftSlot();
@@ -714,7 +714,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             if (deltaBlock > 0) {
                 // PROTOCOL
                 //  extract interest rate owed during that period
-                uint128 rawInterest = interestRate() * deltaBlock;
+                uint128 rawInterest = interestRate() * uint128(deltaBlock);
                 uint128 interestOwed = Math
                     .mulDivWadRoundingUp(inAMM + unrealizedGlobalInterest, rawInterest)
                     .toUint128();
@@ -735,7 +735,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             LeftRightSigned userState = s_interestState[owner];
             int128 netBorrows = userState.leftSlot();
             if (netBorrows != 0) {
-                uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
+                uint128 userInterestOwed = _getUserInterest(userState, currentBorrowIndex);
                 if (userInterestOwed != 0) {
                     uint256 shares = Math.mulDivRoundingUp(
                         userInterestOwed,
@@ -767,7 +767,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     function _getUserInterest(
-        address owner,
         LeftRightSigned userState,
         uint256 currentBorrowIndex
     ) internal view returns (uint128 interestOwed) {
@@ -794,7 +793,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function _owedInterest(address owner) internal view returns (uint128) {
         LeftRightSigned userState = s_interestState[owner];
         uint256 borrowIndex = uint256(uint96(s_interestRateAccumulator.rightSlot()));
-        return _getUserInterest(owner, userState, borrowIndex);
+        return _getUserInterest(userState, borrowIndex);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -667,7 +667,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function interestRate() public view returns (uint128) {
         uint256 utilization = _poolUtilization();
 
-        return uint128((utilization * utilization) / 16 / (DECIMALS - utilization)); // 2**64/(365*24*60*5*5;
+        return uint128((utilization * utilization) / 16 / (DECIMALS + DECIMAL / 20 - utilization)); // u^2 / 16 / (1.05 - u);
         return uint128(1403861801652); // 2**64/(365*24*60*5*5;
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -716,9 +716,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 uint128 rawInterest = uint128(
                     Math.wTaylorCompounded(interestRate(), uint128(deltaTime))
                 );
-                uint128 interestOwed = Math
-                    .mulDivWadRoundingUp(inAMM + unrealizedGlobalInterest, rawInterest)
-                    .toUint128();
+                uint128 interestOwed = Math.mulDivWadRoundingUp(inAMM, rawInterest).toUint128();
                 // add that value to the "inAMM" tracker
 
                 unrealizedGlobalInterest += interestOwed;
@@ -750,11 +748,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         address _owner = owner;
                         uint256 userBalance = balanceOf[_owner];
                         if (shares > userBalance) {
-                            /// Insolvent case: Pay what you can
-                            _burn(_owner, userBalance);
-
                             // update the acrual of interest paid
                             burntInterestValue = uint128(convertToAssets(userBalance));
+
+                            /// Insolvent case: Pay what you can
+                            _burn(_owner, userBalance);
 
                             /// @dev DO NOT update index. By keeping the user's old baseIndex, their debt continues to compound correctly from the original point in time.
                             userBorrowIndex = userState.rightSlot();
@@ -785,7 +783,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice returns the interest rate per second
     function interestRate() public view returns (uint128) {
         uint256 utilization = _poolUtilization();
-        return utilization == 0 ? uint128(0) : uint128(6341958396); // 0.2 * 10**18/(365*24*60*60) = 20% per year;
+        return utilization == 0 ? uint128(1) : uint128(6341958396); // 0.2 * 10**18/(365*24*60*60) = 20% per year;
     }
 
     function _getUserInterest(

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -371,7 +371,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 amount
     ) public override(ERC20Minimal) returns (bool) {
         _accrueInterest(msg.sender);
-        _accrueInterest(recipient);
         // make sure the caller does not have any open option positions
         // if they do: we don't want them sending panoptic pool shares to others
         // as this would reduce their amount of collateral against the opened positions
@@ -392,7 +391,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 amount
     ) public override(ERC20Minimal) returns (bool) {
         _accrueInterest(from);
-        _accrueInterest(to);
         // make sure the sender does not have any open option positions
         // if they do: we don't want them sending panoptic pool shares to others
         // as this would reduce their amount of collateral against the opened positions
@@ -466,7 +464,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        _accrueInterest(receiver);
+        _accrueInterest(msg.sender);
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
         shares = previewDeposit(assets);
 
@@ -522,7 +520,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return assets The amount of assets deposited to mint the desired amount of shares
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
-        _accrueInterest(receiver);
+        _accrueInterest(msg.sender);
         assets = previewMint(shares);
 
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
@@ -723,7 +721,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     /// @notice Accrues protocol-wide interest and makes `to` pay outstanding interest.
-    function accrueInterestTo(address to) public {
+    function accrueInterestTo(address to) external onlyPanopticPool {
         _accrueInterest(to);
     }
 
@@ -1355,7 +1353,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
 
-            // update the inAMM value, removing the part that was paid as interest (CHECK Math)
+            // update the inAMM value, removing the part that was paid as interest
             {
                 // flip the sign of netBorrows since this is closing the position
                 int128 netBorrows = longAmount - shortAmount;

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -884,8 +884,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return Amount of interest owed based on last compounded index
     function _owedInterest(address owner) internal view returns (uint128) {
         LeftRightSigned userState = s_interestState[owner];
-        uint256 borrowIndex = uint256(uint96(s_interestRateAccumulator.rightSlot()));
-        return _getUserInterest(userState, borrowIndex);
+        (uint128 currentBorrowIndex, , , ) = _calculateCurrentInterestState(s_inAMM);
+        return _getUserInterest(userState, currentBorrowIndex);
     }
 
     /// @notice Calculates the current borrow index including uncompounded time
@@ -1151,8 +1151,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address liquidatee,
         int256 bonus
     ) external onlyPanopticPool {
-        _accrueInterest(liquidatee);
-        _accrueInterest(liquidator);
         if (bonus < 0) {
             uint256 bonusAbs;
 
@@ -1239,8 +1237,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param refundee The account being refunded to
     /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative
     function refund(address refunder, address refundee, int256 assets) external onlyPanopticPool {
-        _accrueInterest(refunder);
-        _accrueInterest(refundee);
         if (assets > 0) {
             _transferFrom(refunder, refundee, convertToShares(uint256(assets)));
         } else {

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -110,7 +110,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Cached amount of assets accounted to be held by the Panoptic Pool — ignores donations, pending fee payouts, and other untracked balance changes.
     uint128 internal s_poolAssets;
 
-    /// @notice Amount of assets moved from the Panoptic Pool to the AMM, scaled with the current borrow index.
+    /// @notice Amount of assets moved from the Panoptic Pool to the AMM.
     uint128 internal s_inAMM;
 
     /// @notice Additional risk premium charged on intrinsic value of ITM positions,
@@ -273,6 +273,25 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         insideAMM = s_inAMM;
         currentPoolUtilization = _poolUtilization();
         //TODO add: currentBorrowIndexWad = uint128(s_interestRateAccumulator);
+    }
+
+    /// @notice Returns current borrowIndex.
+    /// @return The borrowIndex
+    function borrowIndex() external view returns (uint128) {
+        return uint128(s_interestRateAccumulator);
+    }
+
+    /// @notice Returns the last block at which interest rates were compounded.
+    /// @return The last block at which the interest rates were compounded
+    function lastInteractionBlock() external view returns (uint256) {
+        return (s_interestRateAccumulator >> 224);
+    }
+
+    /// @notice Returns the baseIndex and the net borrows for the user
+    /// @return The base index of the user in the current state
+    /// @return The net borrowing amounts for the user (if negative, do not pay interest)
+    function interestState(address user) external view returns (int128, int128) {
+        return (s_interestState[user].rightSlot(), s_interestState[user].leftSlot());
     }
 
     /// @notice Returns name of token composed of underlying token symbol and pool data.
@@ -690,30 +709,44 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         LeftRightSigned userState = s_interestState[owner];
         int128 netBorrows = userState.leftSlot();
         if (netBorrows != 0) {
-            uint256 shares;
-            {
-                uint128 userBorrowIndex = uint128(userState.rightSlot());
-                uint128 positiveNetBorrows = uint128(uint256(Math.max(netBorrows, 0)));
-                uint128 latestInterest = Math
-                    .mulDiv(
-                        positiveNetBorrows,
-                        currentBorrowIndex - userBorrowIndex,
-                        userBorrowIndex
-                    )
-                    .toUint128();
-                shares = previewWithdraw(latestInterest);
-            }
+            uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
+            uint256 shares = previewWithdraw(userInterestOwed);
+
             _burn(owner, shares);
+            s_inAMM -= userInterestOwed;
+
+            s_interestState[owner] = LeftRightSigned
+                .wrap(0)
+                .toRightSlot(int128(currentBorrowIndex))
+                .toLeftSlot(netBorrows);
         }
-        s_interestState[owner] = LeftRightSigned
-            .wrap(0)
-            .toRightSlot(int128(currentBorrowIndex))
-            .toLeftSlot(netBorrows);
     }
 
     function interestRate() public view returns (uint128) {
         uint256 utilization = _poolUtilization();
         return utilization == 0 ? uint128(0) : uint128(76103500761); // 0.2 * 10**18/(365*24*60*5) = 20% per year;
+    }
+
+    function _getUserInterest(
+        address owner,
+        LeftRightSigned userState,
+        uint256 currentBorrowIndex
+    ) internal view returns (uint128 interestOwed) {
+        int128 netBorrows = userState.leftSlot();
+        uint128 userBorrowIndex = uint128(userState.rightSlot());
+
+        uint128 positiveNetBorrows = uint128(uint256(Math.max(netBorrows, 0)));
+        unchecked {
+            interestOwed = Math
+                .mulDiv(positiveNetBorrows, currentBorrowIndex - userBorrowIndex, userBorrowIndex)
+                .toUint128();
+        }
+    }
+
+    function owedInterest(address owner) public view returns (uint128 interestOwed) {
+        LeftRightSigned userState = s_interestState[owner];
+        uint256 borrowIndex = uint128(s_interestRateAccumulator);
+        interestOwed = _getUserInterest(owner, userState, borrowIndex);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1241,7 +1274,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     .toLeftSlot(
                         positionBalanceArray.length > 0
                             ? (_getTotalRequiredCollateral(atTick, positionBalanceArray) +
-                                longPremium).toUint128()
+                                longPremium +
+                                owedInterest(user)).toUint128()
                             : 0
                     );
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -786,6 +786,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 .wrap(0)
                 .toRightSlot(userBorrowIndex)
                 .toLeftSlot(netBorrows);
+
+            s_interestRateAccumulator = LeftRightUnsigned
+                .wrap(0)
+                .toLeftSlot(unrealizedGlobalInterest)
+                .toRightSlot(uint128((currentTime << 96) + uint96(currentBorrowIndex)));
         }
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -120,6 +120,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
 
+    /// @notice Interest rate accumulator, contains the last block timestamp in the upper 32 bits, the () in the next 96 bits, and the accumulator itself in the lower 128 bits.
+    ///
+    uint256 internal s_interestRateAccumulator;
+
     /*//////////////////////////////////////////////////////////////
                             RISK PARAMETERS
     //////////////////////////////////////////////////////////////*/
@@ -392,8 +396,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+        accrueInterest();
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
-
         shares = previewDeposit(assets);
 
         // transfer assets (underlying token funds) from the user/the LP to the PanopticPool
@@ -448,6 +452,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return assets The amount of assets deposited to mint the desired amount of shares
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
+        accrueInterest();
         assets = previewMint(shares);
 
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
@@ -505,6 +510,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 shares) {
+        accrueInterest();
         if (assets > maxWithdraw(owner)) revert Errors.ExceedsMaximumRedemption();
 
         shares = previewWithdraw(assets);
@@ -549,6 +555,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address owner,
         TokenId[] calldata positionIdList
     ) external returns (uint256 shares) {
+        accrueInterest();
         shares = previewWithdraw(assets);
 
         // check/update allowance for approved withdraw
@@ -609,6 +616,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 assets) {
+        accrueInterest();
         if (shares > maxRedeem(owner)) revert Errors.ExceedsMaximumRedemption();
 
         // check/update allowance for approved redeem
@@ -637,6 +645,27 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         );
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function accrueInterest() public {
+        uint256 currentBlock = block.number;
+        uint256 previousBlock = s_interestRateAccumulator >> 224;
+
+        if (currentBlock == previousBlock) return;
+
+        uint128 deltaBlock = uint128(currentBlock - previousBlock);
+
+        uint128 borrowIndex = 2 ** 64 + interestRate() * deltaBlock;
+
+        uint128 oldBorrowIndex = uint128(s_interestRateAccumulator);
+
+        uint256 newBorrowIndex = Math.mulDiv64(oldBorrowIndex, borrowIndex);
+
+        s_interestRateAccumulator = (currentBlock << 224) + uint128(newBorrowIndex);
+    }
+
+    function interestRate() public pure returns (uint128) {
+        return uint128(1403861801652); // 2**64/(365*24*60*5*5;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -996,7 +1025,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 shortAmount,
         int128 swappedAmount,
         bool isCovered
-    ) external onlyPanopticPool returns (uint32, uint128) {
+    ) external onlyPanopticPool returns (uint32, LeftRightUnsigned) {
+        accrueInterest();
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
@@ -1031,7 +1061,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_poolAssets = uint256(updatedAssets).toUint128();
             s_inAMM = uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)).toUint128();
 
-            return (uint32(_poolUtilization()), commission);
+            return (
+                uint32(_poolUtilization()),
+                LeftRightUnsigned.wrap(commission).toLeftSlot(uint128(s_interestRateAccumulator))
+            );
         }
     }
 
@@ -1042,17 +1075,28 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param shortAmount The notional value of the short legs of the position (if any)
     /// @param swappedAmount The amount of tokens moved during the option close
     /// @param realizedPremium Premium to settle on the current positions
+    /// @param interestSnapshot snapshot of the interest rate a mint
     /// @return The amount of tokens paid when closing that position
     function exercise(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount,
-        int128 realizedPremium
+        int128 realizedPremium,
+        uint128 interestSnapshot
     ) external onlyPanopticPool returns (int128) {
+        accrueInterest();
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
+
+            uint128 netBorrows = uint128(uint256(Math.max(shortAmount - longAmount, 0)));
+
+            uint128 netInterest = netBorrows == 0
+                ? uint128(0)
+                : uint128(
+                    Math.mulDiv(netBorrows, uint128(s_interestRateAccumulator), interestSnapshot)
+                );
 
             // add premium and token deltas not covered by swap to be paid/collected on position close
             int256 tokenToPay = int256(swappedAmount) -

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -120,14 +120,39 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
 
-    /// @notice Interest rate accumulator, contains the net interest owed in the left slot, the last block timestamp in the upper 32 bits of the right slot and the accumulator itself in the lower 96 bits in Wad of the right slot.
-    ///
+    /**
+     * @notice How the Borrow Index Works
+     *
+     * The borrow index is a global accumulator that tracks how much $1 of debt
+     * grows over time with compound interest. It starts at 1e18 (representing 1.0)
+     * and increases continuously.
+     *
+     * Example:
+     * - User borrows 100 tokens when globalIndex = 1.0e18
+     * - Time passes, globalIndex grows to 1.2e18 (20% growth)
+     * - User now owes: 100 * (1.2e18 / 1.0e18) = 120 tokens
+     *
+     * Each user stores their "checkpoint" index from their last interaction,
+     * allowing efficient compound interest calculation without iteration.
+     */
+
+    /// @notice Global interest rate accumulator packed into a single 256-bit value
+    /// @dev Layout:
+    ///      - Left slot (128 bits): Accumulated unrealized interest that hasn't been distributed
+    ///      - Right slot upper 32 bits: Last interaction timestamp (block.timestamp)
+    ///      - Right slot lower 96 bits: Global borrow index in WAD (starts at 1e18)
+    ///      The borrow index tracks the compound growth factor since protocol inception.
+    ///      A user's current debt = originalDebt * (currentBorrowIndex / userBorrowIndexSnapshot)
     LeftRightUnsigned internal s_interestRateAccumulator;
 
-    /// @notice Mapping that tracks the collateral tracker's baseIndex at mint
-    /// @dev rightSlot: baseIndex is taking a snapshot of the interest rate accumulator in the collateral trackers, which is measuring the basis upon which
-    /// the interest rate will be computed
-    /// @dev leftSlot: netBorrows is the net amount of tokens that have been borrowed, taken as max(netShorts - netLongs, 0)
+    /// @notice Tracks each user's borrowing state and last interaction checkpoint
+    /// @dev Packed layout:
+    ///      - Left slot (128 bits): Net borrows = netShorts - netLongs
+    ///        Represents the user's net borrowed amount in tokens
+    ///        Can be negative, in which case they purchased more options than they sold
+    ///      - Right slot (128 bits): User's borrow index snapshot
+    ///        The global borrow index value when this user last accrued interest
+    /// @dev Interest calculation: interestOwed = netBorrows * (currentIndex - userIndex) / userIndex
     mapping(address account => LeftRightSigned interestState) internal s_interestState;
 
     /*//////////////////////////////////////////////////////////////
@@ -276,28 +301,32 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         currentPoolUtilization = _poolUtilization();
     }
 
-    /// @notice Returns current borrowIndex.
-    /// @return The borrowIndex
+    /// @notice Returns the global borrow index that tracks compound interest growth
+    /// @dev The index starts at 1e18 and compounds continuously. Represents how much 1 unit of debt has grown since inception
+    /// @return The current global borrow index in WAD (18 decimals)
     function borrowIndex() external view returns (uint96) {
         return uint96(s_interestRateAccumulator.rightSlot());
     }
 
-    /// @notice Returns the last block at which interest rates were compounded.
-    /// @return The last block at which the interest rates were compounded
+    /// @notice Returns the timestamp of the last interest accrual
+    /// @return The block timestamp when interest was last compounded
     function lastInteractionTimestamp() external view returns (uint256) {
         return (s_interestRateAccumulator.rightSlot() >> 96);
     }
 
-    /// @notice Returns the last block at which interest rates were compounded.
-    /// @return The last block at which the interest rates were compounded
+    /// @notice Returns the accumulated unrealized global interest
+    /// @return The total interest that has accumulated but not yet been distributed to lenders
     function unrealizedGlobalInterest() external view returns (uint256) {
         return s_interestRateAccumulator.leftSlot();
     }
 
-    /// @notice Returns the baseIndex and the net borrows for the user
-    /// @return The base index of the user in the current state
-    /// @return The net borrowing amounts for the user (if negative, do not pay interest)
-    function interestState(address user) external view returns (int128, int128) {
+    /// @notice Returns the borrowing state for a specific user
+    /// @dev Returns both the user's borrow index snapshot and their net borrowed amount
+    /// @return userBorrowIndex The borrow index when the user last accrued interest (used as the basis for interest calculation)
+    /// @return netBorrows The net borrowed amount for the user (positive = borrower, zero/negative = no interest owed)
+    function interestState(
+        address user
+    ) external view returns (int128 userBorrowIndex, int128 netBorrows) {
         return (s_interestState[user].rightSlot(), s_interestState[user].leftSlot());
     }
 
@@ -693,6 +722,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         _accrueInterest(msg.sender);
     }
 
+    /// @notice Accrues protocol-wide interest and makes `to` pay outstanding interest.
+    function accrueInterestTo(address to) public {
+        _accrueInterest(to);
+    }
+
     /// @notice Accrues protocol-wide interest and settles a specific user's interest.
     /// @dev This function should be called before any user action that affects their borrow balance.
     /// @param owner the account which calls accrue interest
@@ -710,7 +744,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             LeftRightSigned userState = s_interestState[owner];
             int128 netBorrows = userState.leftSlot();
             int128 userBorrowIndex = int128(currentBorrowIndex);
-            if (netBorrows != 0) {
+            if (netBorrows > 0) {
                 uint128 userInterestOwed = _getUserInterest(userState, currentBorrowIndex);
                 if (userInterestOwed != 0) {
                     uint256 _totalAssets = s_poolAssets + inAMM + unrealizedGlobalInterest;
@@ -752,14 +786,16 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 .wrap(0)
                 .toRightSlot(userBorrowIndex)
                 .toLeftSlot(netBorrows);
-
-            s_interestRateAccumulator = LeftRightUnsigned
-                .wrap(0)
-                .toLeftSlot(unrealizedGlobalInterest)
-                .toRightSlot(uint128((currentTime << 96) + uint96(currentBorrowIndex)));
         }
     }
 
+    /// @notice Calculates the current interest state without modifying storage
+    /// @dev Simulates interest accrual from last interaction to current timestamp
+    /// @param inAMM Amount of assets currently deployed in AMM positions
+    /// @return currentBorrowIndex Updated global borrow index after simulated accrual
+    /// @return unrealizedGlobalInterest Total unrealized interest including new accrual
+    /// @return currentTime Current block timestamp
+    /// @return deltaTime Seconds elapsed since last interest accrual
     function _calculateCurrentInterestState(
         uint128 inAMM
     )
@@ -798,12 +834,18 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         }
     }
 
-    /// @notice returns the interest rate per second
+    /// @notice Returns the interest rate per second based on pool utilization
+    /// @return The interest rate per second in 18 decimal precision
     function interestRate() public view returns (uint128) {
         uint256 utilization = _poolUtilization();
         return utilization == 0 ? uint128(1) : uint128(6341958396); // 0.2 * 10**18/(365*24*60*60) = 20% per year;
     }
 
+    /// @notice Calculates interest owed by a user based on their borrow state
+    /// @dev Uses the difference between current and user's last borrow index to compute compound interest
+    /// @param userState Packed state containing user's net borrows (left slot) and last borrow index (right slot)
+    /// @param currentBorrowIndex The current global borrow index
+    /// @return interestOwed Amount of interest the user owes, returns 0 if user is a lender or indices match
     function _getUserInterest(
         LeftRightSigned userState,
         uint256 currentBorrowIndex
@@ -824,21 +866,35 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         }
     }
 
+    /// @notice Returns the current interest owed by a specific user
+    /// @param owner Address of the user to check
+    /// @return The amount of interest currently owed by the user
     function owedInterest(address owner) public view returns (uint128) {
         return _owedInterest(owner);
     }
 
+    /// @notice Internal function to calculate interest owed by a user
+    /// @dev Retrieves user state and current borrow index from storage
+    /// @param owner Address of the user to check
+    /// @return Amount of interest owed based on last compounded index
     function _owedInterest(address owner) internal view returns (uint128) {
         LeftRightSigned userState = s_interestState[owner];
         uint256 borrowIndex = uint256(uint96(s_interestRateAccumulator.rightSlot()));
         return _getUserInterest(userState, borrowIndex);
     }
 
+    /// @notice Calculates the current borrow index including uncompounded time
+    /// @dev Simulates interest accrual up to the current block timestamp
+    /// @return The borrow index as if interest was compounded at current timestamp
     function _calculateCurrentBorrowIndex() internal view returns (uint256) {
         (uint128 currentBorrowIndex, , , ) = _calculateCurrentInterestState(s_inAMM);
         return currentBorrowIndex;
     }
 
+    /// @notice Previews the interest that would be owed if compounded now
+    /// @dev Simulates interest accrual without modifying state
+    /// @param owner Address of the user to preview interest for
+    /// @return The amount of interest that would be owed if accrued at current timestamp
     function previewOwedInterest(address owner) public view returns (uint128) {
         uint256 simulatedBorrowIndex = _calculateCurrentBorrowIndex();
         LeftRightSigned userState = s_interestState[owner];

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -120,7 +120,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
 
-    /// @notice Interest rate accumulator, contains the last block timestamp in the upper 32 bits, the () in the next 96 bits, and the accumulator itself in the lower 128 bits.
+    /// @notice Interest rate accumulator, contains the last block timestamp in the upper 32 bits, the () in the next 96 bits, and the accumulator itself in the lower 128 bits in Wad.
     ///
     uint256 internal s_interestRateAccumulator;
 
@@ -261,8 +261,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         returns (uint256 poolAssets, uint256 insideAMM, uint256 currentPoolUtilization)
     {
         poolAssets = s_poolAssets;
-        insideAMM = s_inAMM;
+        insideAMM = Math.mulDivWad(s_inAMM, uint128(s_interestRateAccumulator));
         currentPoolUtilization = _poolUtilization();
+        //TODO add: currentBorrowIndexWad = uint128(s_interestRateAccumulator);
     }
 
     /// @notice Returns name of token composed of underlying token symbol and pool data.
@@ -350,7 +351,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return The total amount of assets managed by the CollateralTracker vault
     function totalAssets() public view returns (uint256) {
         unchecked {
-            return uint256(s_poolAssets) + s_inAMM;
+            return
+                uint256(s_poolAssets) + Math.mulDivWad(s_inAMM, uint128(s_interestRateAccumulator));
         }
     }
 
@@ -648,27 +650,37 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     function accrueInterest() public {
+        // Get block delta
         uint256 currentBlock = block.number;
         uint256 previousBlock = s_interestRateAccumulator >> 224;
 
+        // return if same block
         if (currentBlock == previousBlock) return;
 
         uint128 deltaBlock = uint128(currentBlock - previousBlock);
 
-        uint128 borrowIndex = 2 ** 64 + interestRate() * deltaBlock;
+        //  extract interest rate owed during that period
+        //uint128 inAmm = s_inAmm;
+        //uint128 interestOwed = inAmm * interestRate() * deltaBlock
 
+        // add that value to the "inAMM" tracker
+        //s_inAMM += interestOwed;
+
+        // Update the borrow index (check that math, it's probably wrong)
+        uint128 borrowIndex = 10 ** 18 + interestRate() * deltaBlock;
+
+        // update the accumulator
         uint128 oldBorrowIndex = uint128(s_interestRateAccumulator);
 
-        uint256 newBorrowIndex = Math.mulDiv64(oldBorrowIndex, borrowIndex);
+        uint256 newBorrowIndex = Math.mulDivWad(oldBorrowIndex, borrowIndex);
 
         s_interestRateAccumulator = (currentBlock << 224) + uint128(newBorrowIndex);
     }
 
     function interestRate() public view returns (uint128) {
-        uint256 utilization = _poolUtilization();
+        //uint256 utilization = _poolUtilization();
 
-        return uint128((utilization * utilization) / 16 / (DECIMALS + DECIMAL / 20 - utilization)); // u^2 / 16 / (1.05 - u);
-        return uint128(1403861801652); // 2**64/(365*24*60*5*5;
+        return uint128(76103500761); // 0.2 * 10**18/(365*24*60*5) = 20% per year;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -778,7 +790,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return poolUtilization The pool utilization in basis points
     function _poolUtilization() internal view returns (uint256 poolUtilization) {
         unchecked {
-            return (s_inAMM * DECIMALS) / totalAssets();
+            return
+                (Math.mulDivWad(s_inAMM * DECIMALS, uint128(s_interestRateAccumulator))) /
+                totalAssets();
         }
     }
 
@@ -1095,16 +1109,23 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             uint128 netBorrows = uint128(uint256(Math.max(shortAmount - longAmount, 0)));
 
-            uint128 netInterest = netBorrows == 0
-                ? uint128(0)
-                : uint128(
-                    Math.mulDiv(netBorrows, uint128(s_interestRateAccumulator), interestSnapshot)
+            int128 netInterest = netBorrows == 0
+                ? int128(0)
+                : int128(
+                    uint128(
+                        Math.mulDiv(
+                            netBorrows,
+                            uint128(s_interestRateAccumulator) - interestSnapshot,
+                            interestSnapshot
+                        )
+                    )
                 );
 
             // add premium and token deltas not covered by swap to be paid/collected on position close
             int256 tokenToPay = int256(swappedAmount) -
                 (longAmount - shortAmount) -
-                realizedPremium;
+                realizedPremium +
+                netInterest;
 
             if (tokenToPay > 0) {
                 // if user must pay tokens, burn them from user balance (revert if balance too small)
@@ -1124,6 +1145,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // any intrinsic value is paid for by the users, so we do not add it to s_inAMM
             // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
             s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
+
+            // update the inAMM value, removing the part that was paid as interest (CHECK Math)
             s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
 
             return (int128(tokenToPay));

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -120,7 +120,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
 
-    /// @notice Interest rate accumulator, contains the net interest owed in the left slot, the last block timestamp in the upper 32 bits of the right slow and the accumulator itself in the lower 96 bits in Wad of the right slot.
+    /// @notice Interest rate accumulator, contains the net interest owed in the left slot, the last block timestamp in the upper 32 bits of the right slot and the accumulator itself in the lower 96 bits in Wad of the right slot.
     ///
     LeftRightUnsigned internal s_interestRateAccumulator;
 
@@ -698,38 +698,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param owner the account which calls accrue interest
     function _accrueInterest(address owner) internal {
         unchecked {
-            // Get block delta
-            LeftRightUnsigned accumulator = s_interestRateAccumulator;
+            (
+                uint128 currentBorrowIndex,
+                uint128 unrealizedGlobalInterest,
+                uint256 currentTime,
+                uint128 deltaTime
+            ) = _calculateCurrentInterestState();
 
-            // keep uint32 to allow for wrapping inside unchecked scope, works as long as the deltaTime is less than 2**32 seconds  = 136 years
-            uint256 currentTime = block.timestamp;
-            uint256 previousTime = accumulator.rightSlot() >> 96;
-            uint128 deltaTime = uint32(currentTime - previousTime);
-
-            uint128 currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
-            uint128 unrealizedGlobalInterest = accumulator.leftSlot();
             uint128 inAMM = s_inAMM;
-            // only update global quantities if not in the same block
-            if (deltaTime > 0) {
-                // PROTOCOL
-                //  extract interest rate owed during that period using: rawInterest = (exp(-interest * ∆t) - 1)
-                uint128 rawInterest = uint128(
-                    Math.wTaylorCompounded(interestRate(), uint128(deltaTime))
-                );
-                uint128 interestOwed = Math.mulDivWadRoundingUp(inAMM, rawInterest).toUint128();
-                // add that value to the "inAMM" tracker
-
-                unrealizedGlobalInterest += interestOwed;
-
-                // Update the borrow index
-                uint128 borrowIndex = 10 ** 18 + rawInterest;
-
-                // update current borrow index
-                currentBorrowIndex = Math
-                    .mulDivWadRoundingUp(currentBorrowIndex, borrowIndex)
-                    .toUint128();
-            }
-
             // USER
             LeftRightSigned userState = s_interestState[owner];
             int128 netBorrows = userState.leftSlot();
@@ -737,10 +713,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             if (netBorrows != 0) {
                 uint128 userInterestOwed = _getUserInterest(userState, currentBorrowIndex);
                 if (userInterestOwed != 0) {
+                    uint256 _totalAssets = s_poolAssets + inAMM + unrealizedGlobalInterest;
+
                     uint256 shares = Math.mulDivRoundingUp(
                         userInterestOwed,
                         totalSupply,
-                        s_poolAssets + inAMM + unrealizedGlobalInterest
+                        _totalAssets
                     );
 
                     uint128 burntInterestValue = userInterestOwed;
@@ -749,7 +727,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         uint256 userBalance = balanceOf[_owner];
                         if (shares > userBalance) {
                             // update the acrual of interest paid
-                            burntInterestValue = uint128(convertToAssets(userBalance));
+                            burntInterestValue = Math
+                                .mulDiv(userBalance, _totalAssets, totalSupply)
+                                .toUint128();
 
                             /// Insolvent case: Pay what you can
                             _burn(_owner, userBalance);
@@ -777,6 +757,45 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 .wrap(0)
                 .toLeftSlot(unrealizedGlobalInterest)
                 .toRightSlot(uint128((currentTime << 96) + uint96(currentBorrowIndex)));
+        }
+    }
+
+    function _calculateCurrentInterestState()
+        internal
+        view
+        returns (
+            uint128 currentBorrowIndex,
+            uint128 unrealizedGlobalInterest,
+            uint256 currentTime,
+            uint128 deltaTime
+        )
+    {
+        unchecked {
+            LeftRightUnsigned accumulator = s_interestRateAccumulator;
+
+            currentTime = block.timestamp;
+            uint256 previousTime = accumulator.rightSlot() >> 96;
+            deltaTime = uint32(currentTime - previousTime);
+            currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
+            unrealizedGlobalInterest = accumulator.leftSlot();
+
+            if (deltaTime > 0) {
+                // Calculate interest growth
+                uint128 rawInterest = uint128(
+                    Math.wTaylorCompounded(interestRate(), uint128(deltaTime))
+                );
+
+                // Calculate interest owed on borrowed amount
+                uint128 inAMM = s_inAMM;
+                uint128 interestOwed = Math.mulDivWadRoundingUp(inAMM, rawInterest).toUint128();
+                unrealizedGlobalInterest += interestOwed;
+
+                // Update borrow index
+                uint128 borrowIndex = 10 ** 18 + rawInterest;
+                currentBorrowIndex = Math
+                    .mulDivWadRoundingUp(currentBorrowIndex, borrowIndex)
+                    .toUint128();
+            }
         }
     }
 
@@ -814,6 +833,17 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         LeftRightSigned userState = s_interestState[owner];
         uint256 borrowIndex = uint256(uint96(s_interestRateAccumulator.rightSlot()));
         return _getUserInterest(userState, borrowIndex);
+    }
+
+    function _calculateCurrentBorrowIndex() internal view returns (uint256) {
+        (uint128 currentBorrowIndex, , , ) = _calculateCurrentInterestState();
+        return currentBorrowIndex;
+    }
+
+    function previewOwedInterest(address owner) public view returns (uint128) {
+        uint256 simulatedBorrowIndex = _calculateCurrentBorrowIndex();
+        LeftRightSigned userState = s_interestState[owner];
+        return _getUserInterest(userState, simulatedBorrowIndex);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
-import "forge-std/Test.sol";
 // Interfaces
 import {PanopticPool} from "./PanopticPool.sol";
 // Inherited implementations
@@ -1148,10 +1147,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 s_interestState[_optionOwner] = s_interestState[_optionOwner].toLeftSlot(
                     netBorrows
                 );
-                console2.log(
-                    "s_interestState[_optionOwner]",
-                    s_interestState[_optionOwner].leftSlot()
-                );
             }
             return (uint32(_poolUtilization()), commission);
         }
@@ -1205,7 +1200,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             {
                 int128 netBorrows = shortAmount - longAmount;
                 s_inAMM = uint256(int256(uint256(s_inAMM)) - netBorrows).toUint128();
-                console2.log("netBorrows", netBorrows);
                 s_interestState[optionOwner] = s_interestState[optionOwner].toLeftSlot(netBorrows);
             }
             return (int128(tokenToPay));

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -786,7 +786,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     Math.wTaylorCompounded(interestRate(), uint128(deltaTime))
                 );
                 // Calculate interest owed on borrowed amount
-                uint128 inAMM = s_inAMM;
                 uint128 interestOwed = Math.mulDivWadRoundingUp(inAMM, rawInterest).toUint128();
                 unrealizedGlobalInterest += interestOwed;
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -274,7 +274,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         poolAssets = s_poolAssets;
         insideAMM = s_inAMM;
         currentPoolUtilization = _poolUtilization();
-        //TODO add: currentBorrowIndexWad = uint128(s_interestRateAccumulator);
     }
 
     /// @notice Returns current borrowIndex.
@@ -285,7 +284,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Returns the last block at which interest rates were compounded.
     /// @return The last block at which the interest rates were compounded
-    function lastInteractionBlock() external view returns (uint256) {
+    function lastInteractionTimestamp() external view returns (uint256) {
         return (s_interestRateAccumulator.rightSlot() >> 96);
     }
 
@@ -736,6 +735,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // USER
             LeftRightSigned userState = s_interestState[owner];
             int128 netBorrows = userState.leftSlot();
+            int128 userBorrowIndex = int128(currentBorrowIndex);
             if (netBorrows != 0) {
                 uint128 userInterestOwed = _getUserInterest(userState, currentBorrowIndex);
                 if (userInterestOwed != 0) {
@@ -744,17 +744,36 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         totalSupply,
                         s_poolAssets + inAMM + unrealizedGlobalInterest
                     );
-                    if (shares > 0) _burn(owner, shares);
 
-                    unrealizedGlobalInterest = userInterestOwed > unrealizedGlobalInterest
+                    uint128 burntInterestValue = userInterestOwed;
+                    if (shares > 0) {
+                        address _owner = owner;
+                        uint256 userBalance = balanceOf[_owner];
+                        if (shares > userBalance) {
+                            /// Insolvent case: Pay what you can
+                            _burn(_owner, userBalance);
+
+                            // update the acrual of interest paid
+                            burntInterestValue = uint128(convertToAssets(userBalance));
+
+                            /// @dev DO NOT update index. By keeping the user's old baseIndex, their debt continues to compound correctly from the original point in time.
+                            userBorrowIndex = userState.rightSlot();
+                        } else {
+                            // Solvent case: Pay in full.
+                            _burn(_owner, shares);
+                        }
+                    }
+
+                    unrealizedGlobalInterest = burntInterestValue > unrealizedGlobalInterest
                         ? 0
-                        : unrealizedGlobalInterest - userInterestOwed;
+                        : unrealizedGlobalInterest - burntInterestValue;
                 }
             }
 
-            s_interestState[owner] = LeftRightSigned.wrap(int128(currentBorrowIndex)).toLeftSlot(
-                netBorrows
-            );
+            s_interestState[owner] = LeftRightSigned
+                .wrap(0)
+                .toRightSlot(userBorrowIndex)
+                .toLeftSlot(netBorrows);
 
             s_interestRateAccumulator = LeftRightUnsigned
                 .wrap(0)

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -698,14 +698,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param owner the account which calls accrue interest
     function _accrueInterest(address owner) internal {
         unchecked {
+            uint128 inAMM = s_inAMM;
             (
                 uint128 currentBorrowIndex,
                 uint128 unrealizedGlobalInterest,
                 uint256 currentTime,
                 uint128 deltaTime
-            ) = _calculateCurrentInterestState();
+            ) = _calculateCurrentInterestState(inAMM);
 
-            uint128 inAMM = s_inAMM;
             // USER
             LeftRightSigned userState = s_interestState[owner];
             int128 netBorrows = userState.leftSlot();
@@ -760,7 +760,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         }
     }
 
-    function _calculateCurrentInterestState()
+    function _calculateCurrentInterestState(
+        uint128 inAMM
+    )
         internal
         view
         returns (
@@ -778,13 +780,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             deltaTime = uint32(currentTime - previousTime);
             currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
             unrealizedGlobalInterest = accumulator.leftSlot();
-
             if (deltaTime > 0) {
                 // Calculate interest growth
                 uint128 rawInterest = uint128(
                     Math.wTaylorCompounded(interestRate(), uint128(deltaTime))
                 );
-
                 // Calculate interest owed on borrowed amount
                 uint128 inAMM = s_inAMM;
                 uint128 interestOwed = Math.mulDivWadRoundingUp(inAMM, rawInterest).toUint128();
@@ -836,7 +836,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     }
 
     function _calculateCurrentBorrowIndex() internal view returns (uint256) {
-        (uint128 currentBorrowIndex, , , ) = _calculateCurrentInterestState();
+        (uint128 currentBorrowIndex, , , ) = _calculateCurrentInterestState(s_inAMM);
         return currentBorrowIndex;
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -290,7 +290,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Returns the last block at which interest rates were compounded.
     /// @return The last block at which the interest rates were compounded
-    function globalInterestOwed() external view returns (uint256) {
+    function unrealizedGlobalInterest() external view returns (uint256) {
         return s_interestRateAccumulator.leftSlot();
     }
 
@@ -390,8 +390,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return The total amount of assets managed by the CollateralTracker vault
     function totalAssets() public view returns (uint256) {
         unchecked {
-            uint128 globalInterestOwed = s_interestRateAccumulator.leftSlot();
-            return uint256(s_poolAssets) + s_inAMM + globalInterestOwed;
+            uint128 unrealizedGlobalInterest = s_interestRateAccumulator.leftSlot();
+            return uint256(s_poolAssets) + s_inAMM + unrealizedGlobalInterest;
         }
     }
 
@@ -688,64 +688,76 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
+    /// @notice Accrues protocol-wide interest.
     function accrueInterest() public {
         _accrueInterest(msg.sender);
     }
 
+    /// @notice Accrues protocol-wide interest and settles a specific user's interest.
+    /// @dev This function should be called before any user action that affects their borrow balance.
+    /// @param owner the account which calls accrue interest
     function _accrueInterest(address owner) internal {
-        // Get block delta
-        uint256 currentBlock = block.number;
-        uint256 previousBlock = s_interestRateAccumulator.rightSlot() >> 96;
-        uint128 deltaBlock = uint128(currentBlock - previousBlock);
+        unchecked {
+            // Get block delta
+            uint256 currentBlock = block.number;
+            uint256 previousBlock = s_interestRateAccumulator.rightSlot() >> 96;
+            uint128 deltaBlock;
+            deltaBlock = uint128(currentBlock - previousBlock);
+            LeftRightSigned userState = s_interestState[owner];
+            int128 netBorrows = userState.leftSlot();
 
-        // only update global quantities if not in the same block
-        uint128 currentBorrowIndex = uint128(uint96(s_interestRateAccumulator.rightSlot()));
-        uint128 globalInterestOwed = s_interestRateAccumulator.leftSlot();
-        if (deltaBlock > 0) {
-            // PROTOCOL
-            //  extract interest rate owed during that period
-            uint128 rawInterest = interestRate() * deltaBlock;
-            uint128 interestOwed = Math
-                .mulDivWad(s_inAMM + globalInterestOwed, rawInterest)
-                .toUint128();
-            // add that value to the "inAMM" tracker
+            // return if in the same block and the user has no borrows
+            if (deltaBlock == 0 && netBorrows == 0) return;
 
-            globalInterestOwed += interestOwed;
+            LeftRightUnsigned accumulator = s_interestRateAccumulator;
+            uint128 currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
+            uint128 unrealizedGlobalInterest = accumulator.leftSlot();
 
-            // Update the borrow index (check that math, it's probably wrong)
-            uint128 borrowIndex = 10 ** 18 + rawInterest;
+            // only update global quantities if not in the same block
+            if (deltaBlock > 0) {
+                // PROTOCOL
+                //  extract interest rate owed during that period
+                uint128 rawInterest = interestRate() * deltaBlock;
+                uint128 interestOwed = Math
+                    .mulDivWad(s_inAMM + unrealizedGlobalInterest, rawInterest)
+                    .toUint128();
+                // add that value to the "inAMM" tracker
 
-            // update current borrow index
-            currentBorrowIndex = Math.mulDivWad(currentBorrowIndex, borrowIndex).toUint128();
-        }
+                unrealizedGlobalInterest += interestOwed;
 
-        // USER
-        LeftRightSigned userState = s_interestState[owner];
-        int128 netBorrows = userState.leftSlot();
-        if (netBorrows != 0) {
-            uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
-            if (userInterestOwed != 0) {
-                uint256 shares = Math.mulDivRoundingUp(
-                    userInterestOwed,
-                    totalSupply,
-                    s_poolAssets + s_inAMM + globalInterestOwed
-                );
+                // Update the borrow index (check that math, it's probably wrong)
+                uint128 borrowIndex = 10 ** 18 + rawInterest;
 
-                if (shares > 0) _burn(owner, shares);
-
-                globalInterestOwed = userInterestOwed < globalInterestOwed
-                    ? globalInterestOwed - userInterestOwed
-                    : 0;
+                // update current borrow index
+                currentBorrowIndex = Math.mulDivWad(currentBorrowIndex, borrowIndex).toUint128();
             }
+
+            // USER
+            if (netBorrows != 0) {
+                uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
+                if (userInterestOwed != 0) {
+                    uint256 shares = Math.mulDivRoundingUp(
+                        userInterestOwed,
+                        totalSupply,
+                        s_poolAssets + s_inAMM + unrealizedGlobalInterest
+                    );
+
+                    if (shares > 0) _burn(owner, shares);
+
+                    unrealizedGlobalInterest = userInterestOwed < unrealizedGlobalInterest
+                        ? unrealizedGlobalInterest - userInterestOwed
+                        : 0;
+                }
+                s_interestState[owner] = LeftRightSigned
+                    .wrap(0)
+                    .toRightSlot(int128(currentBorrowIndex))
+                    .toLeftSlot(netBorrows);
+            }
+            s_interestRateAccumulator = LeftRightUnsigned
+                .wrap(0)
+                .toLeftSlot(unrealizedGlobalInterest)
+                .toRightSlot(uint128((currentBlock << 96) + uint96(currentBorrowIndex)));
         }
-        s_interestRateAccumulator = LeftRightUnsigned
-            .wrap(0)
-            .toLeftSlot(globalInterestOwed)
-            .toRightSlot(uint128((currentBlock << 96) + uint96(currentBorrowIndex)));
-        s_interestState[owner] = LeftRightSigned
-            .wrap(0)
-            .toRightSlot(int128(currentBorrowIndex))
-            .toLeftSlot(netBorrows);
     }
 
     function interestRate() public view returns (uint128) {
@@ -763,15 +775,18 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         if (netBorrows <= 0 || userBorrowIndex == 0) {
             return 0;
         }
-        uint128 positiveNetBorrows = uint128(uint256(Math.max(netBorrows, 0)));
         unchecked {
             interestOwed = Math
-                .mulDiv(positiveNetBorrows, currentBorrowIndex - userBorrowIndex, userBorrowIndex)
+                .mulDiv(uint128(netBorrows), currentBorrowIndex - userBorrowIndex, userBorrowIndex)
                 .toUint128();
         }
     }
 
     function owedInterest(address owner) public view returns (uint128 interestOwed) {
+        _owedInterest(owner);
+    }
+
+    function _owedInterest(address owner) internal view returns (uint128 interestOwed) {
         LeftRightSigned userState = s_interestState[owner];
         uint256 borrowIndex = uint256(uint96(s_interestRateAccumulator.rightSlot()));
         interestOwed = _getUserInterest(owner, userState, borrowIndex);
@@ -884,8 +899,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return poolUtilization The pool utilization in basis points
     function _poolUtilization() internal view returns (uint256 poolUtilization) {
         unchecked {
-            uint128 globalInterestOwed = s_interestRateAccumulator.leftSlot();
-            return ((s_inAMM + globalInterestOwed) * DECIMALS) / totalAssets();
+            uint128 unrealizedGlobalInterest = s_interestRateAccumulator.leftSlot();
+            return ((s_inAMM + unrealizedGlobalInterest) * DECIMALS) / totalAssets();
         }
     }
 
@@ -1303,7 +1318,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         positionBalanceArray.length > 0
                             ? (_getTotalRequiredCollateral(atTick, positionBalanceArray) +
                                 longPremium +
-                                owedInterest(user)).toUint128()
+                                _owedInterest(user)).toUint128()
                             : 0
                     );
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -282,8 +282,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         return uint96(s_interestRateAccumulator.rightSlot());
     }
 
-    /// @notice Returns the last block at which interest rates were compounded.
-    /// @return The last block at which the interest rates were compounded
+    /// @notice Returns the last time at which interest rates were compounded.
+    /// @return The last time at which the interest rates were compounded
     function lastInteractionTimestamp() external view returns (uint256) {
         return (s_interestRateAccumulator.rightSlot() >> 96);
     }
@@ -726,7 +726,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                         address _owner = owner;
                         uint256 userBalance = balanceOf[_owner];
                         if (shares > userBalance) {
-                            // update the acrual of interest paid
+                            // update the accrual of interest paid
                             burntInterestValue = Math
                                 .mulDiv(userBalance, _totalAssets, totalSupply)
                                 .toUint128();

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -333,6 +333,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address recipient,
         uint256 amount
     ) public override(ERC20Minimal) returns (bool) {
+        _accrueInterest(msg.sender);
+        _accrueInterest(recipient);
         // make sure the caller does not have any open option positions
         // if they do: we don't want them sending panoptic pool shares to others
         // as this would reduce their amount of collateral against the opened positions
@@ -352,6 +354,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address to,
         uint256 amount
     ) public override(ERC20Minimal) returns (bool) {
+        _accrueInterest(from);
+        _accrueInterest(to);
         // make sure the sender does not have any open option positions
         // if they do: we don't want them sending panoptic pool shares to others
         // as this would reduce their amount of collateral against the opened positions
@@ -710,7 +714,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         if (netBorrows != 0) {
             uint128 userInterestOwed = _getUserInterest(owner, userState, currentBorrowIndex);
             uint256 shares = previewWithdraw(userInterestOwed);
-
             _burn(owner, shares);
             s_inAMM -= userInterestOwed;
 
@@ -992,6 +995,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address liquidatee,
         int256 bonus
     ) external onlyPanopticPool {
+        _accrueInterest(liquidatee);
+        _accrueInterest(liquidator);
         if (bonus < 0) {
             uint256 bonusAbs;
 
@@ -1078,6 +1083,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param refundee The account being refunded to
     /// @param assets The amount of assets to refund. Positive means a transfer from refunder to refundee, vice versa for negative
     function refund(address refunder, address refundee, int256 assets) external onlyPanopticPool {
+        _accrueInterest(refunder);
+        _accrueInterest(refundee);
         if (assets > 0) {
             _transferFrom(refunder, refundee, convertToShares(uint256(assets)));
         } else {

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -714,7 +714,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             if (deltaTime > 0) {
                 // PROTOCOL
                 //  extract interest rate owed during that period using: rawInterest = (exp(-interest * ∆t) - 1)
-                uint128 rawInterest = interestRate() * uint128(deltaTime);
+                uint128 rawInterest = uint128(
+                    Math.wTaylorCompounded(interestRate(), uint128(deltaTime))
+                );
                 uint128 interestOwed = Math
                     .mulDivWadRoundingUp(inAMM + unrealizedGlobalInterest, rawInterest)
                     .toUint128();

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -706,18 +706,17 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             uint256 previousBlock = accumulator.rightSlot() >> 96;
             uint128 deltaBlock;
             deltaBlock = uint128(currentBlock - previousBlock);
-            // return if in the same block and the user has no borrows
-            //if (deltaBlock == 0 && netBorrows == 0) return;
 
             uint128 currentBorrowIndex = uint128(uint96(accumulator.rightSlot()));
             uint128 unrealizedGlobalInterest = accumulator.leftSlot();
+            uint128 inAMM = s_inAMM;
             // only update global quantities if not in the same block
             if (deltaBlock > 0) {
                 // PROTOCOL
                 //  extract interest rate owed during that period
                 uint128 rawInterest = interestRate() * deltaBlock;
                 uint128 interestOwed = Math
-                    .mulDivWadRoundingUp(s_inAMM + unrealizedGlobalInterest, rawInterest)
+                    .mulDivWadRoundingUp(inAMM + unrealizedGlobalInterest, rawInterest)
                     .toUint128();
                 // add that value to the "inAMM" tracker
 
@@ -741,7 +740,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     uint256 shares = Math.mulDivRoundingUp(
                         userInterestOwed,
                         totalSupply,
-                        s_poolAssets + s_inAMM + unrealizedGlobalInterest
+                        s_poolAssets + inAMM + unrealizedGlobalInterest
                     );
                     if (shares > 0) _burn(owner, shares);
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -201,12 +201,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @notice Collateral vault for token1 in the Uniswap pool.
     CollateralTracker internal s_collateralToken1;
 
-    /// @notice Mapping that tracks the collateral tracker's baseIndex at mint
-    /// @dev baseIndex is taking a snapshot of the interest rate accumulator in the collateral trackers, which is measuring the basis upon which
-    /// the interest rate will be computed
-    mapping(address account => mapping(TokenId tokenId => LeftRightUnsigned interestRateSnapshot))
-        internal s_interestRateSnapshot;
-
     /// @notice Nested mapping that tracks the option formation: address => tokenId => leg => premiaGrowth.
     /// @dev Premia growth is taking a snapshot of the chunk premium in SFPM, which is measuring the amount of fees
     /// collected for every chunk per unit of liquidity (net or short, depending on the isLong value of the specific leg index).
@@ -688,39 +682,26 @@ contract PanopticPool is ERC1155Holder, Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (uint32 utilization0, LeftRightUnsigned commissionAndInterest0) = s_collateralToken0
-            .takeCommissionAddData(
-                msg.sender,
-                longAmounts.rightSlot(),
-                shortAmounts.rightSlot(),
-                totalSwapped.rightSlot(),
-                isCovered
-            );
-        (uint32 utilization1, LeftRightUnsigned commissionAndInterest1) = s_collateralToken1
-            .takeCommissionAddData(
-                msg.sender,
-                longAmounts.leftSlot(),
-                shortAmounts.leftSlot(),
-                totalSwapped.leftSlot(),
-                isCovered
-            );
-
-        {
-            uint128 interestSnapshot0 = commissionAndInterest0.leftSlot();
-            uint128 interestSnapshot1 = commissionAndInterest1.leftSlot();
-            TokenId _tokenId = tokenId;
-            s_interestRateSnapshot[msg.sender][_tokenId] = LeftRightUnsigned
-                .wrap(interestSnapshot0)
-                .toLeftSlot(interestSnapshot1);
-        }
+        (uint32 utilization0, uint128 commission0) = s_collateralToken0.takeCommissionAddData(
+            msg.sender,
+            longAmounts.rightSlot(),
+            shortAmounts.rightSlot(),
+            totalSwapped.rightSlot(),
+            isCovered
+        );
+        (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
+            msg.sender,
+            longAmounts.leftSlot(),
+            shortAmounts.leftSlot(),
+            totalSwapped.leftSlot(),
+            isCovered
+        );
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
             return (
                 utilization0 + (utilization1 << 16),
-                LeftRightUnsigned.wrap(commissionAndInterest0.rightSlot()).toLeftSlot(
-                    commissionAndInterest1.rightSlot()
-                )
+                LeftRightUnsigned.wrap(commission0).toLeftSlot(commission1)
             );
         }
     }
@@ -908,15 +889,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
-        LeftRightUnsigned interestSnapshot = s_interestRateSnapshot[msg.sender][tokenId];
         {
             int128 paid0 = s_collateralToken0.exercise(
                 owner,
                 longAmounts.rightSlot(),
                 shortAmounts.rightSlot(),
                 totalSwapped.rightSlot(),
-                realizedPremia.rightSlot(),
-                interestSnapshot.rightSlot()
+                realizedPremia.rightSlot()
             );
             paidAmounts = paidAmounts.toRightSlot(paid0);
         }
@@ -927,8 +906,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 longAmounts.leftSlot(),
                 shortAmounts.leftSlot(),
                 totalSwapped.leftSlot(),
-                realizedPremia.leftSlot(),
-                interestSnapshot.leftSlot()
+                realizedPremia.leftSlot()
             );
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }
@@ -1585,10 +1563,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 .toLeftSlot(int128(int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64)));
 
             // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-            {
-                s_collateralToken0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot(), 0);
-                s_collateralToken1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot(), 0);
-            }
+            s_collateralToken0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
+            s_collateralToken1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
             bytes32 chunkKey = keccak256(
                 abi.encodePacked(
                     tokenId.strike(legIndex),

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -201,6 +201,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @notice Collateral vault for token1 in the Uniswap pool.
     CollateralTracker internal s_collateralToken1;
 
+    /// @notice Mapping that tracks the collateral tracker's baseIndex at mint
+    /// @dev baseIndex is taking a snapshot of the interest rate accumulator in the collateral trackers, which is measuring the basis upon which
+    /// the interest rate will be computed
+    mapping(address account => mapping(TokenId tokenId => LeftRightUnsigned interestRateSnapshot))
+        internal s_interestRateSnapshot;
+
     /// @notice Nested mapping that tracks the option formation: address => tokenId => leg => premiaGrowth.
     /// @dev Premia growth is taking a snapshot of the chunk premium in SFPM, which is measuring the amount of fees
     /// collected for every chunk per unit of liquidity (net or short, depending on the isLong value of the specific leg index).
@@ -682,26 +688,39 @@ contract PanopticPool is ERC1155Holder, Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (uint32 utilization0, uint128 commission0) = s_collateralToken0.takeCommissionAddData(
-            msg.sender,
-            longAmounts.rightSlot(),
-            shortAmounts.rightSlot(),
-            totalSwapped.rightSlot(),
-            isCovered
-        );
-        (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
-            msg.sender,
-            longAmounts.leftSlot(),
-            shortAmounts.leftSlot(),
-            totalSwapped.leftSlot(),
-            isCovered
-        );
+        (uint32 utilization0, LeftRightUnsigned commissionAndInterest0) = s_collateralToken0
+            .takeCommissionAddData(
+                msg.sender,
+                longAmounts.rightSlot(),
+                shortAmounts.rightSlot(),
+                totalSwapped.rightSlot(),
+                isCovered
+            );
+        (uint32 utilization1, LeftRightUnsigned commissionAndInterest1) = s_collateralToken1
+            .takeCommissionAddData(
+                msg.sender,
+                longAmounts.leftSlot(),
+                shortAmounts.leftSlot(),
+                totalSwapped.leftSlot(),
+                isCovered
+            );
+
+        {
+            uint128 interestSnapshot0 = commissionAndInterest0.leftSlot();
+            uint128 interestSnapshot1 = commissionAndInterest1.leftSlot();
+            TokenId _tokenId = tokenId;
+            s_interestRateSnapshot[msg.sender][_tokenId] = LeftRightUnsigned
+                .wrap(interestSnapshot0)
+                .toLeftSlot(interestSnapshot1);
+        }
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
             return (
                 utilization0 + (utilization1 << 16),
-                LeftRightUnsigned.wrap(commission0).toLeftSlot(commission1)
+                LeftRightUnsigned.wrap(commissionAndInterest0.rightSlot()).toLeftSlot(
+                    commissionAndInterest1.rightSlot()
+                )
             );
         }
     }
@@ -889,14 +908,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
-
+        LeftRightUnsigned interestSnapshot = s_interestRateSnapshot[msg.sender][tokenId];
         {
             int128 paid0 = s_collateralToken0.exercise(
                 owner,
                 longAmounts.rightSlot(),
                 shortAmounts.rightSlot(),
                 totalSwapped.rightSlot(),
-                realizedPremia.rightSlot()
+                realizedPremia.rightSlot(),
+                interestSnapshot.rightSlot()
             );
             paidAmounts = paidAmounts.toRightSlot(paid0);
         }
@@ -907,7 +927,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 longAmounts.leftSlot(),
                 shortAmounts.leftSlot(),
                 totalSwapped.leftSlot(),
-                realizedPremia.leftSlot()
+                realizedPremia.leftSlot(),
+                interestSnapshot.leftSlot()
             );
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }
@@ -1564,9 +1585,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 .toLeftSlot(int128(int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64)));
 
             // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-            s_collateralToken0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
-            s_collateralToken1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
-
+            {
+                s_collateralToken0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot(), 0);
+                s_collateralToken1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot(), 0);
+            }
             bytes32 chunkKey = keccak256(
                 abi.encodePacked(
                     tokenId.strike(legIndex),

--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -1034,6 +1034,74 @@ library Math {
         }
     }
 
+    /// @notice Calculates `floor(a×b÷10^18)` with full precision. Throws if result overflows a uint256.
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @return The 256-bit result
+    /// @dev Optimized version of mulDiv for WAD (10^18) denominator
+    function mulDivWad(uint256 a, uint256 b) internal pure returns (uint256) {
+        unchecked {
+            // 512-bit multiply [prod1 prod0] = a * b
+            // Compute the product mod 2**256 and mod 2**256 - 1
+            // then use the Chinese Remainder Theorem to reconstruct
+            // the 512 bit result. The result is stored in two 256
+            // variables such that product = prod1 * 2**256 + prod0
+            uint256 prod0; // Least significant 256 bits of the product
+            uint256 prod1; // Most significant 256 bits of the product
+            assembly ("memory-safe") {
+                let mm := mulmod(a, b, not(0))
+                prod0 := mul(a, b)
+                prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+            }
+
+            // Handle non-overflow cases, 256 by 256 division
+            if (prod1 == 0) {
+                uint256 res;
+                assembly ("memory-safe") {
+                    res := div(prod0, 1000000000000000000)
+                }
+                return res;
+            }
+
+            // Make sure the result is less than 2**256.
+            require(1000000000000000000 > prod1);
+
+            ///////////////////////////////////////////////
+            // 512 by 256 division.
+            ///////////////////////////////////////////////
+
+            // Make division exact by subtracting the remainder from [prod1 prod0]
+            // Compute remainder using mulmod
+            uint256 remainder;
+            assembly ("memory-safe") {
+                remainder := mulmod(a, b, 1000000000000000000)
+            }
+            // Subtract 256 bit number from 512 bit number
+            assembly ("memory-safe") {
+                prod1 := sub(prod1, gt(remainder, prod0))
+                prod0 := sub(prod0, remainder)
+            }
+
+            // Since 10^18 = 2^18 * 5^18, we need to handle both factors
+            // First divide by 2^18
+            assembly ("memory-safe") {
+                // Right shift by 18 is equivalent to division by 2^18
+                prod0 := shr(18, prod0)
+            }
+
+            // Shift in bits from prod1 into prod0
+            // We need 2^256 / 2^18 = 2^238
+            prod0 |= prod1 << 238;
+
+            // Now divide by 5^18 using modular inverse
+            // Precomputed modular inverse of 5^18 modulo 2^256
+            // This means: (5^18 * inv) mod 2^256 = 1
+            uint256 inv = 0xaccb18165bd6fe31ae1cf318dc5b51eee0e1ba569b88cd74c1773b91fac10669;
+
+            return prod0 * inv;
+        }
+    }
+
     /// @notice Calculates `ceil(a÷b)`, returning 0 if `b == 0`.
     /// @param a The numerator
     /// @param b The denominator

--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -1102,6 +1102,20 @@ library Math {
         }
     }
 
+    /// @notice Calculates `ceil(a×b÷10^18)` with full precision.
+    /// @param a The multiplicand
+    /// @param b The multiplier
+    /// @return result The 256-bit result
+    function mulDivWadRoundingUp(uint256 a, uint256 b) internal pure returns (uint256 result) {
+        unchecked {
+            result = mulDivWad(a, b);
+            if (mulmod(a, b, 10 ** 18) > 0) {
+                require(result < type(uint256).max);
+                result++;
+            }
+        }
+    }
+
     /// @notice Calculates `ceil(a÷b)`, returning 0 if `b == 0`.
     /// @param a The numerator
     /// @param b The denominator

--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -15,6 +15,8 @@ library Math {
     /// @notice This is equivalent to `type(uint256).max` — used in assembly blocks as a replacement.
     uint256 internal constant MAX_UINT256 = 2 ** 256 - 1;
 
+    uint256 constant WAD = 1e18;
+
     /*//////////////////////////////////////////////////////////////
                           GENERAL MATH HELPERS
     //////////////////////////////////////////////////////////////*/
@@ -1163,5 +1165,19 @@ library Math {
             quickSort(data, int256(0), int256(data.length - 1));
         }
         return data;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         EXPONENTIAL MATH
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Returns the sum of the first three non-zero terms of a Taylor expansion of e^(nx) - 1, to approximate a
+    /// continuous compound interest rate. Source: https://github.com/morpho-org/morpho-blue/blob/main/src/libraries/MathLib.sol
+    function wTaylorCompounded(uint256 x, uint256 n) internal pure returns (uint256) {
+        uint256 firstTerm = x * n;
+        uint256 secondTerm = mulDiv(firstTerm, firstTerm, 2 * WAD);
+        uint256 thirdTerm = mulDiv(secondTerm, firstTerm, 3 * WAD);
+
+        return firstTerm + secondTerm + thirdTerm;
     }
 }

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1015,9 +1015,9 @@ library PanopticMath {
             }
 
             if (haircutTotal.rightSlot() != 0)
-                collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()), 0);
+                collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
             if (haircutTotal.leftSlot() != 0)
-                collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()), 0);
+                collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
 
             return
                 LeftRightSigned.wrap(0).toRightSlot(int128(collateralDelta0)).toLeftSlot(

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1015,9 +1015,9 @@ library PanopticMath {
             }
 
             if (haircutTotal.rightSlot() != 0)
-                collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
+                collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()), 0);
             if (haircutTotal.leftSlot() != 0)
-                collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
+                collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()), 0);
 
             return
                 LeftRightSigned.wrap(0).toRightSlot(int128(collateralDelta0)).toLeftSlot(

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -94,6 +94,10 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
         return _getRequiredCollateralAtUtilization(amount, isLong, utilization);
     }
 
+    function getOwedInterest(address owner) external view returns (uint128) {
+        return owedInterest(owner);
+    }
+
     function poolUtilizationHook() external view returns (int128) {
         return int128(int256(_poolUtilization()));
     }
@@ -602,9 +606,20 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.accrueInterest();
         // Calculate the expected new borrow index
         uint128 perBlockInterestRate = collateralToken0.interestRate();
-        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + perBlockInterestRate);
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + perBlockInterestRate
+        );
+        uint256 interestForPeriod = uint256(perBlockInterestRate) * 1;
 
-        uint256 expectedAccumulator = ((startingBlock + 1) << 96) + expectedNewIndex;
+        uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
+            collateralToken0._inAMM(),
+            interestForPeriod
+        );
+
+        uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
+            ((startingBlock + 1) << 96) +
+            expectedNewIndex;
 
         // Get the actual new accumulator value from the contract
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
@@ -635,9 +650,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
 
         // Calculate the expected new borrow index by applying the total interest.
-        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
 
-        uint256 unrealizedGlobalInterest = Math.mulDivWad(
+        uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
             collateralToken0._inAMM(),
             interestForPeriod
         );
@@ -710,9 +728,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Calculate the expected interest for the period.
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
-        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
 
-        uint256 unrealizedGlobalInterest = Math.mulDivWad(
+        uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
             collateralToken0._inAMM(),
             interestForPeriod
         );
@@ -747,7 +768,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken1.deposit(assets, Alice);
         vm.stopPrank();
 
-        // --- Bob deposits ---
+        // --- Bob deposits + Mints ---
         vm.startPrank(Bob);
         _grantTokens(Bob);
         IERC20Partial(token0).approve(address(collateralToken0), assets);
@@ -761,7 +782,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
-        console2.log("mintOptions");
+        console2.log("mintOptions 1st");
         panopticPool.mintOptions(
             positionIdList,
             assets / 2,
@@ -772,9 +793,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         vm.stopPrank();
 
+        // --- Move forward by 1 day ---
+
         uint256 blockAfterBorrow = block.number;
 
         uint32 blocksToSkip = 7200;
+        console2.log("roll 1 day");
         vm.roll(blockAfterBorrow + blocksToSkip);
 
         collateralToken0.accrueInterest();
@@ -784,11 +808,17 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Calculate the expected interest for the period.
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
-        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
 
-        uint256 netInterest = Math.mulDivWad(collateralToken0._inAMM(), interestForPeriod);
+        uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
+            collateralToken0._inAMM(),
+            interestForPeriod
+        );
         // Construct the full expected accumulator value.
-        uint256 expectedAccumulator = (netInterest << 128) +
+        uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
             ((blockAfterBorrow + blocksToSkip) << 96) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
@@ -800,19 +830,72 @@ contract CollateralTrackerTest is Test, PositionUtils {
             "FAIL: Interest did not accrue correctly after borrow was made"
         );
 
+        // --- Mints Again ---
+
         vm.startPrank(Bob);
         console2.log(
             collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
             collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
         );
-        console2.log("burnOptions", Bob);
 
-        panopticPool.burnOptions(
+        strike = 198600 + 12000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        uint256 unrealizedGlobalInterestBefore = actualAccumulator >> 128;
+
+        assertApproxEqAbs(
+            collateralToken0.getOwedInterest(Bob),
+            unrealizedGlobalInterestBefore,
+            1000,
+            "FAIL: owed interest doesn match unrealized tracker"
+        );
+        console2.log("mintOptions 2nd");
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdList1,
+            assets / 4,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK
         );
+        actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        uint256 unrealizedGlobalInterestAfter = actualAccumulator >> 128;
+
+        assertEq(unrealizedGlobalInterestAfter, 0, "FAIL: unrealized interest is not zero");
+
+        // --- Move forward by 1 day ---
+
+        blockAfterBorrow = block.number;
+
+        blocksToSkip = 7200;
+        vm.roll(blockAfterBorrow + blocksToSkip);
+
+        console2.log("burnOptions", Bob);
+
+        actualAccumulator = collateralToken0._interestRateAccumulator();
+        unrealizedGlobalInterestBefore = actualAccumulator >> 128;
+        assertApproxEqAbs(
+            collateralToken0.getOwedInterest(Bob),
+            unrealizedGlobalInterestBefore,
+            1000,
+            "FAIL: owed interest doesn match unrealized tracker"
+        );
+
+        panopticPool.burnOptions(
+            positionIdList,
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        console2.log("DONE", Bob);
+        actualAccumulator = collateralToken0._interestRateAccumulator();
+        unrealizedGlobalInterestAfter = actualAccumulator >> 128;
+        assertEq(unrealizedGlobalInterestAfter, 0, "FAIL: unrealized interest is not zero");
 
         console2.log(
             collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
@@ -894,9 +977,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // 2. Calculate the expected interest for the period.
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
-        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
 
-        uint256 unrealizedGlobalInterest = Math.mulDivWad(
+        uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
             collateralToken0._inAMM(),
             interestForPeriod
         );
@@ -1048,7 +1134,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // 2. Calculate the expected interest for the period.
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
-        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
 
         // 3. Construct the full expected accumulator value.
         uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 96) + expectedNewIndex;

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -58,6 +58,10 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
         return s_inAMM;
     }
 
+    function _interestRateAccumulator() external view returns (uint256) {
+        return s_interestRateAccumulator;
+    }
+
     function _totalAssets() external view returns (uint256 totalManagedAssets) {
         return totalAssets();
     }
@@ -72,6 +76,10 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
 
     function setInAMM(int128 amount) external {
         s_inAMM = uint128(int128(s_inAMM) + amount);
+    }
+
+    function setInterestRateAccumulator(uint256 amount) external {
+        s_interestRateAccumulator = amount;
     }
 
     function setBalance(address owner, uint256 amount) external {
@@ -576,6 +584,391 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // fails if already initialized
         vm.expectRevert(Errors.CollateralTokenAlreadyInitialized.selector);
         collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        INTEREST ACCRUAL TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Success_accrueInterest_oneBlock() public {
+        _initWorld(0);
+        uint256 startingBlock = block.number;
+        uint128 initialBorrowIndex = 1e18;
+        collateralToken0.setPoolAssets(500);
+        collateralToken0.setInAMM(500);
+
+        vm.roll(block.number + 1);
+
+        collateralToken0.accrueInterest();
+        // Calculate the expected new borrow index
+        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + perBlockInterestRate);
+
+        uint256 expectedAccumulator = ((startingBlock + 1) << 224) + expectedNewIndex;
+
+        // Get the actual new accumulator value from the contract
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        // Assert they are equal
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "Interest did not accrue correctly for one block"
+        );
+    }
+
+    function test_Success_accrueInterest_multipleBlocks(uint32 blocksToSkip) public {
+        _initWorld(0);
+        uint256 startingBlock = block.number;
+        uint128 initialBorrowIndex = 1e18; // Set by _initWorld's call to startToken
+        collateralToken0.setPoolAssets(500);
+        collateralToken0.setInAMM(500);
+
+        // Ensure we are actually skipping blocks.
+        vm.assume(blocksToSkip > 0 && blocksToSkip < 1_000_000);
+
+        vm.roll(block.number + blocksToSkip);
+        collateralToken0.accrueInterest();
+
+        // Calculate the total linear interest for the entire period.
+        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+
+        // Calculate the expected new borrow index by applying the total interest.
+        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+
+        // Construct the full expected accumulator value for the new block.
+        uint256 expectedAccumulator = ((startingBlock + blocksToSkip) << 224) + expectedNewIndex;
+
+        // Get the actual new accumulator value from the contract.
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        //  Assert they are equal.
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "Interest did not accrue correctly for multiple blocks"
+        );
+    }
+
+    function test_Unit_accrueInterest_zeroUtilizationStopsAccrual() public {
+        //
+        // ================= SETUP =================
+        //
+        _initWorld(0);
+
+        uint32 blocksToSkip = 10;
+        uint128 amountToBorrow = 100 ether;
+
+        uint256 startingBlock = block.number;
+        uint128 initialBorrowIndex = 1e18; // From startToken initialization
+
+        collateralToken0.setPoolAssets(amountToBorrow * 10);
+
+        collateralToken0.setInAMM(int128(amountToBorrow));
+        uint256 blockAfterBorrow = block.number;
+
+        vm.roll(blockAfterBorrow + blocksToSkip);
+        collateralToken0.accrueInterest();
+
+        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        assertGt(
+            perBlockInterestRate,
+            0,
+            "FAIL: Interest rate should be positive with utilization"
+        );
+
+        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 expectedNewIndex = Math.mulDivWad(
+            initialBorrowIndex, // The starting index for this phase
+            1e18 + interestForPeriod
+        );
+
+        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "FAIL: Interest did not accrue correctly with utilization"
+        );
+    }
+
+    function test_Success_accrueInterest_deposits() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // --- Bob deposits ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+        vm.stopPrank();
+
+        // Check that the interest rate is zero.
+        uint128 currentRate = collateralToken0.interestRate();
+        assertEq(currentRate, 0, "FAIL: Interest rate should be zero at zero utilization");
+
+        // Get the final borrow index.
+        uint128 finalBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+
+        // 4. Assert that the index has not changed from its initial value.
+        assertEq(
+            finalBorrowIndex,
+            initialBorrowIndex,
+            "FAIL: Borrow index should not change when only deposits are made"
+        );
+
+        uint128 amountToBorrow = assets / 10;
+        collateralToken0.setPoolAssets(
+            collateralToken0._availableAssets() - uint128(amountToBorrow)
+        );
+        collateralToken0.setInAMM(int128(amountToBorrow));
+
+        uint256 blockAfterBorrow = block.number;
+
+        uint32 blocksToSkip = 7200;
+        vm.roll(blockAfterBorrow + blocksToSkip);
+        collateralToken0.accrueInterest();
+
+        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+
+        // Calculate the expected interest for the period.
+        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+
+        // Construct the full expected accumulator value.
+        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        // 4. Assert the final state is correct.
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "FAIL: Interest did not accrue correctly after borrow was made"
+        );
+    }
+
+    function test_Success_accrueInterest_mints() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+        collateralToken1.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // --- Bob deposits ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        console2.log("mintOptions");
+        panopticPool.mintOptions(
+            positionIdList,
+            assets / 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        vm.stopPrank();
+
+        uint256 blockAfterBorrow = block.number;
+
+        uint32 blocksToSkip = 7200;
+        vm.roll(blockAfterBorrow + blocksToSkip);
+
+        collateralToken0.accrueInterest();
+
+        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+
+        // Calculate the expected interest for the period.
+        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+
+        // Construct the full expected accumulator value.
+        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        // 4. Assert the final state is correct.
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "FAIL: Interest did not accrue correctly after borrow was made"
+        );
+
+        vm.startPrank(Bob);
+        console2.log(
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        console2.log("burnOptions", Bob);
+
+        panopticPool.burnOptions(
+            positionIdList,
+            positionIdList1,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        console2.log(
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        console2.log(uint128(actualAccumulator), collateralToken0.totalAssets());
+        vm.stopPrank();
+    }
+
+    function test_Success_accrueInterest_mintlong() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+        collateralToken1.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // --- Bob deposits ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob sell assets/2
+        panopticPool.mintOptions(
+            positionIdList,
+            assets,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        vm.stopPrank();
+
+        // Alice buys assets/4
+        vm.startPrank(Alice);
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
+        positionIdList1.push(tokenId);
+        panopticPool.mintOptions(
+            positionIdList1,
+            assets / 2,
+            2 ** 64 - 1,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        vm.stopPrank();
+
+        uint256 blockAfterBorrow = block.number;
+
+        uint32 blocksToSkip = 7200 * 365;
+        vm.roll(blockAfterBorrow + blocksToSkip);
+        console2.log("before accru", uint128(collateralToken0._interestRateAccumulator()));
+        collateralToken0.accrueInterest();
+        console2.log("after accru", uint128(collateralToken0._interestRateAccumulator()));
+
+        {
+            (, , uint256 utilization) = collateralToken0.getPoolData();
+            assertGt(utilization, 0, "FAIL: Utilization should be positive after borrow");
+        }
+        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+
+        // 2. Calculate the expected interest for the period.
+        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+
+        // 3. Construct the full expected accumulator value.
+        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        // 4. Assert the final state is correct.
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "FAIL: Interest did not accrue correctly after borrow was made"
+        );
+        console2.log(
+            "aa",
+            collateralToken0.totalAssets(),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        vm.startPrank(Alice);
+        panopticPool.burnOptions(
+            positionIdList1,
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        console2.log(
+            "bb",
+            collateralToken0.totalAssets(),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        vm.stopPrank();
+
+        vm.startPrank(Bob);
+
+        panopticPool.burnOptions(
+            positionIdList,
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        console2.log(
+            "cc",
+            collateralToken0.totalAssets(),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        vm.stopPrank();
+        assertTrue(false);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1827,8 +2220,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             0,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            1
+            Constants.MIN_V3POOL_TICK
         );
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -58,6 +58,10 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
         return s_inAMM;
     }
 
+    function _poolAssets() external view returns (uint256) {
+        return s_poolAssets;
+    }
+
     function _interestRateAccumulator() external view returns (uint256) {
         return LeftRightUnsigned.unwrap(s_interestRateAccumulator);
     }
@@ -68,6 +72,10 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
 
     function _availableAssets() external view returns (uint256) {
         return s_poolAssets;
+    }
+
+    function burnShares(address owner, uint256 shares) external {
+        _burn(owner, shares);
     }
 
     function setPoolAssets(uint256 amount) external {
@@ -2178,7 +2186,130 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertLt(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
     }
 
-    function test_Fuzz_previewOwedInterest_accuracy(uint32 timeDelta) public {
+    function test_Success_accrueInterest_liquidation_insolventUser() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Charlie the PLP deposits to provide liquidity
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), assets * 10);
+        collateralToken0.deposit(assets * 10, Charlie);
+        vm.stopPrank();
+
+        // Alice th eliquidator does not deposit or provide liquidity
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        //collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Setup Bob with a small balance and large borrow
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(100 ether, Bob); // Deposit 100 ether
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows a significant amount
+        panopticPool.mintOptions(
+            positionIdList,
+            100 ether, // Borrow same amount as deposit
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // Reduce Bob's balance to make him insolvent when interest accrues
+        collateralToken0.burnShares(Bob, collateralToken0.previewDeposit(99 ether));
+        vm.stopPrank();
+
+        // Move forward significantly to generate high interest
+        vm.warp(block.timestamp + 365 days);
+
+        // Preview should show the full interest owed, regardless of solvency
+        uint128 previewedInterest = collateralToken0.previewOwedInterest(Bob);
+        assertGt(previewedInterest, 0, "Preview should show interest even for insolvent user");
+
+        // Convert to shares to check if user is insolvent
+        uint256 sharesOwed = collateralToken0.convertToShares(previewedInterest);
+        uint256 bobBalance = collateralToken0.balanceOf(Bob);
+
+        // Verify Bob would be insolvent
+        assertGt(sharesOwed, bobBalance, "Interest owed in shares should exceed Bob's balance");
+
+        // Preview should still return the full mathematical interest owed
+        // even though Bob can't pay it all
+        uint256 maxBobCanPay = collateralToken0.convertToAssets(bobBalance);
+        assertGt(previewedInterest, maxBobCanPay, "Preview shows more than Bob can pay");
+
+        vm.startPrank(Alice);
+        // Now accrue interest to verify Bob becomes insolvent
+        uint256 charlieAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-before", charlieAssetsBefore);
+        uint256 aliceAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-before", aliceAssetsBefore);
+        uint256 bobAssetsBefore = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-before", bobAssetsBefore);
+
+        uint256 expectedBonus = Math.min(
+            bobAssetsBefore / 2,
+            (previewedInterest - bobAssetsBefore)
+        );
+        console2.log("previewBob-before-liq", collateralToken0.previewOwedInterest(Bob));
+
+        panopticPool.liquidate(new TokenId[](0), Bob, positionIdList);
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 12 seconds);
+
+        console2.log("previewBob-after-liq", collateralToken0.previewOwedInterest(Bob));
+        uint256 charlieAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-after", charlieAssetsAfter);
+        uint256 aliceAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-after", aliceAssetsAfter);
+        uint256 bobAssetsAfter = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-after", bobAssetsAfter);
+
+        assertApproxEqAbs(
+            aliceAssetsAfter - aliceAssetsBefore,
+            expectedBonus,
+            1,
+            "FAIL: wrong bonus"
+        );
+
+        assertApproxEqAbs(
+            charlieAssetsAfter - charlieAssetsBefore,
+            bobAssetsBefore - expectedBonus,
+            1,
+            "FAIL: charlie did not get his share of the interests"
+        );
+
+        vm.stopPrank();
+
+        // Bob's balance should be wiped out
+        uint256 bobBalanceAfter = collateralToken0.balanceOf(Bob);
+        assertEq(bobBalanceAfter, 0, "Insolvent Bob should have 0 balance after accrual");
+
+        // Bob's base index should not have been updated (remains at old value)
+        (int128 baseIndex, int128 netBorrows) = collateralToken0.interestState(Bob);
+        assertEq(netBorrows, 0, "Net borrows should be zero");
+        assertLe(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
+    }
+
+    function test_Fuzz_accrueInterest_previewOwedInterest_accuracy(uint32 timeDelta) public {
         // Bound the time delta to reasonable values (1 second to 1 year)
         timeDelta = uint32(bound(timeDelta, 1, 3650 days));
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1827,7 +1827,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             0,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            1
         );
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -74,6 +74,10 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
         s_poolAssets = uint128(amount);
     }
 
+    function setTotalSupply(uint256 amount) external {
+        totalSupply = amount;
+    }
+
     function setInAMM(int128 amount) external {
         s_inAMM = uint128(int128(s_inAMM) + amount);
     }
@@ -1257,6 +1261,434 @@ contract CollateralTrackerTest is Test, PositionUtils {
             collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
         );
         vm.stopPrank();
+    }
+
+    function test_Success_accrueInterest_smallBalance() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = uint96(collateralToken0._interestRateAccumulator());
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+        collateralToken1.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // --- Bob deposits ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob sell assets/2
+        panopticPool.mintOptions(
+            positionIdList,
+            1,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        (int128 baseIndexBefore, int128 netBorrowsBefore) = collateralToken0.interestState(Bob);
+
+        assertEq(netBorrowsBefore, 1);
+
+        uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
+
+        uint32 blocksToSkip = 1;
+        uint256 blockTime = 1;
+        vm.roll(blockAfterBorrow + blocksToSkip);
+        vm.warp(timestampAfterBorrow + blocksToSkip * blockTime);
+
+        collateralToken0.accrueInterest();
+        (int128 baseIndexAfter, int128 netBorrowsAfter) = collateralToken0.interestState(Bob);
+
+        assertTrue(baseIndexAfter == baseIndexBefore, "FAIL: Bob's base index increased");
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+
+        // 2. Calculate the expected interest for the period.
+        uint256 interestForPeriod = Math.wTaylorCompounded(
+            uint256(perSecondInterestRate),
+            blocksToSkip * blockTime
+        );
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
+
+        uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
+            collateralToken0._inAMM(),
+            interestForPeriod
+        );
+
+        // 3. Construct the full expected accumulator value.
+        uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
+            ((timestampAfterBorrow + blocksToSkip * blockTime) << 96) +
+            expectedNewIndex;
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        // 4. Assert the final state is correct.
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "FAIL: Interest did not accrue correctly after borrow was made"
+        );
+
+        vm.startPrank(Bob);
+        {
+            (baseIndexBefore, netBorrowsBefore) = collateralToken0.interestState(Bob);
+            uint256 balanceBobBefore = collateralToken0.balanceOf(Bob);
+            // pay Bob's interest
+            collateralToken0.accrueInterest();
+            (baseIndexAfter, netBorrowsAfter) = collateralToken0.interestState(Bob);
+            uint256 balanceBobAfter = collateralToken0.balanceOf(Bob);
+
+            assertTrue(balanceBobAfter < balanceBobBefore, "FAIL: Bob's balance did not decrease");
+
+            assertTrue(
+                collateralToken0.convertToAssets(balanceBobBefore - balanceBobAfter) > 0,
+                "FAIL: Bob did not burn at least 1 share"
+            );
+        }
+
+        assertTrue(baseIndexAfter > baseIndexBefore, "FAIL: Bob's base index did not increased");
+
+        actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        assertEq(actualAccumulator >> 128, 0, "FAIL: still outstanding interest");
+        assertEq(actualAccumulator % 2 ** 96, expectedNewIndex, "Fail: wrong index");
+    }
+
+    function testFuzz_accrueInterest_smallValues(
+        uint8 borrowAmount,
+        uint64 userInitialAssets,
+        uint32 deltaTime
+    ) public {
+        // 1. SETUP
+        vm.assume(deltaTime > 0); // Interest only accrues over time.
+        console2.log("data", borrowAmount, userInitialAssets, deltaTime);
+        vm.assume(uint256(userInitialAssets) > uint256(borrowAmount) + 2);
+
+        _initWorld(0);
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), 1 ether);
+        collateralToken0.deposit(1 ether, Alice);
+        vm.stopPrank();
+
+        // Have Bob make a small, fuzzed borrow.
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint104).max);
+        collateralToken0.deposit(userInitialAssets, Bob);
+
+        if (borrowAmount > 0) {
+            (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+            strike = 198600 + 6000;
+            width = 2;
+
+            tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+            positionIdList.push(tokenId);
+
+            panopticPool.mintOptions(
+                positionIdList,
+                borrowAmount,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
+        }
+
+        (int128 baseIndexBefore, ) = collateralToken0.interestState(Bob);
+        uint256 balanceBefore = collateralToken0.balanceOf(Bob);
+
+        // 2. ACTION: Time passes and interest is accrued.
+        vm.warp(block.timestamp + deltaTime);
+        collateralToken0.accrueInterest(); // Settle Bob's interest.
+        vm.stopPrank();
+
+        // 3. ASSERT INVARIANTS
+        (int128 baseIndexAfter, ) = collateralToken0.interestState(Bob);
+        uint256 balanceAfter = collateralToken0.balanceOf(Bob);
+        uint256 sharesOwed = collateralToken0.convertToShares(collateralToken0.owedInterest(Bob));
+
+        // Invariant 1: No reverts (implicitly tested by reaching this point).
+
+        // Invariant 2: No free lunch. Balance should not increase.
+        assertTrue(balanceAfter <= balanceBefore, "FAIL: User gained shares by borrowing");
+
+        // Invariant 4: Solvency logic must hold.
+        if (borrowAmount > 0) {
+            if (balanceBefore >= sharesOwed) {
+                // SOLVENT: Base index must be updated.
+                assertTrue(
+                    baseIndexAfter > baseIndexBefore,
+                    "FAIL: Solvent user index not updated"
+                );
+
+                // Invariant 3: Debt has a cost. If interest is owed, balance must drop.
+                if (sharesOwed > 0) {
+                    assertTrue(balanceAfter < balanceBefore, "FAIL: Solvent user paid no interest");
+                }
+            } else {
+                // INSOLVENT: Base index must NOT be updated.
+                assertTrue(
+                    baseIndexAfter == baseIndexBefore,
+                    "FAIL: Insolvent user index was updated"
+                );
+                // They should have been wiped out.
+                assertEq(balanceAfter, 0, "FAIL: Insolvent user not wiped out");
+            }
+        } else {
+            // If borrowAmount is 0, nothing should change.
+            assertTrue(baseIndexAfter > baseIndexBefore, "FAIL: Index changed with no borrow");
+            assertEq(balanceAfter, balanceBefore, "FAIL: Balance changed with no borrow");
+        }
+    }
+
+    function test_Fail_accrueInterest_noMorefunds() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = uint96(collateralToken0._interestRateAccumulator());
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+        collateralToken1.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // --- Charlie (our control user) deposits and borrows exactly like Bob ---
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Charlie);
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+        panopticPool.mintOptions(
+            positionIdList,
+            assets,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        // --- Bob deposits ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        // Bob sell assets/2
+        panopticPool.mintOptions(
+            positionIdList,
+            assets,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        console2.log("inAMM", collateralToken0._inAMM());
+        collateralToken0.setBalance(Bob, 1 ether);
+
+        uint32 blocksToSkip = 7200 * 365;
+        uint256 timestampAfterBorrow = block.timestamp;
+
+        {
+            uint256 blockAfterBorrow = block.number;
+
+            vm.roll(blockAfterBorrow + blocksToSkip);
+            vm.warp(timestampAfterBorrow + blocksToSkip * 12);
+        }
+        vm.stopPrank();
+
+        // Charlie repays
+        uint256 charliePayment1;
+        {
+            uint256 charlieBalanceBefore1 = collateralToken0.balanceOf(Charlie);
+            vm.startPrank(Charlie);
+            collateralToken0.accrueInterest();
+            vm.stopPrank();
+            uint256 charlieBalanceAfter1 = collateralToken0.balanceOf(Charlie);
+            charliePayment1 = collateralToken0.convertToAssets(
+                charlieBalanceBefore1 - charlieBalanceAfter1
+            );
+        }
+        vm.stopPrank();
+
+        uint256 balanceBobBefore = collateralToken0.balanceOf(Bob);
+        uint256 maxInterestPaidByBob = collateralToken0.convertToAssets(balanceBobBefore);
+
+        vm.startPrank(Bob);
+
+        {
+            (int128 baseIndexBefore, int128 netBorrowsBefore) = collateralToken0.interestState(Bob);
+
+            collateralToken0.accrueInterest();
+
+            uint256 balanceBobAfter = collateralToken0.balanceOf(Bob);
+            (int128 baseIndexAfter, int128 netBorrowsAfter) = collateralToken0.interestState(Bob);
+
+            assertTrue(balanceBobAfter == 0, "FAIL: Bob did not pay all");
+            assertEq(
+                baseIndexAfter,
+                baseIndexBefore,
+                "FAIL: Insolvent user's base index was updated"
+            );
+            assertEq(
+                netBorrowsAfter,
+                netBorrowsBefore,
+                "FAIL: Net borrows changed during interest accrual"
+            );
+        }
+        vm.stopPrank();
+
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
+
+        // 2. Calculate the expected interest for the period.
+        uint256 interestForPeriod = Math.wTaylorCompounded(
+            uint256(perSecondInterestRate),
+            blocksToSkip * 12
+        );
+
+        uint256 totalInterestGenerated = Math.mulDivWadRoundingUp(
+            assets, // The amount borrowed before interest was added, Charlie has paid their share already
+            interestForPeriod
+        );
+
+        uint256 finalUnrealizedInterest = totalInterestGenerated > maxInterestPaidByBob
+            ? totalInterestGenerated - maxInterestPaidByBob
+            : 0;
+
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
+
+        // 3. Construct the full expected accumulator value.
+        uint256 expectedAccumulator = (finalUnrealizedInterest << 128) +
+            ((timestampAfterBorrow + blocksToSkip * 12) << 96) +
+            expectedNewIndex;
+
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        // 4. Assert the final state is correct.
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "FAIL: Interest did not accrue correctly after borrow was made it seems"
+        );
+
+        // Bob re-reposits and pays interest
+        vm.startPrank(Bob);
+        {
+            uint256 newAssets = 5000 ether;
+            _grantTokens(Bob);
+            IERC20Partial(token0).approve(address(collateralToken0), newAssets);
+            collateralToken0.deposit(newAssets, Bob);
+        }
+        (int128 stuckBaseIndex, ) = collateralToken0.interestState(Bob); // His index is still old
+
+        uint256 bobBalanceBeforeFinalPayment = collateralToken0.balanceOf(Bob);
+        vm.warp(block.timestamp + 1 days);
+
+        // Charlie pays interest for the final day
+        uint256 charliePayment2;
+        {
+            uint256 charlieBalanceBefore2 = collateralToken0.balanceOf(Charlie);
+            vm.startPrank(Charlie);
+            collateralToken0.accrueInterest();
+            vm.stopPrank();
+            uint256 charlieBalanceAfter2 = collateralToken0.balanceOf(Charlie);
+            charliePayment2 = collateralToken0.convertToAssets(
+                charlieBalanceBefore2 - charlieBalanceAfter2
+            );
+        }
+        // NOW, BOB PAYS HIS ACCUMULATED DEBT
+        // Since he has funds, this should succeed and take the SOLVENT path
+        vm.startPrank(Bob);
+        collateralToken0.accrueInterest();
+
+        uint256 bobFinalPayment;
+        {
+            uint256 bobBalanceAfterFinalPayment = collateralToken0.balanceOf(Bob);
+            bobFinalPayment = collateralToken0.convertToAssets(
+                bobBalanceBeforeFinalPayment - bobBalanceAfterFinalPayment
+            );
+        }
+        {
+            uint256 finalBalance = collateralToken0.balanceOf(Bob);
+            (int128 finalBaseIndex, ) = collateralToken0.interestState(Bob);
+            uint128 finalGlobalBorrowIndex = collateralToken0.borrowIndex();
+            console2.log("ff", finalBalance, bobBalanceBeforeFinalPayment);
+            assertTrue(
+                finalBalance < bobBalanceBeforeFinalPayment,
+                "FAIL: Bob paid no interest after re-depositing"
+            );
+
+            assertTrue(
+                finalBaseIndex > stuckBaseIndex,
+                "FAIL: Bob's base index was not updated after paying his debt"
+            );
+            assertEq(
+                uint128(finalBaseIndex),
+                finalGlobalBorrowIndex,
+                "FAIL: Bob's index is not current"
+            );
+
+            uint256 finalUnrealizedInterestAfterPayment = collateralToken0
+                .unrealizedGlobalInterest();
+            assertEq(
+                finalUnrealizedInterestAfterPayment,
+                0,
+                "FAIL: Unrealized interest was not settled to zero"
+            );
+        }
+
+        vm.stopPrank();
+        {
+            console2.log("amts", balanceBobBefore, bobFinalPayment);
+        }
+
+        {
+            uint256 totalCharlieInterestPaid = charliePayment1 + charliePayment2;
+            uint256 totalBobInterestPaid = maxInterestPaidByBob + bobFinalPayment;
+
+            console2.log("Total Interest Paid by Charlie (2 payments):", totalCharlieInterestPaid);
+            console2.log("Total Interest Paid by Bob (1 lump sum):", totalBobInterestPaid);
+
+            // This assertion proves that Bob paid more due to compounding.
+            assertTrue(
+                totalBobInterestPaid > totalCharlieInterestPaid,
+                "FAIL: Compounding did not result in higher total interest"
+            );
+        }
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -59,7 +59,7 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
     }
 
     function _interestRateAccumulator() external view returns (uint256) {
-        return s_interestRateAccumulator;
+        return LeftRightUnsigned.unwrap(s_interestRateAccumulator);
     }
 
     function _totalAssets() external view returns (uint256 totalManagedAssets) {
@@ -79,7 +79,7 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
     }
 
     function setInterestRateAccumulator(uint256 amount) external {
-        s_interestRateAccumulator = amount;
+        s_interestRateAccumulator = LeftRightUnsigned.wrap(amount);
     }
 
     function setBalance(address owner, uint256 amount) external {
@@ -604,7 +604,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint128 perBlockInterestRate = collateralToken0.interestRate();
         uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + perBlockInterestRate);
 
-        uint256 expectedAccumulator = ((startingBlock + 1) << 224) + expectedNewIndex;
+        uint256 expectedAccumulator = ((startingBlock + 1) << 96) + expectedNewIndex;
 
         // Get the actual new accumulator value from the contract
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
@@ -637,8 +637,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // Calculate the expected new borrow index by applying the total interest.
         uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
 
+        uint256 unrealizedGlobalInterest = Math.mulDivWad(
+            collateralToken0._inAMM(),
+            interestForPeriod
+        );
+
         // Construct the full expected accumulator value for the new block.
-        uint256 expectedAccumulator = ((startingBlock + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
+            ((startingBlock + blocksToSkip) << 96) +
+            expectedNewIndex;
 
         // Get the actual new accumulator value from the contract.
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
@@ -651,54 +658,13 @@ contract CollateralTrackerTest is Test, PositionUtils {
         );
     }
 
-    function test_Unit_accrueInterest_zeroUtilizationStopsAccrual() public {
-        //
-        // ================= SETUP =================
-        //
-        _initWorld(0);
-
-        uint32 blocksToSkip = 10;
-        uint128 amountToBorrow = 100 ether;
-
-        uint256 startingBlock = block.number;
-        uint128 initialBorrowIndex = 1e18; // From startToken initialization
-
-        collateralToken0.setPoolAssets(amountToBorrow * 10);
-
-        collateralToken0.setInAMM(int128(amountToBorrow));
-        uint256 blockAfterBorrow = block.number;
-
-        vm.roll(blockAfterBorrow + blocksToSkip);
-        collateralToken0.accrueInterest();
-
-        uint128 perBlockInterestRate = collateralToken0.interestRate();
-        assertGt(
-            perBlockInterestRate,
-            0,
-            "FAIL: Interest rate should be positive with utilization"
-        );
-
-        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
-        uint256 expectedNewIndex = Math.mulDivWad(
-            initialBorrowIndex, // The starting index for this phase
-            1e18 + interestForPeriod
-        );
-
-        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
-        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
-        assertEq(
-            actualAccumulator,
-            expectedAccumulator,
-            "FAIL: Interest did not accrue correctly with utilization"
-        );
-    }
-
     function test_Success_accrueInterest_deposits() public {
         _initWorld(0);
         uint104 assets = 1000 ether; // Use a fixed deposit amount
 
         // Get the initial borrow index right after initialization
-        uint128 initialBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+        uint128 initialAccumulator = uint128(collateralToken0._interestRateAccumulator());
+        uint128 initialBorrowIndex = uint96(collateralToken0._interestRateAccumulator());
 
         // --- Alice deposits ---
         vm.startPrank(Alice);
@@ -716,15 +682,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Check that the interest rate is zero.
         uint128 currentRate = collateralToken0.interestRate();
-        assertEq(currentRate, 0, "FAIL: Interest rate should be zero at zero utilization");
 
         // Get the final borrow index.
-        uint128 finalBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+        uint128 finalAccumulator = uint128(collateralToken0._interestRateAccumulator());
 
         // 4. Assert that the index has not changed from its initial value.
         assertEq(
-            finalBorrowIndex,
-            initialBorrowIndex,
+            finalAccumulator,
+            initialAccumulator,
             "FAIL: Borrow index should not change when only deposits are made"
         );
 
@@ -747,8 +712,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
         uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
 
+        uint256 unrealizedGlobalInterest = Math.mulDivWad(
+            collateralToken0._inAMM(),
+            interestForPeriod
+        );
+
         // Construct the full expected accumulator value.
-        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
+            ((blockAfterBorrow + blocksToSkip) << 96) +
+            expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
         // 4. Assert the final state is correct.
@@ -764,7 +736,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint104 assets = 1000 ether; // Use a fixed deposit amount
 
         // Get the initial borrow index right after initialization
-        uint128 initialBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+        uint128 initialBorrowIndex = uint96(collateralToken0._interestRateAccumulator());
 
         // --- Alice deposits ---
         vm.startPrank(Alice);
@@ -814,8 +786,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
         uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
 
+        uint256 netInterest = Math.mulDivWad(collateralToken0._inAMM(), interestForPeriod);
         // Construct the full expected accumulator value.
-        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 expectedAccumulator = (netInterest << 128) +
+            ((blockAfterBorrow + blocksToSkip) << 96) +
+            expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
         // 4. Assert the final state is correct.
@@ -852,7 +827,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint104 assets = 1000 ether; // Use a fixed deposit amount
 
         // Get the initial borrow index right after initialization
-        uint128 initialBorrowIndex = uint128(collateralToken0._interestRateAccumulator());
+        uint128 initialBorrowIndex = uint96(collateralToken0._interestRateAccumulator());
 
         // --- Alice deposits ---
         vm.startPrank(Alice);
@@ -921,8 +896,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
         uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
 
+        uint256 unrealizedGlobalInterest = Math.mulDivWad(
+            collateralToken0._inAMM(),
+            interestForPeriod
+        );
+
         // 3. Construct the full expected accumulator value.
-        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 224) + expectedNewIndex;
+        uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
+            ((blockAfterBorrow + blocksToSkip) << 96) +
+            expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
         // 4. Assert the final state is correct.
@@ -968,7 +950,159 @@ contract CollateralTrackerTest is Test, PositionUtils {
             collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
         );
         vm.stopPrank();
-        assertTrue(false);
+    }
+
+    function test_Success_accrueInterest_negativeborrow() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = uint128(uint96(collateralToken0._interestRateAccumulator()));
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+        collateralToken1.deposit(assets, Alice);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 12000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList1.push(tokenId);
+        console2.log("");
+        console2.log("");
+        console2.log("Alice mints");
+
+        // Alice sell assets/2
+        panopticPool.mintOptions(
+            positionIdList1,
+            assets / 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        vm.stopPrank();
+
+        // --- Bob deposits ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+        console2.log("");
+        console2.log("");
+        console2.log("Bob mints");
+
+        // Bob sell assets/4
+        panopticPool.mintOptions(
+            positionIdList,
+            assets / 8,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        strike = 198600 + 12000;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob buys assets/2
+        panopticPool.mintOptions(
+            positionIdList,
+            assets / 4,
+            2 ** 64 - 1,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        vm.stopPrank();
+
+        uint256 blockAfterBorrow = block.number;
+
+        uint32 blocksToSkip = 7200 * 365;
+        vm.roll(blockAfterBorrow + blocksToSkip);
+        console2.log("before accru", uint128(collateralToken0._interestRateAccumulator()));
+        collateralToken0.accrueInterest();
+        console2.log("after accru", uint128(collateralToken0._interestRateAccumulator()));
+
+        {
+            (, , uint256 utilization) = collateralToken0.getPoolData();
+            assertGt(utilization, 0, "FAIL: Utilization should be positive after borrow");
+        }
+        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+
+        // 2. Calculate the expected interest for the period.
+        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 expectedNewIndex = Math.mulDivWad(initialBorrowIndex, 1e18 + interestForPeriod);
+
+        // 3. Construct the full expected accumulator value.
+        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 96) + expectedNewIndex;
+        uint256 actualAccumulator = uint128(collateralToken0._interestRateAccumulator());
+
+        // 4. Assert the final state is correct.
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "FAIL: Interest did not accrue correctly after borrow was made"
+        );
+        console2.log(
+            "aa",
+            collateralToken0.totalAssets(),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        vm.startPrank(Bob);
+
+        console2.log("");
+        console2.log("");
+        console2.log("Bob Burns");
+        panopticPool.burnOptions(
+            positionIdList,
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        console2.log(
+            "bb",
+            collateralToken0.totalAssets(),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        vm.stopPrank();
+        console2.log("");
+        console2.log("");
+        console2.log("Alice Burns");
+
+        vm.startPrank(Alice);
+        panopticPool.burnOptions(
+            positionIdList1,
+            new TokenId[](0),
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        console2.log(
+            "cc",
+            collateralToken0.totalAssets(),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Alice)),
+            collateralToken0.previewRedeem(collateralToken0.balanceOf(Bob))
+        );
+        vm.stopPrank();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1462,6 +1462,324 @@ contract CollateralTrackerTest is Test, PositionUtils {
         }
     }
 
+    function test_Success_accrueInterest_concurrentBorrowers() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+        // Setup initial liquidity
+        vm.startPrank(Swapper);
+        deal(token0, Swapper, type(uint104).max);
+        deal(token1, Swapper, type(uint104).max);
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        collateralToken0.deposit(assets * 3, Swapper);
+        vm.stopPrank();
+
+        // Setup position parameters
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Alice deposits and borrows 100 ether
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+
+        uint128 aliceBorrowAmount = 100 ether;
+        panopticPool.mintOptions(
+            positionIdList,
+            aliceBorrowAmount,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        // Bob deposits and borrows 50 ether (half of Alice)
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        uint128 bobBorrowAmount = 50 ether;
+        panopticPool.mintOptions(
+            positionIdList,
+            bobBorrowAmount,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        // Charlie deposits and borrows 50 ether (half of Alice)
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Charlie);
+
+        uint128 charlieBorrowAmount = 50 ether;
+        panopticPool.mintOptions(
+            positionIdList,
+            charlieBorrowAmount,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+        uint256 initialTotalSupply = collateralToken0.totalSupply();
+
+        // Record initial balances
+        uint256 aliceInitialBalance = collateralToken0.balanceOf(Alice);
+        uint256 bobInitialBalance = collateralToken0.balanceOf(Bob);
+        uint256 charlieInitialBalance = collateralToken0.balanceOf(Charlie);
+
+        {
+            // Verify initial borrow states
+            (int128 aliceInitIndex, int128 aliceNetBorrows) = collateralToken0.interestState(Alice);
+            (int128 bobInitIndex, int128 bobNetBorrows) = collateralToken0.interestState(Bob);
+            (int128 charlieInitIndex, int128 charlieNetBorrows) = collateralToken0.interestState(
+                Charlie
+            );
+
+            assertEq(aliceNetBorrows, int128(aliceBorrowAmount), "Alice net borrows incorrect");
+            assertEq(bobNetBorrows, int128(bobBorrowAmount), "Bob net borrows incorrect");
+            assertEq(
+                charlieNetBorrows,
+                int128(charlieBorrowAmount),
+                "Charlie net borrows incorrect"
+            );
+            assertEq(aliceInitIndex, bobInitIndex, "Initial indices should match");
+            assertEq(bobInitIndex, charlieInitIndex, "Initial indices should match");
+        }
+        // Move forward 1 day
+        uint256 timeJump = 1 days;
+        vm.warp(block.timestamp + timeJump);
+
+        // Alice accrues and pays interest
+        vm.prank(Alice);
+        collateralToken0.accrueInterest();
+
+        uint256 aliceInterestPaid;
+        {
+            uint256 aliceFinalBalance = collateralToken0.balanceOf(Alice);
+            aliceInterestPaid = collateralToken0.convertToAssets(
+                aliceInitialBalance - aliceFinalBalance
+            );
+        }
+        // Bob accrues and pays interest
+        vm.prank(Bob);
+        collateralToken0.accrueInterest();
+        uint256 bobInterestPaid;
+        {
+            uint256 bobFinalBalance = collateralToken0.balanceOf(Bob);
+            bobInterestPaid = collateralToken0.convertToAssets(bobInitialBalance - bobFinalBalance);
+        }
+        // Charlie accrues and pays interest
+        vm.prank(Charlie);
+        collateralToken0.accrueInterest();
+
+        uint256 charlieInterestPaid;
+        {
+            uint256 charlieFinalBalance = collateralToken0.balanceOf(Charlie);
+            charlieInterestPaid = collateralToken0.convertToAssets(
+                charlieInitialBalance - charlieFinalBalance
+            );
+        }
+        // Verify interest accounting is properly isolated
+        console2.log(
+            "Alice borrowed:",
+            aliceBorrowAmount / 1e18,
+            "ether, paid:",
+            aliceInterestPaid
+        );
+        console2.log("Bob borrowed:", bobBorrowAmount / 1e18, "ether, paid:", bobInterestPaid);
+        console2.log(
+            "Charlie borrowed:",
+            charlieBorrowAmount / 1e18,
+            "ether, paid:",
+            charlieInterestPaid
+        );
+        console2.log("Bob + Charlie combined interest:", bobInterestPaid + charlieInterestPaid);
+
+        // Key assertion: Bob and Charlie's combined interest should equal Alice's
+        // Since Bob + Charlie borrowed the same total amount as Alice for the same period
+        assertApproxEqAbs(
+            bobInterestPaid + charlieInterestPaid,
+            aliceInterestPaid,
+            1, // Small tolerance for rounding
+            "Combined interest of Bob+Charlie should equal Alice's interest"
+        );
+
+        // Verify proportional interest: Bob and Charlie should pay equal amounts
+        assertApproxEqAbs(
+            bobInterestPaid,
+            charlieInterestPaid,
+            1, // Very small tolerance
+            "Bob and Charlie should pay equal interest for equal borrows"
+        );
+
+        // Verify Alice paid approximately 2x what Bob paid
+        assertApproxEqAbs(
+            aliceInterestPaid,
+            bobInterestPaid * 2,
+            1,
+            "Alice should pay 2x Bob's interest for 2x borrow"
+        );
+
+        {
+            // Verify all users' indices are now current
+            (int128 aliceFinalIndex, ) = collateralToken0.interestState(Alice);
+            (int128 bobFinalIndex, ) = collateralToken0.interestState(Bob);
+            (int128 charlieFinalIndex, ) = collateralToken0.interestState(Charlie);
+            uint128 globalIndex = collateralToken0.borrowIndex();
+
+            assertEq(uint128(aliceFinalIndex), globalIndex, "Alice index should be current");
+            assertEq(uint128(bobFinalIndex), globalIndex, "Bob index should be current");
+            assertEq(uint128(charlieFinalIndex), globalIndex, "Charlie index should be current");
+        }
+        // Test overlapping time periods with different accrual times
+        vm.warp(block.timestamp + 1 days);
+
+        // Only Bob accrues
+        vm.prank(Bob);
+        collateralToken0.accrueInterest();
+
+        vm.warp(block.timestamp + 1 days);
+
+        {
+            // Verify Bob's index is ahead of Alice and Charlie
+            (int128 bobIndexMid, ) = collateralToken0.interestState(Bob);
+            (int128 aliceIndexMid, ) = collateralToken0.interestState(Alice);
+            (int128 charlieIndexMid, ) = collateralToken0.interestState(Charlie);
+            assertGt(bobIndexMid, aliceIndexMid, "Bob should have a more recent index than Alice");
+            assertGt(
+                bobIndexMid,
+                charlieIndexMid,
+                "Bob should have a more recent index than Charlie"
+            );
+        }
+
+        // Bob and Charlie accrue after Alice
+        vm.prank(Alice);
+        collateralToken0.accrueInterest();
+        vm.prank(Charlie);
+        collateralToken0.accrueInterest();
+        {
+            // Verify Bob and Charlie still have matching interest despite accruing at different times
+            (int128 aliceIndex2, ) = collateralToken0.interestState(Alice);
+            (int128 charlieIndex2, ) = collateralToken0.interestState(Charlie);
+            assertEq(aliceIndex2, charlieIndex2, "Alice and Charlie should have matching indices");
+            // Only BoB accrues
+            vm.prank(Bob);
+            collateralToken0.accrueInterest();
+
+            // ADD: Verify all users are now synchronized
+            (int128 bobIndexFinal, ) = collateralToken0.interestState(Bob);
+            assertEq(bobIndexFinal, aliceIndex2, "All users should now have the same index");
+        }
+        {
+            // ADD: Verify Bob paid more interest total (accrued twice in this period)
+            uint256 bobFinalBalanceEnd = collateralToken0.balanceOf(Bob);
+            uint256 aliceFinalBalanceEnd = collateralToken0.balanceOf(Alice);
+            uint256 charlieFinalBalanceEnd = collateralToken0.balanceOf(Charlie);
+            {
+                // Calculate actual interest paid by each user
+                uint256 bobTotalInterestPaid = collateralToken0.convertToAssets(
+                    bobInitialBalance - bobFinalBalanceEnd
+                );
+                uint256 aliceTotalInterestPaid = collateralToken0.convertToAssets(
+                    aliceInitialBalance - aliceFinalBalanceEnd
+                );
+                // Bob accrued 3 times (more frequent payments), Alice only 2 times
+                // Bob has half the borrow, so his interest should be slightly LESS than half of Alice's
+                // because frequent accruals mean less compounding
+                assertLt(
+                    bobTotalInterestPaid * 2,
+                    aliceTotalInterestPaid,
+                    "Bob should pay slightly less than half of Alice's interest due to more frequent payments"
+                );
+                {
+                    uint256 charlieTotalInterestPaid = collateralToken0.convertToAssets(
+                        charlieInitialBalance - charlieFinalBalanceEnd
+                    );
+
+                    // Charlie should have paid more than Bob (same borrow, but less frequent accruals = more compounding)
+                    assertGt(
+                        charlieTotalInterestPaid,
+                        bobTotalInterestPaid,
+                        "Charlie should pay more than Bob due to less frequent accruals (more compounding)"
+                    );
+
+                    // Alice's interest should be approximately equal to Bob + Charlie
+                    // (Alice has 2x the borrow, but same accrual pattern as Charlie)
+                    assertApproxEqAbs(
+                        aliceTotalInterestPaid,
+                        charlieTotalInterestPaid * 2,
+                        1,
+                        "Alice should pay approximately 2x Charlie's interest (same accrual pattern, 2x borrow)"
+                    );
+                }
+            }
+            {
+                // Verify no cross-contamination of interest between users
+                uint256 unrealizedInterest = collateralToken0.unrealizedGlobalInterest();
+                assertEq(
+                    unrealizedInterest,
+                    0,
+                    "All interest should be settled after all users accrued"
+                );
+            }
+            {
+                // ADD: Final sanity check - verify total interest collected
+                uint256 totalInterestCollected = (aliceInitialBalance - aliceFinalBalanceEnd) +
+                    (bobInitialBalance - bobFinalBalanceEnd) +
+                    (charlieInitialBalance - charlieFinalBalanceEnd);
+
+                assertGt(totalInterestCollected, 0, "Total interest collected should be positive");
+            }
+
+            // Verify net borrows haven't changed (only interest was paid, not principal)
+            {
+                (, int128 aliceFinalBorrows) = collateralToken0.interestState(Alice);
+                uint128 _aliceBorrowAmount = aliceBorrowAmount;
+                assertEq(
+                    aliceFinalBorrows,
+                    int128(_aliceBorrowAmount),
+                    "Alice's borrows should be unchanged"
+                );
+            }
+            {
+                (, int128 bobFinalBorrows) = collateralToken0.interestState(Bob);
+                assertEq(
+                    bobFinalBorrows,
+                    int128(bobBorrowAmount),
+                    "Bob's borrows should be unchanged"
+                );
+            }
+            {
+                (, int128 charlieFinalBorrows) = collateralToken0.interestState(Charlie);
+                assertEq(
+                    charlieFinalBorrows,
+                    int128(charlieBorrowAmount),
+                    "Charlie's borrows should be unchanged"
+                );
+            }
+            // Verify total supply decreased by exactly the interest paid (burned shares)
+            uint256 expectedSupplyDecrease = (aliceInitialBalance - aliceFinalBalanceEnd) +
+                (bobInitialBalance - bobFinalBalanceEnd) +
+                (charlieInitialBalance - charlieFinalBalanceEnd);
+
+            uint256 _initialTotalSupply = initialTotalSupply;
+            console2.log("aa", _initialTotalSupply, collateralToken0.totalSupply());
+            assertEq(
+                _initialTotalSupply - collateralToken0.totalSupply(),
+                expectedSupplyDecrease,
+                "Total supply should decrease by exactly the burned interest shares"
+            );
+        }
+    }
+
     function test_Success_accrueInterest_noMorefunds() public {
         _initWorld(0);
         uint104 assets = 1000 ether; // Use a fixed deposit amount

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -78,6 +78,10 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
         _burn(owner, shares);
     }
 
+    function mintShares(address owner, uint256 shares) external {
+        _mint(owner, shares);
+    }
+
     function setPoolAssets(uint256 amount) external {
         s_poolAssets = uint128(amount);
     }
@@ -2186,6 +2190,334 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertLt(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
     }
 
+    function test_Success_accrueInterest_liquidation_barelyInsolventUser() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Charlie the PLP deposits to provide liquidity
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), assets * 10);
+        collateralToken0.deposit(assets * 10, Charlie);
+        vm.stopPrank();
+
+        // Alice th eliquidator does not deposit or provide liquidity
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        //collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Setup Bob with a small balance and large borrow
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(100 ether, Bob); // Deposit 100 ether
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows a significant amount
+        mintOptions(
+            panopticPool,
+            positionIdList,
+            100 ether, // Borrow same amount as deposit
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        ($shortPremia, $longPremia, posBalanceArray) = panopticPool
+            .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
+
+        // Move forward significantly to generate high interest
+        vm.warp(block.timestamp + 365 days);
+
+        LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
+            Bob,
+            currentTick,
+            posBalanceArray,
+            $shortPremia.rightSlot(),
+            $longPremia.rightSlot()
+        );
+        console2.log("balan, thr", tokenData0.rightSlot(), tokenData0.leftSlot());
+
+        // Reduce Bob's balance to make him insolvent when interest accrues
+        collateralToken0.burnShares(Bob, collateralToken0.previewDeposit(tokenData0.rightSlot()));
+        collateralToken0.mintShares(Bob, collateralToken0.previewDeposit(tokenData0.leftSlot()));
+
+        tokenData0 = collateralToken0.getAccountMarginDetails(
+            Bob,
+            currentTick,
+            posBalanceArray,
+            $shortPremia.rightSlot(),
+            $longPremia.rightSlot()
+        );
+        console2.log("balan, thr", tokenData0.rightSlot(), tokenData0.leftSlot());
+
+        vm.stopPrank();
+
+        // Preview should show the full interest owed, regardless of solvency
+        uint128 previewedInterest = collateralToken0.previewOwedInterest(Bob);
+        assertGt(previewedInterest, 0, "Preview should show interest even for insolvent user");
+
+        // Convert to shares to check if user is insolvent
+        uint256 sharesOwed = collateralToken0.convertToShares(previewedInterest);
+        uint256 bobBalance = collateralToken0.balanceOf(Bob);
+
+        // Verify Bob would be insolvent but can pau
+        assertLt(
+            sharesOwed,
+            bobBalance,
+            "Interest owed in shares should be less than Bob's balance"
+        );
+
+        // Preview should still return the full mathematical interest owed
+        // even though Bob can't pay it all
+        uint256 maxBobCanPay = collateralToken0.convertToAssets(bobBalance);
+        assertLt(previewedInterest, maxBobCanPay, "Preview shows that Bob can pay");
+
+        vm.startPrank(Alice);
+        // Now accrue interest to verify Bob becomes insolvent
+        uint256 charlieAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-before", charlieAssetsBefore);
+        uint256 aliceAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-before", aliceAssetsBefore);
+        uint256 bobAssetsBefore = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-before", bobAssetsBefore);
+
+        uint256 expectedBonus = Math.min(
+            bobAssetsBefore / 2,
+            (tokenData0.leftSlot() - tokenData0.rightSlot())
+        );
+        console.log("expectedBonus", expectedBonus);
+        console2.log("previewBob-before-liq", collateralToken0.previewOwedInterest(Bob));
+
+        liquidate(panopticPool, new TokenId[](0), Bob, positionIdList);
+
+        vm.stopPrank();
+
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 12 seconds);
+
+        console2.log("previewBob-after-liq", collateralToken0.previewOwedInterest(Bob));
+        uint256 charlieAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-after", charlieAssetsAfter);
+        uint256 aliceAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-after", aliceAssetsAfter);
+        uint256 bobAssetsAfter = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-after", bobAssetsAfter);
+
+        assertApproxEqAbs(
+            aliceAssetsAfter - aliceAssetsBefore,
+            expectedBonus,
+            1,
+            "FAIL: wrong bonus"
+        );
+
+        assertApproxEqAbs(
+            charlieAssetsAfter - charlieAssetsBefore,
+            (previewedInterest * charlieAssetsBefore) / (charlieAssetsBefore + bobAssetsBefore),
+            1,
+            "FAIL: charlie did not get his share of the interests"
+        );
+
+        assertApproxEqAbs(
+            bobAssetsAfter,
+            bobAssetsBefore -
+                expectedBonus -
+                previewedInterest +
+                (previewedInterest * bobAssetsBefore) /
+                (charlieAssetsBefore + bobAssetsBefore),
+            1,
+            "FAIL: bob did not get his share of the interests"
+        );
+
+        // Bob's base index should not have been updated (remains at old value)
+        (int128 baseIndex, int128 netBorrows) = collateralToken0.interestState(Bob);
+        assertEq(netBorrows, 0, "Net borrows should be zero");
+        assertLe(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
+    }
+
+    function test_Success_accrueInterest_liquidation_noProtocolLossInsolventUser() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Charlie the PLP deposits to provide liquidity
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), assets * 10);
+        collateralToken0.deposit(assets * 10, Charlie);
+        vm.stopPrank();
+
+        // Alice th eliquidator does not deposit or provide liquidity
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        //collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Setup Bob with a small balance and large borrow
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(100 ether, Bob); // Deposit 100 ether
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows a significant amount
+        mintOptions(
+            panopticPool,
+            positionIdList,
+            100 ether, // Borrow same amount as deposit
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        ($shortPremia, $longPremia, posBalanceArray) = panopticPool
+            .getAccumulatedFeesAndPositionsData(Bob, false, positionIdList);
+
+        // Move forward significantly to generate high interest
+        vm.warp(block.timestamp + 365 days);
+
+        // Preview should show the full interest owed, regardless of solvency
+        uint128 previewedInterest = collateralToken0.previewOwedInterest(Bob);
+        assertGt(previewedInterest, 0, "Preview should show interest even for insolvent user");
+
+        LeftRightUnsigned tokenData0 = collateralToken0.getAccountMarginDetails(
+            Bob,
+            currentTick,
+            posBalanceArray,
+            $shortPremia.rightSlot(),
+            $longPremia.rightSlot()
+        );
+        console2.log("balan, thr", tokenData0.rightSlot(), tokenData0.leftSlot());
+
+        // Reduce Bob's balance to make him insolvent when interest accrues
+        collateralToken0.burnShares(Bob, collateralToken0.previewDeposit(tokenData0.rightSlot()));
+        // reduce balance so the account has barely any shares left
+        collateralToken0.mintShares(
+            Bob,
+            collateralToken0.previewDeposit(tokenData0.leftSlot() - 9932835926210985458)
+        );
+
+        tokenData0 = collateralToken0.getAccountMarginDetails(
+            Bob,
+            currentTick,
+            posBalanceArray,
+            $shortPremia.rightSlot(),
+            $longPremia.rightSlot()
+        );
+        console2.log("balan, thr", tokenData0.rightSlot(), tokenData0.leftSlot());
+
+        vm.stopPrank();
+
+        // Convert to shares to check if user is insolvent
+        uint256 sharesOwed = collateralToken0.convertToShares(previewedInterest);
+        uint256 bobBalance = collateralToken0.balanceOf(Bob);
+
+        // Verify Bob would be insolvent but can pau
+        assertLt(
+            sharesOwed,
+            bobBalance,
+            "Interest owed in shares should be less than Bob's balance"
+        );
+
+        // Preview should still return the full mathematical interest owed
+        // even though Bob can't pay it all
+        uint256 maxBobCanPay = collateralToken0.convertToAssets(bobBalance);
+        assertLt(previewedInterest, maxBobCanPay, "Preview shows that Bob can pay");
+
+        vm.startPrank(Alice);
+        // Now accrue interest to verify Bob becomes insolvent
+        uint256 charlieAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-before", charlieAssetsBefore);
+        uint256 aliceAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-before", aliceAssetsBefore);
+        uint256 bobAssetsBefore = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-before", bobAssetsBefore);
+
+        uint256 expectedBonus = Math.min(
+            bobAssetsBefore / 2,
+            (tokenData0.leftSlot() - tokenData0.rightSlot())
+        );
+        console.log("expectedBonus", expectedBonus);
+        console2.log("previewBob-before-liq", collateralToken0.previewOwedInterest(Bob));
+
+        liquidate(panopticPool, new TokenId[](0), Bob, positionIdList);
+
+        vm.stopPrank();
+
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 12 seconds);
+
+        console2.log("previewBob-after-liq", collateralToken0.previewOwedInterest(Bob));
+        uint256 charlieAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-after", charlieAssetsAfter);
+        uint256 aliceAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-after", aliceAssetsAfter);
+        uint256 bobAssetsAfter = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-after", bobAssetsAfter);
+        assertGt(bobAssetsAfter, 0, "FAIL: Bob has no shares left");
+
+        assertApproxEqAbs(
+            aliceAssetsAfter - aliceAssetsBefore,
+            expectedBonus,
+            1,
+            "FAIL: wrong bonus"
+        );
+
+        assertApproxEqAbs(
+            charlieAssetsAfter - charlieAssetsBefore,
+            (previewedInterest * charlieAssetsBefore) / (charlieAssetsBefore + bobAssetsBefore),
+            1,
+            "FAIL: charlie did not get his share of the interests"
+        );
+
+        console2.log("previewIn", expectedBonus, previewedInterest);
+        {
+            uint256 deltaInt = (previewedInterest * charlieAssetsBefore) /
+                (charlieAssetsBefore + bobAssetsBefore) +
+                expectedBonus;
+            assertApproxEqAbs(
+                bobAssetsAfter,
+                bobAssetsBefore - deltaInt,
+                10,
+                "FAIL: bob did not get his share of the interests"
+            );
+        }
+        // Bob's base index should not have been updated (remains at old value)
+        (int128 baseIndex, int128 netBorrows) = collateralToken0.interestState(Bob);
+        assertEq(netBorrows, 0, "Net borrows should be zero");
+        assertLe(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
+    }
+
     function test_Success_accrueInterest_liquidation_insolventUser() public {
         _initWorld(0);
         uint104 assets = 1000 ether;
@@ -2295,6 +2627,131 @@ contract CollateralTrackerTest is Test, PositionUtils {
             bobAssetsBefore - expectedBonus,
             1,
             "FAIL: charlie did not get his share of the interests"
+        );
+
+        vm.stopPrank();
+
+        // Bob's balance should be wiped out
+        uint256 bobBalanceAfter = collateralToken0.balanceOf(Bob);
+        assertEq(bobBalanceAfter, 0, "Insolvent Bob should have 0 balance after accrual");
+
+        // Bob's base index should not have been updated (remains at old value)
+        (int128 baseIndex, int128 netBorrows) = collateralToken0.interestState(Bob);
+        assertEq(netBorrows, 0, "Net borrows should be zero");
+        assertLe(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
+    }
+
+    function test_Success_accrueInterest_liquidation_100percent_insolventUser() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Charlie the PLP deposits to provide liquidity
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), assets * 10);
+        collateralToken0.deposit(assets * 10, Charlie);
+        vm.stopPrank();
+
+        // Alice th eliquidator does not deposit or provide liquidity
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        //collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Setup Bob with a small balance and large borrow
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(100 ether, Bob); // Deposit 100 ether
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows a significant amount
+        mintOptions(
+            panopticPool,
+            positionIdList,
+            100 ether, // Borrow same amount as deposit
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        // Reduce Bob's balance to ZERO
+        collateralToken0.burnShares(Bob, collateralToken0.balanceOf(Bob));
+        vm.stopPrank();
+
+        // Move forward significantly to generate high interest
+        vm.warp(block.timestamp + 365 days);
+
+        // Preview should show the full interest owed, regardless of solvency
+        uint128 previewedInterest = collateralToken0.previewOwedInterest(Bob);
+        assertGt(previewedInterest, 0, "Preview should show interest even for insolvent user");
+
+        // Convert to shares to check if user is insolvent
+        uint256 sharesOwed = collateralToken0.convertToShares(previewedInterest);
+        uint256 bobBalance = collateralToken0.balanceOf(Bob);
+
+        // Verify Bob would be insolvent
+        assertGt(sharesOwed, bobBalance, "Interest owed in shares should exceed Bob's balance");
+
+        // Preview should still return the full mathematical interest owed
+        // even though Bob can't pay it all
+        uint256 maxBobCanPay = collateralToken0.convertToAssets(bobBalance);
+        assertGt(previewedInterest, maxBobCanPay, "Preview shows more than Bob can pay");
+
+        vm.startPrank(Alice);
+        // Now accrue interest to verify Bob becomes insolvent
+        uint256 charlieAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-before", charlieAssetsBefore);
+        uint256 aliceAssetsBefore = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-before", aliceAssetsBefore);
+        uint256 bobAssetsBefore = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-before", bobAssetsBefore);
+
+        uint256 expectedBonus = Math.min(
+            bobAssetsBefore / 2,
+            (previewedInterest - bobAssetsBefore)
+        );
+        console2.log("previewBob-before-liq", collateralToken0.previewOwedInterest(Bob));
+
+        liquidate(panopticPool, new TokenId[](0), Bob, positionIdList);
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 12 seconds);
+
+        console2.log("previewBob-after-liq", collateralToken0.previewOwedInterest(Bob));
+        uint256 charlieAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Charlie)
+        );
+        console2.log("c-after", charlieAssetsAfter);
+        uint256 aliceAssetsAfter = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        console2.log("a-after", aliceAssetsAfter);
+        uint256 bobAssetsAfter = collateralToken0.convertToAssets(collateralToken0.balanceOf(Bob));
+        console2.log("b-after", bobAssetsAfter);
+
+        assertApproxEqAbs(
+            aliceAssetsAfter - aliceAssetsBefore,
+            expectedBonus,
+            1,
+            "FAIL: wrong bonus"
+        );
+
+        assertApproxEqAbs(
+            charlieAssetsAfter,
+            charlieAssetsBefore,
+            1,
+            "FAIL: Charlie's balance changed"
         );
 
         vm.stopPrank();

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -596,30 +596,68 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     function test_Success_accrueInterest_oneBlock() public {
         _initWorld(0);
-        uint256 startingBlock = block.number;
+        uint256 startingTime = block.timestamp;
         uint128 initialBorrowIndex = 1e18;
         collateralToken0.setPoolAssets(500);
         collateralToken0.setInAMM(500);
 
         vm.roll(block.number + 1);
+        vm.warp(block.timestamp + 12 seconds);
 
         collateralToken0.accrueInterest();
         // Calculate the expected new borrow index
-        uint128 perBlockInterestRate = collateralToken0.interestRate();
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        uint256 interestForPeriod = uint256(perSecondInterestRate) * 12;
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
-            1e18 + perBlockInterestRate
+            1e18 + interestForPeriod
         );
-        uint256 interestForPeriod = uint256(perBlockInterestRate) * 1;
-
         uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
             collateralToken0._inAMM(),
             interestForPeriod
         );
 
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
-            ((startingBlock + 1) << 96) +
+            ((startingTime + 12) << 96) +
             expectedNewIndex;
+
+        // Get the actual new accumulator value from the contract
+        uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
+
+        // Assert they are equal
+        assertEq(
+            actualAccumulator,
+            expectedAccumulator,
+            "Interest did not accrue correctly for one block"
+        );
+    }
+
+    function test_Success_accrueInterest_loop() public {
+        vm.warp(2 ** 32 - 10);
+        _initWorld(0);
+        uint256 startingTime = block.timestamp;
+        uint128 initialBorrowIndex = 1e18;
+        collateralToken0.setPoolAssets(500);
+        collateralToken0.setInAMM(500);
+
+        vm.warp(2 ** 32 + 10);
+
+        collateralToken0.accrueInterest();
+        console2.log("acc2", collateralToken0._interestRateAccumulator());
+        // Calculate the expected new borrow index
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        uint256 interestForPeriod = uint256(perSecondInterestRate) * 20;
+        uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
+            initialBorrowIndex,
+            1e18 + interestForPeriod
+        );
+        uint256 unrealizedGlobalInterest = Math.mulDivWadRoundingUp(
+            collateralToken0._inAMM(),
+            interestForPeriod
+        );
+
+        uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
+            uint128((uint256(uint32(startingTime + 20)) << 96) + expectedNewIndex);
 
         // Get the actual new accumulator value from the contract
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
@@ -634,7 +672,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     function test_Success_accrueInterest_multipleBlocks(uint32 blocksToSkip) public {
         _initWorld(0);
-        uint256 startingBlock = block.number;
+        uint256 startingTime = block.timestamp;
         uint128 initialBorrowIndex = 1e18; // Set by _initWorld's call to startToken
         collateralToken0.setPoolAssets(500);
         collateralToken0.setInAMM(500);
@@ -643,11 +681,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
         vm.assume(blocksToSkip > 0 && blocksToSkip < 1_000_000);
 
         vm.roll(block.number + blocksToSkip);
+        vm.warp(block.timestamp + 12 * blocksToSkip);
         collateralToken0.accrueInterest();
 
         // Calculate the total linear interest for the entire period.
-        uint128 perBlockInterestRate = collateralToken0.interestRate();
-        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
 
         // Calculate the expected new borrow index by applying the total interest.
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
@@ -662,7 +701,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Construct the full expected accumulator value for the new block.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
-            ((startingBlock + blocksToSkip) << 96) +
+            ((startingTime + blocksToSkip * 12) << 96) +
             expectedNewIndex;
 
         // Get the actual new accumulator value from the contract.
@@ -718,16 +757,18 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.setInAMM(int128(amountToBorrow));
 
         uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
 
         uint32 blocksToSkip = 7200;
         vm.roll(blockAfterBorrow + blocksToSkip);
+        vm.warp(timestampAfterBorrow + 12 * blocksToSkip);
         collateralToken0.accrueInterest();
 
-        uint128 perBlockInterestRate = collateralToken0.interestRate();
-        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -740,7 +781,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
-            ((blockAfterBorrow + blocksToSkip) << 96) +
+            ((timestampAfterBorrow + blocksToSkip * 12) << 96) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
@@ -796,18 +837,20 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // --- Move forward by 1 day ---
 
         uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
 
         uint32 blocksToSkip = 7200;
         console2.log("roll 1 day");
         vm.roll(blockAfterBorrow + blocksToSkip);
+        vm.warp(timestampAfterBorrow + blocksToSkip * 12);
 
         collateralToken0.accrueInterest();
 
-        uint128 perBlockInterestRate = collateralToken0.interestRate();
-        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -819,7 +862,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         );
         // Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
-            ((blockAfterBorrow + blocksToSkip) << 96) +
+            ((timestampAfterBorrow + blocksToSkip * 12) << 96) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
@@ -871,9 +914,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // --- Move forward by 1 day ---
 
         blockAfterBorrow = block.number;
+        timestampAfterBorrow = block.timestamp;
 
         blocksToSkip = 7200;
         vm.roll(blockAfterBorrow + blocksToSkip);
+        vm.warp(timestampAfterBorrow + blocksToSkip * 12);
 
         console2.log("burnOptions", Bob);
 
@@ -961,9 +1006,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
         vm.stopPrank();
 
         uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
 
         uint32 blocksToSkip = 7200 * 365;
         vm.roll(blockAfterBorrow + blocksToSkip);
+        vm.warp(timestampAfterBorrow + blocksToSkip * 12);
         console2.log("before accru", uint128(collateralToken0._interestRateAccumulator()));
         collateralToken0.accrueInterest();
         console2.log("after accru", uint128(collateralToken0._interestRateAccumulator()));
@@ -972,11 +1019,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, , uint256 utilization) = collateralToken0.getPoolData();
             assertGt(utilization, 0, "FAIL: Utilization should be positive after borrow");
         }
-        uint128 perBlockInterestRate = collateralToken0.interestRate();
-        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // 2. Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -989,7 +1036,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // 3. Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 128) +
-            ((blockAfterBorrow + blocksToSkip) << 96) +
+            ((timestampAfterBorrow + blocksToSkip * 12) << 96) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
@@ -1118,9 +1165,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
         vm.stopPrank();
 
         uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
 
         uint32 blocksToSkip = 7200 * 365;
         vm.roll(blockAfterBorrow + blocksToSkip);
+        vm.warp(timestampAfterBorrow + blocksToSkip * 12);
         console2.log("before accru", uint128(collateralToken0._interestRateAccumulator()));
         collateralToken0.accrueInterest();
         console2.log("after accru", uint128(collateralToken0._interestRateAccumulator()));
@@ -1129,18 +1178,19 @@ contract CollateralTrackerTest is Test, PositionUtils {
             (, , uint256 utilization) = collateralToken0.getPoolData();
             assertGt(utilization, 0, "FAIL: Utilization should be positive after borrow");
         }
-        uint128 perBlockInterestRate = collateralToken0.interestRate();
-        assertGt(perBlockInterestRate, 0, "FAIL: Rate should be positive after borrow");
+        uint128 perSecondInterestRate = collateralToken0.interestRate();
+        assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // 2. Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perBlockInterestRate) * blocksToSkip;
+        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
         );
 
         // 3. Construct the full expected accumulator value.
-        uint256 expectedAccumulator = ((blockAfterBorrow + blocksToSkip) << 96) + expectedNewIndex;
+        uint256 expectedAccumulator = ((timestampAfterBorrow + blocksToSkip * 12) << 96) +
+            expectedNewIndex;
         uint256 actualAccumulator = uint128(collateralToken0._interestRateAccumulator());
 
         // 4. Assert the final state is correct.

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -607,7 +607,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.accrueInterest();
         // Calculate the expected new borrow index
         uint128 perSecondInterestRate = collateralToken0.interestRate();
-        uint256 interestForPeriod = uint256(perSecondInterestRate) * 12;
+        uint256 interestForPeriod = Math.wTaylorCompounded(uint256(perSecondInterestRate), 12);
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -646,7 +646,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         console2.log("acc2", collateralToken0._interestRateAccumulator());
         // Calculate the expected new borrow index
         uint128 perSecondInterestRate = collateralToken0.interestRate();
-        uint256 interestForPeriod = uint256(perSecondInterestRate) * 20;
+        uint256 interestForPeriod = Math.wTaylorCompounded(uint256(perSecondInterestRate), 20);
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -686,7 +686,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Calculate the total linear interest for the entire period.
         uint128 perSecondInterestRate = collateralToken0.interestRate();
-        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
+        uint256 interestForPeriod = Math.wTaylorCompounded(
+            uint256(perSecondInterestRate),
+            blocksToSkip * 12
+        );
 
         // Calculate the expected new borrow index by applying the total interest.
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
@@ -768,7 +771,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
+        uint256 interestForPeriod = Math.wTaylorCompounded(
+            uint256(perSecondInterestRate),
+            blocksToSkip * 12
+        );
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -850,7 +856,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
+        uint256 interestForPeriod = Math.wTaylorCompounded(
+            uint256(perSecondInterestRate),
+            blocksToSkip * 12
+        );
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -1023,7 +1032,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // 2. Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
+        uint256 interestForPeriod = Math.wTaylorCompounded(
+            uint256(perSecondInterestRate),
+            blocksToSkip * 12
+        );
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod
@@ -1182,7 +1194,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertGt(perSecondInterestRate, 0, "FAIL: Rate should be positive after borrow");
 
         // 2. Calculate the expected interest for the period.
-        uint256 interestForPeriod = uint256(perSecondInterestRate) * blocksToSkip * 12;
+        uint256 interestForPeriod = Math.wTaylorCompounded(
+            uint256(perSecondInterestRate),
+            blocksToSkip * 12
+        );
         uint256 expectedNewIndex = Math.mulDivWadRoundingUp(
             initialBorrowIndex,
             1e18 + interestForPeriod

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1462,7 +1462,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         }
     }
 
-    function test_Fail_accrueInterest_noMorefunds() public {
+    function test_Success_accrueInterest_noMorefunds() public {
         _initWorld(0);
         uint104 assets = 1000 ether; // Use a fixed deposit amount
 
@@ -1689,6 +1689,514 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 "FAIL: Compounding did not result in higher total interest"
             );
         }
+    }
+
+    function test_Success_accrueInterest_previewOwedInterest() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Alice deposits
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Bob deposits and borrows
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows by minting options
+        panopticPool.mintOptions(
+            positionIdList,
+            assets / 2,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        // Record initial state
+        uint256 initialAccumulator = collateralToken0._interestRateAccumulator();
+        uint128 initialOwedInterest = collateralToken0.owedInterest(Bob);
+
+        // Should be 0 initially since no time has passed
+        assertEq(initialOwedInterest, 0, "Initial owed interest should be 0");
+
+        // Move forward in time without accruing
+        uint256 timeJump = 86400; // 1 day
+        vm.warp(block.timestamp + timeJump);
+
+        // Get preview of what interest would be owed
+        uint128 previewedInterest = collateralToken0.previewOwedInterest(Bob);
+
+        // Verify state hasn't changed
+        uint256 accumulatorAfterPreview = collateralToken0._interestRateAccumulator();
+        assertEq(
+            accumulatorAfterPreview,
+            initialAccumulator,
+            "Preview should not modify accumulator"
+        );
+
+        // owedInterest should still return stale value
+        uint128 staleOwedInterest = collateralToken0.owedInterest(Bob);
+        assertEq(staleOwedInterest, 0, "Stale owed interest should still be 0");
+
+        // Preview should show non-zero interest
+        assertGt(previewedInterest, 0, "Preview should show interest accrued over time");
+
+        // Now actually accrue interest
+        collateralToken0.accrueInterest();
+
+        // After accrual, owedInterest should match what preview showed
+        uint128 actualOwedInterest = collateralToken0.owedInterest(Bob);
+        assertEq(
+            actualOwedInterest,
+            previewedInterest,
+            "Actual owed interest should match preview"
+        );
+
+        // Test preview with multiple time jumps
+        uint256 timeJump2 = 43200; // 0.5 days
+        vm.warp(block.timestamp + timeJump2);
+
+        uint128 previewedInterest2 = collateralToken0.previewOwedInterest(Bob);
+        assertGt(
+            previewedInterest2,
+            actualOwedInterest,
+            "Preview should show additional interest for new time period"
+        );
+
+        // Verify preview works correctly for users with no borrows
+        uint128 alicePreview = collateralToken0.previewOwedInterest(Alice);
+        assertEq(alicePreview, 0, "Preview for non-borrower should be 0");
+
+        // Test preview in same block (deltaTime = 0)
+        collateralToken0.accrueInterest();
+        uint128 immediatePreview = collateralToken0.previewOwedInterest(Bob);
+        uint128 immediateOwed = collateralToken0.owedInterest(Bob);
+        assertEq(
+            immediatePreview,
+            immediateOwed,
+            "Preview in same block should match owedInterest"
+        );
+    }
+
+    function test_Success_previewOwedInterest_insolventUser() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Alice deposits to provide liquidity
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Setup Bob with a small balance and large borrow
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(100 ether, Bob); // Deposit 100 ether
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows a significant amount
+        panopticPool.mintOptions(
+            positionIdList,
+            100 ether, // Borrow same amount as deposit
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+
+        // Reduce Bob's balance to make him insolvent when interest accrues
+        collateralToken0.setBalance(Bob, 1 ether); // Set very low balance
+        vm.stopPrank();
+
+        // Move forward significantly to generate high interest
+        vm.warp(block.timestamp + 365 days);
+
+        // Preview should show the full interest owed, regardless of solvency
+        uint128 previewedInterest = collateralToken0.previewOwedInterest(Bob);
+        assertGt(previewedInterest, 0, "Preview should show interest even for insolvent user");
+
+        // Convert to shares to check if user is insolvent
+        uint256 sharesOwed = collateralToken0.convertToShares(previewedInterest);
+        uint256 bobBalance = collateralToken0.balanceOf(Bob);
+
+        // Verify Bob would be insolvent
+        assertGt(sharesOwed, bobBalance, "Interest owed in shares should exceed Bob's balance");
+
+        // Preview should still return the full mathematical interest owed
+        // even though Bob can't pay it all
+        uint256 maxBobCanPay = collateralToken0.convertToAssets(bobBalance);
+        assertGt(previewedInterest, maxBobCanPay, "Preview shows more than Bob can pay");
+
+        vm.startPrank(Bob);
+        // Now accrue interest to verify Bob becomes insolvent
+        collateralToken0.accrueInterest();
+        vm.stopPrank();
+
+        // Bob's balance should be wiped out
+        uint256 bobBalanceAfter = collateralToken0.balanceOf(Bob);
+        assertEq(bobBalanceAfter, 0, "Insolvent Bob should have 0 balance after accrual");
+
+        // Bob's base index should not have been updated (remains at old value)
+        (int128 baseIndex, int128 netBorrows) = collateralToken0.interestState(Bob);
+        assertEq(netBorrows, 100 ether, "Net borrows should remain unchanged");
+        assertLt(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
+    }
+
+    function test_Fuzz_previewOwedInterest_accuracy(uint32 timeDelta) public {
+        // Bound the time delta to reasonable values (1 second to 1 year)
+        timeDelta = uint32(bound(timeDelta, 1, 3650 days));
+
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Alice deposits for liquidity
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Bob deposits and borrows
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows
+        uint128 borrowAmount = assets / 2;
+        panopticPool.mintOptions(
+            positionIdList,
+            borrowAmount,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        // Record state immediately after borrow
+        uint256 initialTimestamp = block.timestamp;
+
+        // Move forward by fuzzed time delta
+        vm.warp(initialTimestamp + timeDelta);
+
+        // Get preview before accrual
+        uint128 previewedInterest = collateralToken0.previewOwedInterest(Bob);
+
+        // Store state before accrual to verify preview didn't change it
+        uint256 accumulatorBefore = collateralToken0._interestRateAccumulator();
+        (int128 baseIndexBefore, int128 netBorrowsBefore) = collateralToken0.interestState(Bob);
+
+        // Actually accrue interest
+        collateralToken0.accrueInterest();
+
+        // Get actual interest after accrual
+        uint128 actualInterest = collateralToken0.owedInterest(Bob);
+
+        // Verify preview didn't modify state
+        assertEq(
+            accumulatorBefore >> 96, // Extract timestamp portion
+            initialTimestamp,
+            "Preview modified the accumulator timestamp"
+        );
+
+        // Main assertion: preview should exactly match actual
+        assertEq(
+            previewedInterest,
+            actualInterest,
+            "Preview interest doesn't match actual interest after accrual"
+        );
+
+        // Additional test: multiple preview calls should return same result
+        vm.warp(block.timestamp + timeDelta);
+        {
+            uint128 preview1 = collateralToken0.previewOwedInterest(Bob);
+            uint128 preview2 = collateralToken0.previewOwedInterest(Bob);
+            assertEq(preview1, preview2, "Multiple preview calls return different results");
+        }
+        // Test preview accuracy for Charlie (non-borrower)
+        uint128 charliePreview = collateralToken0.previewOwedInterest(Charlie);
+        assertEq(charliePreview, 0, "Non-borrower should have zero preview interest");
+
+        // Edge case: preview immediately after accrual (deltaTime = 0)
+        {
+            collateralToken0.accrueInterest();
+            uint128 immediatePreview = collateralToken0.previewOwedInterest(Bob);
+            uint128 immediateOwed = collateralToken0.owedInterest(Bob);
+            assertEq(
+                immediatePreview,
+                immediateOwed,
+                "Preview with deltaTime=0 should match owedInterest"
+            );
+        }
+        // Test with varying borrow amounts by having Bob adjust position
+        if (timeDelta < 30 days) {
+            // Only do this for shorter time periods to avoid overflow
+            vm.startPrank(Bob);
+
+            // Bob increases his borrow
+            panopticPool.burnOptions(
+                positionIdList[0],
+                new TokenId[](0),
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
+
+            // Bob increases his borrow
+            panopticPool.mintOptions(
+                positionIdList,
+                borrowAmount + borrowAmount / 4,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK
+            );
+
+            // Move forward again
+            vm.warp(block.timestamp + timeDelta);
+
+            vm.stopPrank();
+            // Preview should account for the new borrow amount
+            uint128 previewAfterIncrease = collateralToken0.previewOwedInterest(Bob);
+            collateralToken0.accrueInterest();
+            uint128 actualAfterIncrease = collateralToken0.owedInterest(Bob);
+
+            assertEq(
+                previewAfterIncrease,
+                actualAfterIncrease,
+                "Preview doesn't match actual after position change"
+            );
+        }
+
+        // Verify mathematical properties
+        if (timeDelta > 1) {
+            // Interest should be monotonically increasing with time
+            vm.warp(initialTimestamp + (timeDelta / 2));
+            uint128 halfTimePreview = collateralToken0.previewOwedInterest(Bob);
+
+            vm.warp(initialTimestamp + timeDelta);
+            uint128 fullTimePreview = collateralToken0.previewOwedInterest(Bob);
+
+            assertGe(
+                fullTimePreview,
+                halfTimePreview,
+                "Interest should increase monotonically with time"
+            );
+        }
+
+        // Test precision: ensure we're not losing significant amounts to rounding
+        if (borrowAmount > 1e18 && timeDelta > 1 days) {
+            // For significant borrows over meaningful time, interest should be non-zero
+            assertGt(
+                previewedInterest,
+                0,
+                "Should accrue non-zero interest for significant borrows"
+            );
+        }
+    }
+
+    function test_Success_accrueInterest_compoundingAccuracy() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Setup initial liquidity
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // Setup two identical borrowers - Bob (frequent accrual) and Charlie (infrequent accrual)
+        uint128 borrowAmount = 100 ether;
+        uint256 depositAmount = 200 ether;
+
+        // Bob setup
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmount);
+        collateralToken0.deposit(depositAmount, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        panopticPool.mintOptions(
+            positionIdList,
+            borrowAmount,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        // Charlie setup (identical position)
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmount);
+        collateralToken0.deposit(depositAmount, Charlie);
+
+        panopticPool.mintOptions(
+            positionIdList,
+            borrowAmount,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        collateralToken0.setBalance(Bob, 1e6 * 200 ether);
+        collateralToken0.setBalance(Charlie, 1e6 * 200 ether);
+        // Record initial balances
+        uint256 bobInitialBalance = collateralToken0.balanceOf(Bob);
+        uint256 charlieInitialBalance = collateralToken0.balanceOf(Charlie);
+        assertEq(bobInitialBalance, charlieInitialBalance, "Initial balances should match");
+
+        // Test period: 365 days
+        uint256 testDuration = 365 days;
+        uint256 startTime = block.timestamp;
+        uint256 endTime = startTime + testDuration;
+
+        // Bob: Accrue interest frequently (hourly)
+        uint256 accrualFrequency = 1 hours;
+        uint256 numAccruals = testDuration / accrualFrequency;
+
+        for (uint256 i = 0; i < numAccruals; i++) {
+            vm.warp(startTime + (i + 1) * accrualFrequency);
+            vm.prank(Bob);
+            collateralToken0.accrueInterest();
+        }
+
+        uint256 bobFinalBalance = collateralToken0.balanceOf(Bob);
+        uint256 bobInterestPaid = collateralToken0.convertToAssets(
+            bobInitialBalance - bobFinalBalance
+        );
+
+        // Charlie: Accrue interest once at the end
+        vm.warp(endTime);
+        vm.prank(Charlie);
+        collateralToken0.accrueInterest();
+
+        uint256 tolerance;
+        {
+            uint256 charlieFinalBalance = collateralToken0.balanceOf(Charlie);
+            uint256 charlieInterestPaid = collateralToken0.convertToAssets(
+                charlieInitialBalance - charlieFinalBalance
+            );
+
+            // Log results for debugging
+            console2.log("Bob (daily accrual) paid:", bobInterestPaid);
+            console2.log("Charlie (single accrual) paid:", charlieInterestPaid);
+            console2.log(
+                "Difference:",
+                bobInterestPaid > charlieInterestPaid
+                    ? bobInterestPaid - charlieInterestPaid
+                    : charlieInterestPaid - bobInterestPaid
+            );
+
+            // The difference should be minimal (due to rounding in compound calculations)
+            // We allow for a small tolerance based on the total interest amount
+            tolerance = Math.max(bobInterestPaid, charlieInterestPaid) / 1000; // 1% tolerance
+            uint256 tolerance = bobInterestPaid ** 2 /
+                (collateralToken0.convertToAssets(bobInitialBalance));
+
+            assertApproxEqAbs(
+                bobInterestPaid,
+                charlieInterestPaid,
+                tolerance,
+                "Interest paid should be nearly identical regardless of accrual frequency"
+            );
+        }
+    }
+
+    function test_Success_accrueInterest_maxValues() public {
+        _initWorld(0);
+
+        // Setup with near-maximum values
+        // Use values close to type(uint104).max (the limit for deposits)
+        uint128 maxAssets = type(uint104).max - 1e18; // Leave small buffer for calculations
+
+        // Alice provides massive liquidity
+        vm.startPrank(Alice);
+        deal(token0, Alice, type(uint256).max);
+        deal(token1, Alice, type(uint256).max);
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        collateralToken0.deposit(maxAssets / 2, Alice);
+        vm.stopPrank();
+
+        // Bob makes a massive deposit and borrow
+        vm.startPrank(Bob);
+        deal(token0, Bob, type(uint256).max);
+        deal(token1, Bob, type(uint256).max);
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        collateralToken0.deposit(maxAssets / 2, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows near the maximum possible amount
+        uint128 maxBorrow = uint128(maxAssets / 450000);
+        panopticPool.mintOptions(
+            positionIdList,
+            maxBorrow,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK
+        );
+        vm.stopPrank();
+
+        collateralToken0.setInAMM(int128(maxAssets - 1)); // Maximum borrowed
+        Math.wTaylorCompounded(2 ** 93, type(uint32).max);
+
+        // Record initial state
+        uint256 initialAccumulator = collateralToken0._interestRateAccumulator();
+        uint256 bobInitialBalance = collateralToken0.balanceOf(Bob);
+        (int128 initialBaseIndex, int128 initialNetBorrows) = collateralToken0.interestState(Bob);
+
+        // Test 1: Maximum time jump (just under uint32 max to avoid wrap)
+        vm.roll(block.number + 1);
+        vm.warp(block.timestamp + type(uint32).max); // 138 years
+
+        // This should not revert despite massive values
+        vm.prank(Bob);
+        collateralToken0.accrueInterest();
+
+        // Verify state updated correctly
+        uint256 newAccumulator = collateralToken0._interestRateAccumulator();
+        assertGt(newAccumulator, initialAccumulator, "Accumulator should have increased");
+
+        // Verify Bob paid interest (or was wiped out if insolvent)
+        uint256 bobAfterBalance = collateralToken0.balanceOf(Bob);
+        assertLe(bobAfterBalance, bobInitialBalance, "Bob's balance should decrease or be zero");
+        console2.log("Final borrow index:", collateralToken0.borrowIndex());
+        console2.log("Final unrealized interest:", collateralToken0.unrealizedGlobalInterest());
+        console2.log("Bob final balance:", collateralToken0.balanceOf(Bob));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/libraries/Math.t.sol
+++ b/test/foundry/libraries/Math.t.sol
@@ -10,6 +10,7 @@ import {TickMath} from "v3-core/libraries/TickMath.sol";
 import {FullMath} from "v3-core/libraries/FullMath.sol";
 import {Tick} from "v3-core/libraries/Tick.sol";
 import "forge-std/Test.sol";
+import "forge-std/StdError.sol";
 
 /**
  * Test the Core Math library using Foundry and Fuzzing.
@@ -367,5 +368,131 @@ contract MathTest is Test {
             .liquidity();
 
         assertEq(uniV3Result, returnedResult);
+    }
+
+    function test_wTaylorCompounded_SmallValues() public {
+        // Test with very small nx values where approximation should be nearly exact
+
+        uint256 x1 = 1; //
+        uint256 n1 = 1; //
+        uint256 result1 = Math.wTaylorCompounded(x1, n1);
+        uint256 expected1 = 1; // nx = 1e13, very close to first term
+
+        // For such small values, result should be equal to nx (first term)
+        assertEq(result1, expected1); // 0.0001% tolerance
+
+        // Case 2: x = 1000, n = 1 → nx = 0.01
+        uint256 x2 = 1e9; // 1e-9 * WAD
+        uint256 n2 = 1;
+        uint256 result2 = Math.wTaylorCompounded(x2, n2);
+        uint256 expected2 = x2; // nx = 1e13
+
+        assertEq(result2, expected2); // 0.0001% tolerance
+
+        // Case 3: Largest value for which output = n*x
+        uint256 x3 = 1414213562; // √2 * 1e-9 WAD
+        uint256 n3 = 1;
+        uint256 result3 = Math.wTaylorCompounded(x3, n3);
+        uint256 expected3 = x3; //
+
+        assertEq(result3, expected3); // output = input exactly
+
+        // Case 3: Largest value for which output = n*x
+        uint256 x4 = 1414213563; // (√2 * 1e-9 + 1) WAD
+        uint256 n4 = 1;
+        uint256 result4 = Math.wTaylorCompounded(x4, n4);
+        uint256 expected4 = x4 + 1; //
+
+        assertEq(result4, expected4); // output = input + 1
+    }
+
+    function test_wTaylorCompounded_LargeValues() public {
+        // Test with larger nx values (1.0 - 5.0) to understand degradation
+
+        // Case 1: nx = 1.0
+        uint256 x1 = 1e18; // 1.0 * WAD
+        uint256 n1 = 1;
+        uint256 result1 = Math.wTaylorCompounded(x1, n1);
+        // nx=1e18, (nx)²/(2*WAD) = 5e17, (nx)³/(6*WAD²) = 166666666666666666
+        uint256 expected1 = 1e18 + 5e17 + 166666666666666666; // 1.666666666666666666 * WAD
+        uint256 exact1 = 1718281828459045235;
+
+        assertEq(result1, expected1);
+        assertApproxEqRel(result1, exact1, 516e14); // within 0.0516%
+
+        // Case 1: nx = 10
+        uint256 x2 = 1e19; // 10 * WAD
+        uint256 n2 = 1;
+        uint256 result2 = Math.wTaylorCompounded(x2, n2);
+        // nx=10, first=10, second=50, third≈166.67
+        uint256 expected2 = 10e18 + 50e18 + 166666666666666666666; // 226.666... * WAD
+        uint256 exact2 = 22025465794806716516957;
+
+        assertEq(result2, expected2);
+        assertApproxEqRel(result2, exact2, 9898e14); // within 98.98%, so pretty bad
+    }
+
+    function test_wTaylorCompounded_VeryLargeInputs() public {
+        // Test behavior near uint256 limits
+
+        // Case 1: Maximum safe single input (√uint256_max ≈ 2^128)
+
+        uint256 maxVal = 88567974649812873576190202090484573885; // ~2^128
+        uint256 x1 = maxVal + 1;
+        uint256 n1 = 1;
+
+        vm.expectRevert(stdError.arithmeticError);
+        harness.wTaylorCompounded(maxVal + 1, 1);
+
+        // Case 2: At largest possible valuem should work
+        uint256 result2 = Math.wTaylorCompounded(maxVal, 1);
+
+        uint256 expectedFirst2 = type(uint256).max;
+        assertApproxEqRel(result2, expectedFirst2, 1);
+        assertLt(result2, type(uint256).max);
+    }
+
+    function testFuzz_wTaylorCompounded_MonotonicInX(uint256 x1, uint256 x2) public {
+        // Verify output increases with x when n is fixed
+
+        // Bound inputs to avoid overflow issues
+        x1 = bound(x1, 0, 88567974649812873576190202090484573885); // Max safe value from your previous test
+        x2 = bound(x2, 0, 88567974649812873576190202090484573885);
+
+        // Ensure x1 ≠ x2 for meaningful comparison
+        vm.assume(x1 != x2);
+
+        // Calculate results for both x values with same n
+        uint256 result1 = Math.wTaylorCompounded(x1, 1);
+        uint256 result2 = Math.wTaylorCompounded(x2, 1);
+
+        // Verify monotonicity: if x1 < x2, then result1 < result2
+        if (x1 < x2) {
+            assertLt(result1, result2, "Function should be strictly increasing in x");
+        } else {
+            // x1 > x2 (since we assumed x1 != x2)
+            assertGt(result1, result2, "Function should be strictly increasing in x");
+        }
+    }
+
+    function testFuzz_wTaylorCompounded_MonotonicInN(uint256 x1, uint256 n) public {
+        // Verify output increases with n when x is fixed
+
+        // First bound n to reasonable range
+        n = bound(n, 1, 1e20); // Much smaller range to avoid extreme cases
+
+        // Then bound x1 based on n to avoid overflow
+        uint256 maxSafeX = 88567974649812873576190202090484573885 / (2 * n);
+
+        // Ensure maxSafeX is at least 1, otherwise skip this test case
+        vm.assume(maxSafeX >= 1);
+
+        x1 = bound(x1, 1, maxSafeX);
+
+        // Calculate results for both n values with same x
+        uint256 result1 = Math.wTaylorCompounded(x1, n);
+        uint256 result2 = Math.wTaylorCompounded(x1, n + 1);
+
+        assertLt(result1, result2, "Function should be strictly increasing in n");
     }
 }

--- a/test/foundry/libraries/Math.t.sol
+++ b/test/foundry/libraries/Math.t.sol
@@ -200,6 +200,20 @@ contract MathTest is Test {
         harness.mulDiv192(input, input);
     }
 
+    function test_Success_mulDivWad_Simple(uint128 a, uint128 b) public view {
+        uint256 expectedResult = FullMath.mulDiv(a, b, 1e18);
+        uint256 returnedResult = harness.mulDivWad(a, b);
+        assertEq(expectedResult, returnedResult);
+    }
+
+    function test_Fail_mulDivWad_Overflow() public {
+        uint256 a = 2 ** 128;
+        uint256 b = 2 ** 128 * 1_000_000_000_000_000_000;
+
+        vm.expectRevert();
+        harness.mulDivWad(a, b);
+    }
+
     function test_Success_mulDivCapped(uint256 a, uint256 b, uint256 c, uint256 power) public view {
         power = bound(power, 0, 255);
         vm.assume(c != 0);

--- a/test/foundry/libraries/harnesses/MathHarness.sol
+++ b/test/foundry/libraries/harnesses/MathHarness.sol
@@ -125,6 +125,11 @@ contract MathHarness {
         return result;
     }
 
+    function mulDivWad(uint256 a, uint256 b) public pure returns (uint256) {
+        uint256 result = Math.mulDivWad(a, b);
+        return result;
+    }
+
     function unsafeDivRoundingUp(uint256 a, uint256 b) public pure returns (uint256) {
         uint256 result = Math.unsafeDivRoundingUp(a, b);
         return result;

--- a/test/foundry/libraries/harnesses/MathHarness.sol
+++ b/test/foundry/libraries/harnesses/MathHarness.sol
@@ -175,4 +175,8 @@ contract MathHarness {
         LiquidityChunk result = Math.getLiquidityForAmount1(tl, tu, a1);
         return result;
     }
+
+    function wTaylorCompounded(uint256 x, uint256 n) public pure returns (uint256) {
+        return Math.wTaylorCompounded(x, n);
+    }
 }


### PR DESCRIPTION
This PR introduces a protocol-wide interest accrual mechanism into CollateralTracker, along with math utilities and tests. 

This is in direct response to the commissions-based yield being too low and not reactive enough to allow for new capital to respond to higher yields (yields are ex post).

Not doing it here, but this means the size of the commissions will need to be adjusted down to reflect on the interest-rate model being the main source of yield of passive LPs instead of pure commissions (will still keep a small commission rate to prevent attacks)

## Key changes

### Global accumulator (s_interestRateAccumulator) 

- Left slot: `unrealizedGlobalInterest` (uint128)
- Right slot: packed (`lastBlock:uint32`, `borrowIndex:uint96`)
- Updated on every accrual to track protocol-wide interest growth.

### Per-account state (s_interestState)

- Left slot: `netBorrows` (int128)
- Right slot: `baseIndex` snapshot (int128)
- Used to compute user-level interest owed relative to global borrow index.

### Accrual flow

- New `_accrueInterest(owner)` called on deposits, withdrawals, transfers, exercises, settles, liquidations, refunds.
- Computes `deltaBlock` using `uint32` wrap-safe subtraction.
- Updates borrow index and `unrealizedGlobalInterest`.
- Charges user interest by burning shares, redistributing value to LPs.
- Clears user’s owed interest from global unrealized bucket.

### Accounting updates

- `totalAssets()` and `_poolUtilization()` now include unrealizedGlobalInterest.
- `interestState(address)` getter exposes per-user baseIndex + netBorrows.
- Added getters for `borrowIndex`, `lastInteractionBlock`, `unrealizedGlobalInterest`.

### Math library

- Added `mulDivWad` and `mulDivWadRoundingUp` optimized for `1e18` denominator
- Extensive tests against FullMath.mulDiv.

### Tests

- Added end-to-end scenarios for one-block and multi-block accrual, deposits without borrowing, borrowing via option mints, long/short flows, and negative borrow cases.
- Verified accumulator packing, borrow index evolution, global interest bucket behavior, and per-user owed interest.

### Notes / TODO

- Current interest rate is constant (≈20% APR per block basis) once utilization > 0. Utilization-dependent curve to be added later. Likely follow Morpho's PD controller on the log of the rate (using TickMath)
- While I added a test that involved selling+buying from multiple users, more tests to explore more complex scenarios


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protocol-wide block-based interest accrual with per-account tracking and a global borrow index; interest now affects balances, pool utilization, and margin health. New read-only views to inspect index, last interaction, unrealized global interest, per-account interest state, rate, and owed/previewed interest.

* **Libraries**
  * Added WAD fixed-point helpers and a Taylor-series utility for compounded math.

* **Style**
  * Minor whitespace cleanup.

* **Tests**
  * Extensive interest-accrual and WAD/math tests with new harness accessors for deterministic validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->