### PR TITLE
Fix0: long premia only at mint + virtual shares in settleLongPremium

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -542,12 +542,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param receiver User to receive the assets
     /// @param owner User to burn the shares from
     /// @param positionIdList The list of all option positions held by `owner`
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     /// @return shares The amount of shares burned to withdraw the desired amount of assets
     function withdraw(
         uint256 assets,
         address receiver,
         address owner,
-        TokenId[] calldata positionIdList
+        TokenId[] calldata positionIdList,
+        bool usePremiaAsCollateral
     ) external returns (uint256 shares) {
         shares = previewWithdraw(assets);
 
@@ -565,7 +567,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         s_poolAssets -= uint128(assets);
 
         // reverts if account is not solvent/eligible to withdraw
-        s_panopticPool.validateCollateralWithdrawable(owner, positionIdList);
+        s_panopticPool.validateCollateralWithdrawable(owner, positionIdList, usePremiaAsCollateral);
 
         // transfer assets (underlying token funds) from the PanopticPool to the LP
         SafeTransferLib.safeTransferFrom(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -6,7 +6,6 @@ import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
 import {IUniswapV3Pool} from "univ3-core/interfaces/IUniswapV3Pool.sol";
 // Inherited implementations
-import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 import {Multicall} from "@base/Multicall.sol";
 // Libraries
 import {Constants} from "@libraries/Constants.sol";
@@ -23,7 +22,7 @@ import {TokenId} from "@types/TokenId.sol";
 /// @title The Panoptic Pool: Create permissionless options on a CLAMM.
 /// @author Axicon Labs Limited
 /// @notice Manages positions, collateral, liquidations and forced exercises.
-contract PanopticPool is ERC1155Holder, Multicall {
+contract PanopticPool is Multicall {
     /*//////////////////////////////////////////////////////////////
                                 EVENTS
     //////////////////////////////////////////////////////////////*/
@@ -98,7 +97,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     int24 internal constant MAX_SWAP_TICK = Constants.MAX_V3POOL_TICK + 1;
 
     /// @notice Flag that signals to compute premia for both the short and long legs of a position.
-    bool internal constant COMPUTE_ALL_PREMIA = true;
+    bool internal constant COMPUTE_PREMIA_AS_COLLATERAL = true;
 
     /// @notice Flag that indicates only to include the share of (settled) premium that is available to collect when calling `_calculateAccumulatedPremia`.
     bool internal constant ONLY_AVAILABLE_PREMIUM = false;
@@ -292,6 +291,24 @@ contract PanopticPool is ERC1155Holder, Multicall {
     }
 
     /*//////////////////////////////////////////////////////////////
+                              EIP SUPPORT
+    //////////////////////////////////////////////////////////////*/
+
+    // note: this contract does not need to accept batch ERC1155 transfers from the SFPM or supply ERC-165 calls
+    // thus, `supportsInterface` and `onERC1155BatchReceived` are left unimplemented to reduce contract size
+
+    /// @notice Returns magic value when called by the `SemiFungiblePositionManager` contract to indicate that this contract supports ERC1155.
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes memory
+    ) external pure returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    /*//////////////////////////////////////////////////////////////
                              QUERY HELPERS
     //////////////////////////////////////////////////////////////*/
 
@@ -314,11 +331,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @dev Reverts if account is not solvent with `BP_DECREASE_BUFFER`.
     /// @param user The account to check for collateral withdrawal eligibility
     /// @param positionIdList The list of all option positions held by `user`
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function validateCollateralWithdrawable(
         address user,
-        TokenId[] calldata positionIdList
+        TokenId[] calldata positionIdList,
+        bool usePremiaAsCollateral
     ) external view {
-        _validateSolvency(user, positionIdList, BP_DECREASE_BUFFER);
+        _validateSolvency(user, positionIdList, BP_DECREASE_BUFFER, usePremiaAsCollateral);
     }
 
     /// @notice Returns the total amount of premium accumulated for a list of positions and a list containing the corresponding `PositionBalance` information for each position.
@@ -341,7 +360,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             _calculateAccumulatedPremia(
                 user,
                 positionIdList,
-                COMPUTE_ALL_PREMIA,
+                COMPUTE_PREMIA_AS_COLLATERAL,
                 includePendingPremium,
                 currentTick
             );
@@ -350,7 +369,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @notice Calculate the accumulated premia owed from the option buyer to the option seller.
     /// @param user The holder of options
     /// @param positionIdList The list of all option positions held by user
-    /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false)
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     /// @param includePendingPremium If true, include premium that is owed to the user but has not yet settled; if false, only include premium that is available to collect
     /// @param atTick The current tick of the Uniswap pool
     /// @return shortPremium The total amount of premium owed (which may `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
@@ -359,7 +378,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     function _calculateAccumulatedPremia(
         address user,
         TokenId[] calldata positionIdList,
-        bool computeAllPremia,
+        bool usePremiaAsCollateral,
         bool includePendingPremium,
         int24 atTick
     )
@@ -379,8 +398,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
         for (uint256 k = 0; k < pLength; ) {
             TokenId tokenId = positionIdList[k];
 
-            balances[k][0] = TokenId.unwrap(tokenId);
-            balances[k][1] = PositionBalance.unwrap(s_positionBalance[c_user][tokenId]);
+            balances[k] = [
+                TokenId.unwrap(tokenId),
+                PositionBalance.unwrap(s_positionBalance[c_user][tokenId])
+            ];
 
             (
                 LeftRightSigned[4] memory premiaByLeg,
@@ -389,7 +410,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                     tokenId,
                     LeftRightUnsigned.wrap(balances[k][1]).rightSlot(),
                     c_user,
-                    computeAllPremia,
+                    usePremiaAsCollateral,
                     atTick
                 );
 
@@ -406,16 +427,17 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         );
 
                         (uint256 totalLiquidity, , ) = _getLiquidities(tokenId, leg);
-                        LeftRightUnsigned availablePremium = _getAvailablePremium(
-                            totalLiquidity,
-                            s_settledTokens[chunkKey],
-                            s_grossPremiumLast[chunkKey],
-                            LeftRightUnsigned.wrap(
-                                uint256(LeftRightSigned.unwrap(premiaByLeg[leg]))
-                            ),
-                            premiumAccumulatorsByLeg[leg]
+                        shortPremium = shortPremium.add(
+                            _getAvailablePremium(
+                                totalLiquidity,
+                                s_settledTokens[chunkKey],
+                                s_grossPremiumLast[chunkKey],
+                                LeftRightUnsigned.wrap(
+                                    uint256(LeftRightSigned.unwrap(premiaByLeg[leg]))
+                                ),
+                                premiumAccumulatorsByLeg[leg]
+                            )
                         );
-                        shortPremium = shortPremium.add(availablePremium);
                     } else {
                         shortPremium = shortPremium.add(
                             LeftRightUnsigned.wrap(
@@ -480,14 +502,16 @@ contract PanopticPool is ERC1155Holder, Multicall {
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
         int24 tickLimitLow,
-        int24 tickLimitHigh
+        int24 tickLimitHigh,
+        bool usePremiaAsCollateral
     ) external {
         _mintOptions(
             positionIdList,
             positionSize,
             effectiveLiquidityLimitX32,
             tickLimitLow,
-            tickLimitHigh
+            tickLimitHigh,
+            usePremiaAsCollateral
         );
     }
 
@@ -496,15 +520,22 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param newPositionIdList The new positionIdList without the token being burnt
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function burnOptions(
         TokenId tokenId,
         TokenId[] calldata newPositionIdList,
         int24 tickLimitLow,
-        int24 tickLimitHigh
+        int24 tickLimitHigh,
+        bool usePremiaAsCollateral
     ) external {
         _burnOptions(COMMIT_LONG_SETTLED, tokenId, msg.sender, tickLimitLow, tickLimitHigh);
 
-        uint256 medianData = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
+        uint256 medianData = _validateSolvency(
+            msg.sender,
+            newPositionIdList,
+            NO_BUFFER,
+            usePremiaAsCollateral
+        );
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
@@ -515,11 +546,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param newPositionIdList The new positionIdList without the token(s) being burnt
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function burnOptions(
         TokenId[] calldata positionIdList,
         TokenId[] calldata newPositionIdList,
         int24 tickLimitLow,
-        int24 tickLimitHigh
+        int24 tickLimitHigh,
+        bool usePremiaAsCollateral
     ) external {
         _burnAllOptionsFrom(
             msg.sender,
@@ -529,7 +562,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
             positionIdList
         );
 
-        uint256 medianData = _validateSolvency(msg.sender, newPositionIdList, NO_BUFFER);
+        uint256 medianData = _validateSolvency(
+            msg.sender,
+            newPositionIdList,
+            NO_BUFFER,
+            usePremiaAsCollateral
+        );
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
         if (medianData != 0) s_miniMedian = medianData;
@@ -546,12 +584,14 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function _mintOptions(
         TokenId[] calldata positionIdList,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
         int24 tickLimitLow,
-        int24 tickLimitHigh
+        int24 tickLimitHigh,
+        bool usePremiaAsCollateral
     ) internal {
         // the new tokenId will be the last element in `positionIdList`
         TokenId tokenId;
@@ -613,7 +653,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
-        _checkSolvency(msg.sender, positionIdList, tickData, BP_DECREASE_BUFFER);
+        _checkSolvency(
+            msg.sender,
+            positionIdList,
+            tickData,
+            BP_DECREASE_BUFFER,
+            usePremiaAsCollateral
+        );
 
         emit OptionMinted(msg.sender, tokenId, balanceData, commissions);
     }
@@ -778,11 +824,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param user The account to validate
     /// @param positionIdList The list of positions to validate solvency for
     /// @param buffer The buffer to apply to the collateral requirement for `user`
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     /// @return If nonzero (enough time has passed since last observation), the updated value for `s_miniMedian` with a new observation
     function _validateSolvency(
         address user,
         TokenId[] calldata positionIdList,
-        uint256 buffer
+        uint256 buffer,
+        bool usePremiaAsCollateral
     ) internal view returns (uint256) {
         (
             int24 currentTick,
@@ -799,7 +847,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             lastObservedTick
         );
 
-        _checkSolvency(user, positionIdList, tickData, buffer);
+        _checkSolvency(user, positionIdList, tickData, buffer, usePremiaAsCollateral);
 
         return medianData;
     }
@@ -809,11 +857,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param positionIdList The list of positions to validate solvency for
     /// @param tickData The packed tick data to check solvency at
     /// @param buffer The buffer to apply to the collateral requirement for `user`
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function _checkSolvency(
         address user,
         TokenId[] calldata positionIdList,
         uint96 tickData,
-        uint256 buffer
+        uint256 buffer,
+        bool usePremiaAsCollateral
     ) internal view {
         // check that the provided positionIdList matches the positions in memory
         _validatePositionList(user, positionIdList, 0);
@@ -848,7 +898,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
             atTicks[0] = fastOracleTick;
         }
 
-        _checkSolvencyAtTicks(user, positionIdList, currentTick, atTicks, buffer, ASSERT_SOLVENCY);
+        _checkSolvencyAtTicks(
+            user,
+            positionIdList,
+            currentTick,
+            atTicks,
+            buffer,
+            ASSERT_SOLVENCY,
+            usePremiaAsCollateral
+        );
     }
 
     /// @notice Burns and handles the exercise of options.
@@ -958,7 +1016,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 currentTick,
                 atTicks,
                 NO_BUFFER,
-                ASSERT_INSOLVENCY
+                ASSERT_INSOLVENCY,
+                COMPUTE_PREMIA_AS_COLLATERAL
             );
         }
 
@@ -971,7 +1030,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             (shortPremium, longPremium, positionBalanceArray) = _calculateAccumulatedPremia(
                 liquidatee,
                 positionIdList,
-                COMPUTE_ALL_PREMIA,
+                COMPUTE_PREMIA_AS_COLLATERAL,
                 ONLY_AVAILABLE_PREMIUM,
                 currentTick
             );
@@ -1055,7 +1114,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
         s_collateralToken1.settleLiquidation(msg.sender, liquidatee, bonusAmounts.leftSlot());
 
         // ensure the liquidator is still solvent after the liquidation
-        _validateSolvency(msg.sender, positionIdListLiquidator, NO_BUFFER);
+        _validateSolvency(
+            msg.sender,
+            positionIdListLiquidator,
+            NO_BUFFER,
+            COMPUTE_PREMIA_AS_COLLATERAL
+        );
 
         emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
     }
@@ -1065,11 +1129,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tokenId The position to be force exercised; this position must contain at least one out-of-range long leg
     /// @param positionIdListExercisee Post-burn list of open positions in the exercisee's (`account`) account
     /// @param positionIdListExercisor List of open positions in the exercisor's (`msg.sender`) account
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the exercisee(right slot)/exercisor(left slot) for collateral (>0), or just owed premia for long legs (0)
     function forceExercise(
         address account,
         TokenId tokenId,
         TokenId[] calldata positionIdListExercisee,
-        TokenId[] calldata positionIdListExercisor
+        TokenId[] calldata positionIdListExercisor,
+        LeftRightUnsigned usePremiaAsCollateral
     ) external {
         // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
         _validatePositionList(msg.sender, positionIdListExercisor, 0);
@@ -1093,12 +1159,13 @@ contract PanopticPool is ERC1155Holder, Multicall {
                 positionSize
             );
 
+            TokenId _tokenId = tokenId;
             // Compute the exerciseFee, this will decrease the further away the price is from the exercised position
             // Include any deltas in long legs between the current and oracle tick in the exercise fee
             exerciseFees = ct0.exerciseCost(
                 currentTick,
                 twapTick,
-                tokenId,
+                _tokenId,
                 positionSize,
                 longAmounts
             );
@@ -1129,14 +1196,24 @@ contract PanopticPool is ERC1155Holder, Multicall {
         ct0.revoke(account);
         ct1.revoke(account);
 
-        _validateSolvency(account, positionIdListExercisee, NO_BUFFER);
+        _validateSolvency(
+            account,
+            positionIdListExercisee,
+            NO_BUFFER,
+            usePremiaAsCollateral.rightSlot() > 0
+        );
 
         // the exercisor's position list is validated above
         // we need to assert their solvency against their collateral requirement plus a buffer
         // force exercises involve a collateral decrease with open positions, so there is a higher standard for solvency
         // a similar buffer is also invoked when minting options, which also decreases the available collateral
         if (positionIdListExercisor.length > 0)
-            _validateSolvency(msg.sender, positionIdListExercisor, BP_DECREASE_BUFFER);
+            _validateSolvency(
+                msg.sender,
+                positionIdListExercisor,
+                BP_DECREASE_BUFFER,
+                usePremiaAsCollateral.leftSlot() > 0
+            );
 
         emit ForcedExercised(msg.sender, account, tokenId, exerciseFees);
     }
@@ -1153,13 +1230,15 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param atTicks An array of ticks to check solvency at
     /// @param buffer The buffer to apply to the collateral requirement
     /// @param expectedSolvent Whether the account is expected to be solvent (true) or insolvent (false) at all provided `atTicks`
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function _checkSolvencyAtTicks(
         address account,
         TokenId[] calldata positionIdList,
         int24 currentTick,
         int24[] memory atTicks,
         uint256 buffer,
-        bool expectedSolvent
+        bool expectedSolvent,
+        bool usePremiaAsCollateral
     ) internal view {
         (
             LeftRightUnsigned shortPremium,
@@ -1168,7 +1247,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         ) = _calculateAccumulatedPremia(
                 account,
                 positionIdList,
-                COMPUTE_ALL_PREMIA,
+                usePremiaAsCollateral,
                 ONLY_AVAILABLE_PREMIUM,
                 currentTick
             );
@@ -1428,7 +1507,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param tokenId The option position
     /// @param positionSize The number of contracts (size) of the option position
     /// @param owner The holder of the tokenId option
-    /// @param computeAllPremia Whether to compute accumulated premia for all legs held by the user (true), or just owed premia for long legs (false)
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     /// @param atTick The tick at which the premia is calculated -> use (`atTick < type(int24).max`) to compute it
     /// up to current block. `atTick = type(int24).max` will only consider fees as of the last on-chain transaction
     /// @return premiaByLeg The amount of premia owed to the user for each leg of the position
@@ -1437,7 +1516,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         TokenId tokenId,
         uint128 positionSize,
         address owner,
-        bool computeAllPremia,
+        bool usePremiaAsCollateral,
         int24 atTick
     )
         internal
@@ -1450,7 +1529,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         uint256 numLegs = tokenId.countLegs();
         for (uint256 leg = 0; leg < numLegs; ) {
             uint256 isLong = tokenId.isLong(leg);
-            if ((isLong == 1) || computeAllPremia) {
+            if ((isLong == 1) || usePremiaAsCollateral) {
                 LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
                     tokenId,
                     leg,
@@ -1514,10 +1593,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @param positionIdList Exhaustive list of open positions for `owner` used for solvency checks where the tokenId to settle is placed at the last index
     /// @param owner The owner of the option position to make premium payments on
     /// @param legIndex the index of the leg in tokenId that is to be collected on (must be isLong=1)
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the settlee for collateral (true), or just owed premia for long legs (false)
     function settleLongPremium(
         TokenId[] calldata positionIdList,
         address owner,
-        uint256 legIndex
+        uint256 legIndex,
+        bool usePremiaAsCollateral
     ) external {
         _validatePositionList(owner, positionIdList, 0);
 
@@ -1589,7 +1670,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
 
         // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
-        _validateSolvency(owner, positionIdList, NO_BUFFER);
+        _validateSolvency(owner, positionIdList, NO_BUFFER, usePremiaAsCollateral);
     }
 
     /// @notice Adds collected tokens to `s_settledTokens` and adjusts `s_grossPremiumLast` for any liquidity added.
@@ -1807,7 +1888,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             tokenId,
             positionSize,
             owner,
-            COMPUTE_ALL_PREMIA,
+            COMPUTE_PREMIA_AS_COLLATERAL,
             type(int24).max
         );
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -123,6 +123,10 @@ contract PanopticPool is Multicall {
     /// @dev Mitigates manipulation of the currentTick that causes positions to be liquidated at a less favorable price.
     int256 internal constant MAX_TWAP_DELTA_LIQUIDATION = 513;
 
+    /// @notice The maximum allowed delta (~2%) between the lastObservedTick and the slowOracleTick/fastOracleTick during forceExercise/settleLongPremium.
+    /// @dev Ensures token substitution between two accounts is settled safely at a price close to market.
+    int256 internal constant MAX_TICK_DELTA_SUBSTITUTION = 203;
+
     /// @notice The maximum allowed cumulative delta between the fast & slow oracle tick, the current & slow oracle tick, and the last-observed & slow oracle tick.
     /// @dev Falls back on the more conservative (less solvent) tick during times of extreme volatility, where the price moves ~10% in <4 minutes.
     int256 internal constant MAX_TICKS_DELTA = 953;
@@ -1000,7 +1004,7 @@ contract PanopticPool is Multicall {
 
             unchecked {
                 if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
-                    revert Errors.StaleTWAP();
+                    revert Errors.StaleOracle();
             }
 
             // Ensure the account is insolvent at twapTick (in place of slowOracleTick), currentTick, fastOracleTick, and lastObservedTick
@@ -1140,18 +1144,28 @@ contract PanopticPool is Multicall {
         // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
         _validatePositionList(msg.sender, positionIdListExercisor, 0);
 
-        int24 twapTick = getUniV3TWAP();
+        int24 currentTick;
+        int24 lastObservedTick;
+        {
+            int24 fastOracleTick;
+            int24 slowOracleTick;
+            (fastOracleTick, slowOracleTick, lastObservedTick, currentTick, ) = PanopticMath
+                .getOracleTicks(s_univ3pool, s_miniMedian);
+
+            if (
+                Math.abs(lastObservedTick - fastOracleTick) > MAX_TICK_DELTA_SUBSTITUTION ||
+                Math.abs(lastObservedTick - slowOracleTick) > MAX_TICK_DELTA_SUBSTITUTION
+            ) revert Errors.StaleOracle();
+        }
 
         // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-        tokenId.validateIsExercisable(twapTick);
+        tokenId.validateIsExercisable(lastObservedTick);
 
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
         LeftRightSigned exerciseFees;
         {
-            (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-
             uint128 positionSize = s_positionBalance[account][tokenId].positionSize();
 
             (LeftRightSigned longAmounts, ) = PanopticMath.computeExercisedAmounts(
@@ -1164,7 +1178,7 @@ contract PanopticPool is Multicall {
             // Include any deltas in long legs between the current and oracle tick in the exercise fee
             exerciseFees = ct0.exerciseCost(
                 currentTick,
-                twapTick,
+                lastObservedTick,
                 _tokenId,
                 positionSize,
                 longAmounts
@@ -1180,10 +1194,10 @@ contract PanopticPool is Multicall {
         _burnOptions(COMMIT_LONG_SETTLED, tokenId, account, MIN_SWAP_TICK, MAX_SWAP_TICK);
 
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
-        LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+        LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
             account,
             exerciseFees,
-            twapTick,
+            lastObservedTick,
             ct0,
             ct1
         );
@@ -1609,6 +1623,13 @@ contract PanopticPool is Multicall {
 
         if (tokenId.isLong(legIndex) == 0 || legIndex > 3) revert Errors.NotALongLeg();
 
+        CollateralTracker ct0 = s_collateralToken0;
+        CollateralTracker ct1 = s_collateralToken1;
+
+        // The protocol delegates some virtual shares to ensure the premia can be settled.
+        ct0.delegate(owner);
+        ct1.delegate(owner);
+
         LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
             tokenId,
             legIndex,
@@ -1619,11 +1640,10 @@ contract PanopticPool is Multicall {
 
         LeftRightUnsigned accumulatedPremium;
         {
-            uint256 tokenType = tokenId.tokenType(legIndex);
             (uint128 premiumAccumulator0, uint128 premiumAccumulator1) = SFPM.getAccountPremium(
                 address(s_univ3pool),
                 address(this),
-                tokenType,
+                tokenId.tokenType(legIndex),
                 liquidityChunk.tickLower(),
                 liquidityChunk.tickUpper(),
                 currentTick,
@@ -1651,8 +1671,8 @@ contract PanopticPool is Multicall {
                 .toLeftSlot(int128(int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64)));
 
             // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-            s_collateralToken0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
-            s_collateralToken1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
+            ct0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
+            ct1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
 
             bytes32 chunkKey = keccak256(
                 abi.encodePacked(
@@ -1669,8 +1689,45 @@ contract PanopticPool is Multicall {
             emit PremiumSettled(owner, tokenId, legIndex, realizedPremia);
         }
 
+        int24 lastObservedTick;
+        uint96 tickData;
+        {
+            int24 fastOracleTick;
+            int24 slowOracleTick;
+            (fastOracleTick, slowOracleTick, lastObservedTick, , ) = PanopticMath.getOracleTicks(
+                s_univ3pool,
+                s_miniMedian
+            );
+
+            if (
+                Math.abs(lastObservedTick - fastOracleTick) > MAX_TICK_DELTA_SUBSTITUTION ||
+                Math.abs(lastObservedTick - slowOracleTick) > MAX_TICK_DELTA_SUBSTITUTION
+            ) revert Errors.StaleOracle();
+            tickData = PositionBalanceLibrary.packTickData(
+                currentTick,
+                fastOracleTick,
+                slowOracleTick,
+                lastObservedTick
+            );
+        }
+
+        LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
+            owner,
+            LeftRightSigned.wrap(0),
+            lastObservedTick,
+            ct0,
+            ct1
+        );
+
+        // allow the caller to settle tokens owed to the protocol by the settlee in exchange for the surplus token
+        ct0.refund(owner, msg.sender, refundAmounts.rightSlot());
+        ct1.refund(owner, msg.sender, refundAmounts.leftSlot());
+
+        ct0.revoke(owner);
+        ct1.revoke(owner);
+
         // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
-        _validateSolvency(owner, positionIdList, NO_BUFFER, usePremiaAsCollateral);
+        _checkSolvency(owner, positionIdList, tickData, NO_BUFFER, usePremiaAsCollateral);
     }
 
     /// @notice Adds collected tokens to `s_settledTokens` and adjusts `s_grossPremiumLast` for any liquidity added.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1149,7 +1149,7 @@ contract PanopticPool is Multicall {
         {
             int24 fastOracleTick;
             int24 slowOracleTick;
-            (fastOracleTick, slowOracleTick, lastObservedTick, currentTick, ) = PanopticMath
+            (currentTick, fastOracleTick, slowOracleTick, lastObservedTick, ) = PanopticMath
                 .getOracleTicks(s_univ3pool, s_miniMedian);
 
             if (
@@ -1694,7 +1694,7 @@ contract PanopticPool is Multicall {
         {
             int24 fastOracleTick;
             int24 slowOracleTick;
-            (fastOracleTick, slowOracleTick, lastObservedTick, , ) = PanopticMath.getOracleTicks(
+            (, fastOracleTick, slowOracleTick, lastObservedTick, ) = PanopticMath.getOracleTicks(
                 s_univ3pool,
                 s_miniMedian
             );

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -131,7 +131,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
     /// @notice The maximum allowed ratio for a single chunk, defined as `removedLiquidity / netLiquidity`.
     /// @dev The long premium spread multiplier that corresponds with the MAX_SPREAD value depends on VEGOID,
     /// which can be explored in this calculator: [https://www.desmos.com/calculator/mdeqob2m04](https://www.desmos.com/calculator/mdeqob2m04).
-    uint64 internal constant MAX_SPREAD = 9 * (2 ** 32);
+    uint256 internal constant MAX_SPREAD = 9 * (2 ** 32);
 
     /// @notice The maximum allowed number of legs across all open positions for a user.
     uint64 internal constant MAX_OPEN_LEGS = 25;
@@ -890,27 +890,25 @@ contract PanopticPool is ERC1155Holder, Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        {
-            int128 paid0 = s_collateralToken0.exercise(
-                owner,
-                longAmounts.rightSlot(),
-                shortAmounts.rightSlot(),
-                totalSwapped.rightSlot(),
-                realizedPremia.rightSlot()
+        paidAmounts = paidAmounts
+            .toRightSlot(
+                s_collateralToken0.exercise(
+                    owner,
+                    longAmounts.rightSlot(),
+                    shortAmounts.rightSlot(),
+                    totalSwapped.rightSlot(),
+                    realizedPremia.rightSlot()
+                )
+            )
+            .toLeftSlot(
+                s_collateralToken1.exercise(
+                    owner,
+                    longAmounts.leftSlot(),
+                    shortAmounts.leftSlot(),
+                    totalSwapped.leftSlot(),
+                    realizedPremia.leftSlot()
+                )
             );
-            paidAmounts = paidAmounts.toRightSlot(paid0);
-        }
-
-        {
-            int128 paid1 = s_collateralToken1.exercise(
-                owner,
-                longAmounts.leftSlot(),
-                shortAmounts.leftSlot(),
-                totalSwapped.leftSlot(),
-                realizedPremia.leftSlot()
-            );
-            paidAmounts = paidAmounts.toLeftSlot(paid1);
-        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1081,6 +1079,9 @@ contract PanopticPool is ERC1155Holder, Multicall {
         // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
         tokenId.validateIsExercisable(twapTick);
 
+        CollateralTracker ct0 = s_collateralToken0;
+        CollateralTracker ct1 = s_collateralToken1;
+
         LeftRightSigned exerciseFees;
         {
             (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
@@ -1094,7 +1095,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
             // Compute the exerciseFee, this will decrease the further away the price is from the exercised position
             // Include any deltas in long legs between the current and oracle tick in the exercise fee
-            exerciseFees = s_collateralToken0.exerciseCost(
+            exerciseFees = ct0.exerciseCost(
                 currentTick,
                 twapTick,
                 tokenId,
@@ -1104,8 +1105,8 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
 
         // The protocol delegates some virtual shares to ensure the burn can be settled.
-        s_collateralToken0.delegate(account);
-        s_collateralToken1.delegate(account);
+        ct0.delegate(account);
+        ct1.delegate(account);
 
         // Exercise the option
         // Turn off ITM swapping to prevent swap at potentially unfavorable price
@@ -1116,17 +1117,17 @@ contract PanopticPool is ERC1155Holder, Multicall {
             account,
             exerciseFees,
             twapTick,
-            s_collateralToken0,
-            s_collateralToken1
+            ct0,
+            ct1
         );
 
         // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
-        s_collateralToken0.refund(account, msg.sender, refundAmounts.rightSlot());
-        s_collateralToken1.refund(account, msg.sender, refundAmounts.leftSlot());
+        ct0.refund(account, msg.sender, refundAmounts.rightSlot());
+        ct1.refund(account, msg.sender, refundAmounts.leftSlot());
 
         // revoke the virtual shares that were delegated after settling the difference with the exercisor
-        s_collateralToken0.revoke(account);
-        s_collateralToken1.revoke(account);
+        ct0.revoke(account);
+        ct1.revoke(account);
 
         _validateSolvency(account, positionIdListExercisee, NO_BUFFER);
 
@@ -1174,10 +1175,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         uint256 numberOfTicks = atTicks.length;
 
-        uint8 solvent;
+        uint256 solvent;
         for (uint256 i; i < numberOfTicks; ) {
             unchecked {
-                solvent += (
+                if (
                     _isAccountSolvent(
                         account,
                         atTicks[i],
@@ -1186,9 +1187,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
                         longPremium,
                         buffer
                     )
-                        ? uint8(1)
-                        : uint8(0)
-                );
+                ) ++solvent;
 
                 ++i;
             }
@@ -1214,24 +1213,21 @@ contract PanopticPool is ERC1155Holder, Multicall {
         LeftRightUnsigned longPremium,
         uint256 buffer
     ) internal view returns (bool) {
-        LeftRightUnsigned tokenData0 = s_collateralToken0.getAccountMarginDetails(
-            account,
-            atTick,
-            positionBalanceArray,
-            shortPremium.rightSlot(),
-            longPremium.rightSlot()
-        );
-        LeftRightUnsigned tokenData1 = s_collateralToken1.getAccountMarginDetails(
-            account,
-            atTick,
-            positionBalanceArray,
-            shortPremium.leftSlot(),
-            longPremium.leftSlot()
-        );
-
         (uint256 balanceCross, uint256 thresholdCross) = PanopticMath.getCrossBalances(
-            tokenData0,
-            tokenData1,
+            s_collateralToken0.getAccountMarginDetails(
+                account,
+                atTick,
+                positionBalanceArray,
+                shortPremium.rightSlot(),
+                longPremium.rightSlot()
+            ),
+            s_collateralToken1.getAccountMarginDetails(
+                account,
+                atTick,
+                positionBalanceArray,
+                shortPremium.leftSlot(),
+                longPremium.leftSlot()
+            ),
             Math.getSqrtRatioAtTick(atTick)
         );
 
@@ -1246,12 +1242,20 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         uint256 medianData = s_miniMedian;
         unchecked {
-            int24 medianTick = (int24(
-                uint24(medianData >> ((uint24(medianData >> (192 + 3 * 3)) % 8) * 24))
-            ) + int24(uint24(medianData >> ((uint24(medianData >> (192 + 3 * 4)) % 8) * 24)))) / 2;
-
             // If ticks have recently deviated more than +/- ~10%, enforce covered mints
-            return Math.abs(currentTick - medianTick) > MAX_TICKS_DELTA;
+            return
+                Math.abs(
+                    currentTick -
+                        (int24(
+                            uint24(medianData >> ((uint24(medianData >> (192 + 3 * 3)) % 8) * 24))
+                        ) +
+                            int24(
+                                uint24(
+                                    medianData >> ((uint24(medianData >> (192 + 3 * 4)) % 8) * 24)
+                                )
+                            )) /
+                        2
+                ) > MAX_TICKS_DELTA;
         }
     }
 
@@ -1269,7 +1273,6 @@ contract PanopticPool is ERC1155Holder, Multicall {
         uint256 offset
     ) internal view {
         uint256 pLength;
-        uint256 currentHash = s_positionsHash[account];
 
         unchecked {
             pLength = positionIdList.length - offset;
@@ -1289,7 +1292,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
         }
 
         // revert if fingerprint for provided `_positionIdList` does not match the one stored for the `_account`
-        if (fingerprintIncomingList != currentHash) revert Errors.InputListFail();
+        if (fingerprintIncomingList != s_positionsHash[account]) revert Errors.InputListFail();
     }
 
     /// @notice Updates the hash for all positions owned by an account. This fingerprints the list of all incoming options with a single hash.
@@ -1401,10 +1404,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
     function _checkLiquiditySpread(
         TokenId tokenId,
         uint256 leg,
-        uint64 effectiveLiquidityLimitX32
+        uint256 effectiveLiquidityLimitX32
     ) internal view returns (uint256 totalLiquidity) {
-        uint128 netLiquidity;
-        uint128 removedLiquidity;
+        uint256 netLiquidity;
+        uint256 removedLiquidity;
         (totalLiquidity, netLiquidity, removedLiquidity) = _getLiquidities(tokenId, leg);
 
         // compute and return effective liquidity. Return if short=net=0, which is closing short position
@@ -1412,12 +1415,12 @@ contract PanopticPool is ERC1155Holder, Multicall {
 
         uint256 effectiveLiquidityFactorX32;
         unchecked {
-            effectiveLiquidityFactorX32 = (uint256(removedLiquidity) * 2 ** 32) / netLiquidity;
+            effectiveLiquidityFactorX32 = (removedLiquidity * 2 ** 32) / netLiquidity;
         }
 
         // put a limit on how much new liquidity in one transaction can be deployed into this leg
         // the effective liquidity measures how many times more the newly added liquidity is compared to the existing/base liquidity
-        if (effectiveLiquidityFactorX32 > uint256(effectiveLiquidityLimitX32))
+        if (effectiveLiquidityFactorX32 > effectiveLiquidityLimitX32)
             revert Errors.EffectiveLiquidityAboveThreshold();
     }
 
@@ -1518,7 +1521,10 @@ contract PanopticPool is ERC1155Holder, Multicall {
     ) external {
         _validatePositionList(owner, positionIdList, 0);
 
-        TokenId tokenId = positionIdList[positionIdList.length - 1];
+        TokenId tokenId;
+        unchecked {
+            tokenId = positionIdList[positionIdList.length - 1];
+        }
 
         if (tokenId.isLong(legIndex) == 0 || legIndex > 3) revert Errors.NotALongLeg();
 
@@ -1644,7 +1650,7 @@ contract PanopticPool is ERC1155Holder, Multicall {
             uint256 totalLiquidity = _checkLiquiditySpread(
                 tokenId,
                 leg,
-                isLong == 0 ? MAX_SPREAD : uint64(Math.min(effectiveLiquidityLimitX32, MAX_SPREAD))
+                isLong == 0 ? MAX_SPREAD : Math.min(effectiveLiquidityLimitX32, MAX_SPREAD)
             );
 
             // if position is short, adjust `grossPremiumLast` upward to account for the increase in short liquidity

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1603,7 +1603,7 @@ contract PanopticPool is Multicall {
 
     /// @notice Settle unpaid premium for one `legIndex` on a position owned by `owner`.
     /// @dev Called by sellers on buyers of their chunk to increase the available premium for withdrawal (before closing their position).
-    /// @dev This feature is only available when `owner` is solvent and has the requisite tokens to settle the premium.
+    /// @dev This feature is only available when owner is solvent and has the requisite collateral (in either token) to settle the premium.
     /// @param positionIdList Exhaustive list of open positions for `owner` used for solvency checks where the tokenId to settle is placed at the last index
     /// @param owner The owner of the option position to make premium payments on
     /// @param legIndex the index of the leg in tokenId that is to be collected on (must be isLong=1)

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -69,8 +69,8 @@ library Errors {
     error PriceBoundFail();
 
     /// @notice An oracle price is too far away from another oracle price or the current tick
-    /// @dev This is a safeguard against price manipulation during option mints, burns, and liquidations
-    error StaleTWAP();
+    /// @dev This is a safeguard against price manipulation during option mints, burns, liquidations, force exercises, and premium settlements
+    error StaleOracle();
 
     /// @notice PanopticPool: The position being minted would increase the total amount of legs open for the account above the maximum
     error TooManyLegsOpen();

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1040,27 +1040,27 @@ library PanopticMath {
         }
     }
 
-    /// @notice Redistribute the final exercise fee deltas between tokens if necessary according to the available collateral from the exercised user.
-    /// @param exercisee The address of the user being exercised
-    /// @param exerciseFees Pre-adjustment exercise fees to debit from exercisor (rightSlot = token0 left = token1)
-    /// @param atTick The tick at which to convert between token0/token1 when redistributing the exercise fees
-    /// @param ct0 The collateral tracker for token0
-    /// @param ct1 The collateral tracker for token1
-    /// @return The LeftRight-packed deltas for token0/token1 to move from the exercisor to the exercisee
-    function getExerciseDeltas(
-        address exercisee,
-        LeftRightSigned exerciseFees,
+    /// @notice Substitutes surplus tokens to a caller in exchange for any potential token shortages prior to revoking virtual shares from a payor.
+    /// @param payor The address of the user being exercised/settled
+    /// @param fees If applicable, fees to debit from caller (rightSlot = currency0 left = currency1), 0 for `settleLongPremium`
+    /// @param atTick The tick at which to convert between currency0/currency1 when redistributing the surplus tokens
+    /// @param ct0 The collateral tracker for currency0
+    /// @param ct1 The collateral tracker for currency1
+    /// @return The LeftRight-packed deltas for currency0/currency1 to move from the caller to the payor
+    function getRefundAmounts(
+        address payor,
+        LeftRightSigned fees,
         int24 atTick,
         CollateralTracker ct0,
         CollateralTracker ct1
     ) external view returns (LeftRightSigned) {
         uint160 sqrtPriceX96 = Math.getSqrtRatioAtTick(atTick);
         unchecked {
-            // if the refunder lacks sufficient token0 to pay back the virtual shares, have the exercisor cover the difference in exchange for token1 (and vice versa)
+            // if the refunder lacks sufficient currency0 to pay back the virtual shares, have the caller cover the difference in exchange for currency1 (and vice versa)
 
             int256 balanceShortage = int256(uint256(type(uint248).max)) -
-                int256(ct0.balanceOf(exercisee)) -
-                int256(ct0.convertToShares(uint128(-exerciseFees.rightSlot())));
+                int256(ct0.balanceOf(payor)) -
+                int256(ct0.convertToShares(uint128(-fees.rightSlot())));
 
             if (balanceShortage > 0) {
                 return
@@ -1068,7 +1068,7 @@ library PanopticMath {
                         .wrap(0)
                         .toRightSlot(
                             int128(
-                                exerciseFees.rightSlot() -
+                                fees.rightSlot() -
                                     int256(
                                         Math.mulDivRoundingUp(
                                             uint256(balanceShortage),
@@ -1081,19 +1081,19 @@ library PanopticMath {
                         .toLeftSlot(
                             int128(
                                 int256(
-                                    PanopticMath.convert0to1(
+                                    PanopticMath.convert0to1RoundingUp(
                                         ct0.convertToAssets(uint256(balanceShortage)),
                                         sqrtPriceX96
                                     )
-                                ) + exerciseFees.leftSlot()
+                                ) + fees.leftSlot()
                             )
                         );
             }
 
             balanceShortage =
                 int256(uint256(type(uint248).max)) -
-                int256(ct1.balanceOf(exercisee)) -
-                int256(ct1.convertToShares(uint128(-exerciseFees.leftSlot())));
+                int256(ct1.balanceOf(payor)) -
+                int256(ct1.convertToShares(uint128(-fees.leftSlot())));
             if (balanceShortage > 0) {
                 return
                     LeftRightSigned
@@ -1101,16 +1101,16 @@ library PanopticMath {
                         .toRightSlot(
                             int128(
                                 int256(
-                                    PanopticMath.convert1to0(
+                                    PanopticMath.convert1to0RoundingUp(
                                         ct1.convertToAssets(uint256(balanceShortage)),
                                         sqrtPriceX96
                                     )
-                                ) + exerciseFees.rightSlot()
+                                ) + fees.rightSlot()
                             )
                         )
                         .toLeftSlot(
                             int128(
-                                exerciseFees.leftSlot() -
+                                fees.leftSlot() -
                                     int256(
                                         Math.mulDivRoundingUp(
                                             uint256(balanceShortage),
@@ -1123,7 +1123,7 @@ library PanopticMath {
             }
         }
 
-        // otherwise, no need to deviate from the original exercise fee deltas
-        return exerciseFees;
+        // otherwise, no need to deviate from the original deltas
+        return fees;
     }
 }

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1043,10 +1043,10 @@ library PanopticMath {
     /// @notice Substitutes surplus tokens to a caller in exchange for any potential token shortages prior to revoking virtual shares from a payor.
     /// @param payor The address of the user being exercised/settled
     /// @param fees If applicable, fees to debit from caller (rightSlot = token0 left = token1), 0 for `settleLongPremium`
-    /// @param atTick The tick at which to convert between currency0/currency1 when redistributing the surplus tokens
-    /// @param ct0 The collateral tracker for currency0
-    /// @param ct1 The collateral tracker for currency1
-    /// @return The LeftRight-packed deltas for currency0/currency1 to move from the caller to the payor
+    /// @param atTick The tick at which to convert between token0/token1 when redistributing the surplus tokens
+    /// @param ct0 The collateral tracker for token0
+    /// @param ct1 The collateral tracker for token1
+    /// @return The LeftRight-packed deltas for token0/token1 to move from the caller to the payor
     function getRefundAmounts(
         address payor,
         LeftRightSigned fees,
@@ -1056,7 +1056,7 @@ library PanopticMath {
     ) external view returns (LeftRightSigned) {
         uint160 sqrtPriceX96 = Math.getSqrtRatioAtTick(atTick);
         unchecked {
-            // if the refunder lacks sufficient currency0 to pay back the virtual shares, have the caller cover the difference in exchange for currency1 (and vice versa)
+            // if the refunder lacks sufficient token0 to pay back the virtual shares, have the caller cover the difference in exchange for token1 (and vice versa)
 
             int256 balanceShortage = int256(uint256(type(uint248).max)) -
                 int256(ct0.balanceOf(payor)) -

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -128,10 +128,17 @@ library PanopticMath {
         uint256 updatedHash = uint248(existingHash) ^
             (uint248(uint256(keccak256(abi.encode(tokenId)))));
 
+        uint256 positionLegs = tokenId.countLegs();
         // increment the upper 8 bits (leg counter) if addFlag=true, decrement otherwise
-        uint256 newLegCount = addFlag
-            ? uint8(existingHash >> 248) + uint8(tokenId.countLegs())
-            : uint8(existingHash >> 248) - tokenId.countLegs();
+
+        uint256 newLegCount;
+        if (addFlag) {
+            newLegCount = uint8(existingHash >> 248) + uint8(positionLegs);
+        } else {
+            unchecked {
+                newLegCount = (existingHash >> 248) - positionLegs;
+            }
+        }
 
         unchecked {
             return uint256(updatedHash) + (newLegCount << 248);
@@ -240,8 +247,11 @@ library PanopticMath {
                     int256(timestamps[i] - timestamps[i + 1]);
             }
 
+            // the `ticks` array descends from the most recent Uniswap observation prior to the sort
+            int24 latestObservation = int24(ticks[0]);
+
             // get the median of the `ticks` array (assuming `cardinality` is odd)
-            return (int24(Math.sort(ticks)[cardinality / 2]), int24(ticks[0]));
+            return (int24(Math.sort(ticks)[cardinality / 2]), latestObservation);
         }
     }
 
@@ -409,7 +419,7 @@ library PanopticMath {
         //  The following function takes this into account when computing the liquidity of the leg and switches between
         //  the definition for getLiquidityForAmount0 or getLiquidityForAmount1 when relevant.
 
-        uint256 amount = uint256(positionSize) * tokenId.optionRatio(legIndex);
+        uint256 amount = positionSize * tokenId.optionRatio(legIndex);
         if (tokenId.asset(legIndex) == 0) {
             return Math.getLiquidityForAmount0(tickLower, tickUpper, amount);
         } else {

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1042,7 +1042,7 @@ library PanopticMath {
 
     /// @notice Substitutes surplus tokens to a caller in exchange for any potential token shortages prior to revoking virtual shares from a payor.
     /// @param payor The address of the user being exercised/settled
-    /// @param fees If applicable, fees to debit from caller (rightSlot = currency0 left = currency1), 0 for `settleLongPremium`
+    /// @param fees If applicable, fees to debit from caller (rightSlot = token0 left = token1), 0 for `settleLongPremium`
     /// @param atTick The tick at which to convert between currency0/currency1 when redistributing the surplus tokens
     /// @param ct0 The collateral tracker for currency0
     /// @param ct1 The collateral tracker for currency1

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -699,18 +699,22 @@ library PanopticMath {
         if (tokenId.tokenType(legIndex) == 0) {
             if (isShort) {
                 // if option is short, increment shorts by contracts
-                shorts = shorts.toRightSlot(Math.toInt128(amountsMoved.rightSlot()));
+                shorts = LeftRightSigned.wrap(0).toRightSlot(
+                    Math.toInt128(amountsMoved.rightSlot())
+                );
             } else {
                 // is option is long, increment longs by contracts
-                longs = longs.toRightSlot(Math.toInt128(amountsMoved.rightSlot()));
+                longs = LeftRightSigned.wrap(0).toRightSlot(
+                    Math.toInt128(amountsMoved.rightSlot())
+                );
             }
         } else {
             if (isShort) {
                 // if option is short, increment shorts by notional
-                shorts = shorts.toLeftSlot(Math.toInt128(amountsMoved.leftSlot()));
+                shorts = LeftRightSigned.wrap(0).toLeftSlot(Math.toInt128(amountsMoved.leftSlot()));
             } else {
                 // if option is long, increment longs by notional
-                longs = longs.toLeftSlot(Math.toInt128(amountsMoved.leftSlot()));
+                longs = LeftRightSigned.wrap(0).toLeftSlot(Math.toInt128(amountsMoved.leftSlot()));
             }
         }
     }

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -133,10 +133,10 @@ library PositionBalanceLibrary {
     function unpackTickData(uint96 _tickData) internal pure returns (int24, int24, int24, int24) {
         PositionBalance self = PositionBalance.wrap(uint256(_tickData) << 160);
         return (
-            self.currentTick(),
-            self.fastOracleTick(),
-            self.slowOracleTick(),
-            self.lastObservedTick()
+            int24(int256(PositionBalance.unwrap(self) >> 160)),
+            int24(int256(PositionBalance.unwrap(self) >> 184)),
+            int24(int256(PositionBalance.unwrap(self) >> 208)),
+            int24(int256(PositionBalance.unwrap(self) >> 232))
         );
     }
 

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -360,25 +360,6 @@ library TokenIdLibrary {
     function flipToBurnToken(TokenId self) internal pure returns (TokenId) {
         unchecked {
             // NOTE: This is a hack to avoid blowing up the contract size.
-            // We copy the logic from the countLegs function, using it here adds 5K to the contract size with IR for some reason
-            // Strip all bits except for the option ratios
-            uint256 optionRatios = TokenId.unwrap(self) & OPTION_RATIO_MASK;
-
-            // The legs are filled in from least to most significant
-            // Each comparison here is to the start of the next leg's option ratio
-            // Since only the option ratios remain, we can be sure that no bits above the start of the inactive legs will be 1
-            if (optionRatios < 2 ** 64) {
-                optionRatios = 0;
-            } else if (optionRatios < 2 ** 112) {
-                optionRatios = 1;
-            } else if (optionRatios < 2 ** 160) {
-                optionRatios = 2;
-            } else if (optionRatios < 2 ** 208) {
-                optionRatios = 3;
-            } else {
-                optionRatios = 4;
-            }
-
             // We need to ensure that only active legs are flipped
             // In order to achieve this, we shift our long bit mask to the right by (4-# active legs)
             // i.e the whole mask is used to flip all legs with 4 legs, but only the first leg is flipped with 1 leg so we shift by 3 legs
@@ -386,7 +367,7 @@ library TokenIdLibrary {
             return
                 TokenId.wrap(
                     TokenId.unwrap(self) ^
-                        ((LONG_MASK >> (48 * (4 - optionRatios))) & CLEAR_POOLID_MASK)
+                        ((LONG_MASK >> (48 * (4 - self.countLegs()))) & CLEAR_POOLID_MASK)
                 );
         }
     }
@@ -419,24 +400,16 @@ library TokenIdLibrary {
     /// @notice Return the number of active legs in the option position.
     /// @dev ASSUMPTION: For any leg, the option ratio is always > 0 (the leg always has a number of contracts associated with it).
     /// @param self The TokenId to count active legs for
-    /// @return The number of active legs in `self` (in the range {0,...,4})
-    function countLegs(TokenId self) internal pure returns (uint256) {
+    /// @return numLegs The number of active legs in `self` (in the range {0,...,4})
+    function countLegs(TokenId self) internal pure returns (uint256 numLegs) {
         // Strip all bits except for the option ratios
-        uint256 optionRatios = TokenId.unwrap(self) & OPTION_RATIO_MASK;
+        uint256 optionRatios = (TokenId.unwrap(self) & OPTION_RATIO_MASK) >> 64;
 
-        // The legs are filled in from least to most significant
-        // Each comparison here is to the start of the next leg's option ratio section
-        // Since only the option ratios remain, we can be sure that no bits above the start of the inactive legs will be 1
-        if (optionRatios < 2 ** 64) {
-            return 0;
-        } else if (optionRatios < 2 ** 112) {
-            return 1;
-        } else if (optionRatios < 2 ** 160) {
-            return 2;
-        } else if (optionRatios < 2 ** 208) {
-            return 3;
+        unchecked {
+            while (optionRatios >= 1 << (48 * numLegs)) {
+                ++numLegs;
+            }
         }
-        return 4;
     }
 
     /// @notice Clear a leg in an option position at `legIndex`.

--- a/foundry.toml
+++ b/foundry.toml
@@ -20,7 +20,7 @@ script="DO_NOT_COMPILE"
 fork_block_number = 18963715
 
 [profile.ci_sizes]
-optimizer_runs = 833
+optimizer_runs = 277
 test = 'DO_NOT_COMPILE'
 
 [profile.ci_sizes_ir]

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -741,8 +741,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 assetsToken1 = convertToAssets(returnedShares1, collateralToken1);
 
         // withdraw tokens
-        collateralToken0.withdraw(assetsToken0, Bob, Bob, new TokenId[](0));
-        collateralToken1.withdraw(assetsToken1, Bob, Bob, new TokenId[](0));
+        collateralToken0.withdraw(assetsToken0, Bob, Bob, new TokenId[](0), true);
+        collateralToken1.withdraw(assetsToken1, Bob, Bob, new TokenId[](0), true);
 
         // Total amount of shares after withdrawal (after burn)
         uint256 sharesAfter0 = convertToAssets(collateralToken0.totalSupply(), collateralToken0);
@@ -820,7 +820,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // attempt to withdraw
         // fail as assets > maxWithdraw(owner)
         vm.expectRevert(stdError.arithmeticError);
-        collateralToken0.withdraw(maxAssets + 1, Bob, Bob, new TokenId[](0));
+        collateralToken0.withdraw(maxAssets + 1, Bob, Bob, new TokenId[](0), true);
     }
 
     function test_Fail_mintGTAvailableAssets(
@@ -863,7 +863,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint128(bound(positionSizeSeed, 501, 1000)),
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -899,7 +900,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             750,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
@@ -910,7 +912,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             500,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 300);
@@ -922,7 +925,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId,
             positionIdList,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -958,7 +962,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             750,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
@@ -972,7 +977,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             500,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1008,7 +1014,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             750,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         collateralToken0.setInAMM(-250);
@@ -1020,7 +1027,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId,
             positionIdList,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1051,7 +1059,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // no erc4626 maxWithdraw check, so s_poolAssets math underflows instead
         vm.expectRevert(stdError.arithmeticError);
-        collateralToken0.withdraw(assets, Bob, Bob, new TokenId[](0));
+        collateralToken0.withdraw(assets, Bob, Bob, new TokenId[](0), true);
     }
 
     function test_Success_withdraw_OnBehalf(uint256 x, uint104 assets) public {
@@ -1120,8 +1128,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 balanceBefore1 = IERC20Partial(token1).balanceOf(Alice);
 
         // attempt to withdraw
-        collateralToken0.withdraw(assets, Alice, Bob, new TokenId[](0));
-        collateralToken1.withdraw(assets, Alice, Bob, new TokenId[](0));
+        collateralToken0.withdraw(assets, Alice, Bob, new TokenId[](0), true);
+        collateralToken1.withdraw(assets, Alice, Bob, new TokenId[](0), true);
 
         // Bob's token balance after withdraw
         uint256 balanceAfter0 = IERC20Partial(token0).balanceOf(Alice);
@@ -1183,7 +1191,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // attempt to withdraw
         // fail as user does not have approval to transfer on behalf
         vm.expectRevert(stdError.arithmeticError);
-        collateralToken0.withdraw(100, Alice, Bob, new TokenId[](0));
+        collateralToken0.withdraw(100, Alice, Bob, new TokenId[](0), true);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1356,7 +1364,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // Attempt a transfer to Alice from Bob
@@ -1448,7 +1457,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -1898,7 +1908,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -1928,7 +1939,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             uint256 inAMMOffset = collateralToken0._inAMM();
@@ -1945,7 +1957,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2093,7 +2106,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2122,7 +2136,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2299,7 +2314,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2328,7 +2344,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 4,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2507,7 +2524,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2536,7 +2554,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2738,7 +2757,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2776,7 +2796,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -2985,7 +3006,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -3022,7 +3044,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticHelper
                 .optionPositionInfo(panopticPool, Alice, tokenId1);
@@ -3194,7 +3217,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -3224,7 +3248,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             uint256 inAMMOffset = inAMMBefore - collateralToken0._inAMM();
@@ -3241,7 +3266,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             int128 currentUtilization = collateralToken0.poolUtilizationHook();
@@ -3426,7 +3452,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -3456,7 +3483,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             uint256 inAMMOffset = inAMMBefore - collateralToken0._inAMM();
@@ -3473,7 +3501,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             int128 currentUtilization = collateralToken0.poolUtilizationHook();
@@ -3644,7 +3673,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -3674,7 +3704,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             uint256 inAMMOffset = inAMMBefore - collateralToken0._inAMM();
@@ -3691,7 +3722,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 2,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             int128 currentUtilization = collateralToken0.poolUtilizationHook();
@@ -3870,7 +3902,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.revertTo(snapshot);
@@ -3891,7 +3924,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.assume(
@@ -4050,7 +4084,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.revertTo(snapshot);
@@ -4071,7 +4106,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.assume(collateralToken0.poolUtilizationHook() < 5_000);
@@ -4253,7 +4289,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.revertTo(snapshot);
@@ -4268,7 +4305,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             int128 currentUtilization = collateralToken0.poolUtilizationHook();
@@ -4445,7 +4483,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.revertTo(snapshot);
@@ -4460,7 +4499,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             int128 currentUtilization = collateralToken1.poolUtilizationHook();
@@ -4634,7 +4674,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.revertTo(snapshot);
@@ -4649,7 +4690,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             int128 currentUtilization = collateralToken0.poolUtilizationHook();
@@ -4809,7 +4851,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
 
             vm.revertTo(snapshot);
@@ -4824,7 +4867,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
             int128 currentUtilization = collateralToken1.poolUtilizationHook();
             vm.assume(currentUtilization > 5_000 && currentUtilization < 9_000);
@@ -4994,7 +5038,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5180,7 +5225,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5208,7 +5254,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 4,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5308,7 +5355,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5345,7 +5393,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 4,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5445,7 +5494,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5482,7 +5532,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 4,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5582,7 +5633,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 
@@ -5619,7 +5671,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 positionSize0 / 4,
                 type(uint64).max,
                 TickMath.MIN_TICK,
-                TickMath.MAX_TICK
+                TickMath.MAX_TICK,
+                true
             );
         }
 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -427,7 +427,8 @@ contract Misctest is Test, PositionUtils {
                 2_000_000,
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
 
             if (i == positionCount - 1) {
@@ -484,7 +485,8 @@ contract Misctest is Test, PositionUtils {
                 1_000_000,
                 type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
 
@@ -532,7 +534,8 @@ contract Misctest is Test, PositionUtils {
                 2_000_000,
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
 
             if (i == positionCount - 1) {
@@ -558,7 +561,8 @@ contract Misctest is Test, PositionUtils {
                 1_000_000,
                 type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
 
@@ -637,7 +641,8 @@ contract Misctest is Test, PositionUtils {
                 2_000_000,
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
 
             posId = TokenId
@@ -738,7 +743,8 @@ contract Misctest is Test, PositionUtils {
                 1_000_000,
                 type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
 
@@ -786,7 +792,8 @@ contract Misctest is Test, PositionUtils {
                 2_000_000,
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
 
             posId = TokenId
@@ -827,7 +834,8 @@ contract Misctest is Test, PositionUtils {
                 1_000_000,
                 type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
 
@@ -1356,14 +1364,16 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         pp.burnOptions(
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1391,14 +1401,16 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         pp.burnOptions(
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1413,14 +1425,22 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        pp.mintOptions($posIdList, 537, 0, Constants.MIN_V3POOL_TICK, Constants.MAX_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            537,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
 
         pp.mintOptions(
             $posIdList,
             2_000_000,
             0,
             Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK
+            Constants.MAX_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Alice);
@@ -1430,7 +1450,14 @@ contract Misctest is Test, PositionUtils {
             .addLeg(0, 1, 0, 1, 0, 0, -224040, 3540);
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        pp.mintOptions($posIdList, 537, 0, Constants.MIN_V3POOL_TICK, Constants.MAX_V3POOL_TICK);
+        pp.mintOptions(
+            $posIdList,
+            537,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
     }
 
     function test_success_MintBurnCallSpread() public {
@@ -1455,7 +1482,8 @@ contract Misctest is Test, PositionUtils {
             2_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // mint OTM position
@@ -1472,14 +1500,16 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         pp.burnOptions(
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1505,7 +1535,8 @@ contract Misctest is Test, PositionUtils {
             2_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // mint OTM position
@@ -1522,19 +1553,21 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         pp.burnOptions(
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
     // are delegations for ITM positions sufficient?
-    function test_success_exercise_crossDelegate() public {
+    function test_success_exercise_crossDelegate_1() public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -1556,7 +1589,8 @@ contract Misctest is Test, PositionUtils {
             2_000_000,
             0,
             Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK
+            Constants.MAX_V3POOL_TICK,
+            true
         );
 
         $posIdList[0] = TokenId
@@ -1570,7 +1604,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             type(uint64).max,
             Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK
+            Constants.MAX_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct1, Alice, 0);
@@ -1593,7 +1628,13 @@ contract Misctest is Test, PositionUtils {
         PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        pp.forceExercise(Alice, $posIdList[0], new TokenId[](0), new TokenId[](0));
+        pp.forceExercise(
+            Alice,
+            $posIdList[0],
+            new TokenId[](0),
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+        );
     }
 
     function test_success_ITMspreadfee_0_01bp() public {
@@ -1636,6 +1677,374 @@ contract Misctest is Test, PositionUtils {
         );
     }
 
+    function test_success_ExerciseSettle_ComputeLongPremium() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(sfpm.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                1,
+                0,
+                -35,
+                1
+            )
+        );
+
+        vm.startPrank(Seller);
+        pp.mintOptions(
+            $posIdList,
+            4_000_000,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.startPrank(Alice);
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.startPrank(Bob);
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.startPrank(Swapper);
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(-35));
+
+        accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1_000_000, 1_000_000_000);
+
+        swapperc.swapTo(uniPool, 2 ** 96);
+
+        editCollateral(ct0, Alice, ct0.convertToShares(5000));
+        editCollateral(ct1, Alice, ct1.convertToShares(5000));
+
+        editCollateral(ct0, Bob, ct0.convertToShares(5000));
+        editCollateral(ct1, Bob, ct1.convertToShares(5000));
+
+        vm.startPrank(Bob);
+
+        $tempIdList = $posIdList;
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(sfpm.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                1,
+                1,
+                0,
+                -35,
+                1
+            )
+        );
+
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            type(uint64).max,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.startPrank(Alice);
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.settleLongPremium($posIdList, Bob, 0, false);
+
+        uint256 snap = vm.snapshotState();
+        pp.settleLongPremium($posIdList, Bob, 0, true);
+
+        vm.revertToState(snap);
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            $tempIdList,
+            $tempIdList,
+            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+        );
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            $tempIdList,
+            $tempIdList,
+            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+        );
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            $tempIdList,
+            $tempIdList,
+            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+        );
+
+        snap = vm.snapshotState();
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            $tempIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+        );
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            $tempIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+        );
+
+        uint256 snap2 = vm.snapshotState();
+
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            $tempIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+        );
+
+        vm.revertToState(snap2);
+
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            $tempIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
+
+        vm.revertToState(snap);
+
+        $setupIdList.push($posIdList[1]);
+
+        vm.startPrank(Bob);
+        pp.burnOptions(
+            $posIdList[0],
+            $setupIdList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.startPrank(Alice);
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            $tempIdList,
+            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+        );
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            $tempIdList,
+            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+        );
+
+        snap2 = vm.snapshotState();
+
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            $tempIdList,
+            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+        );
+
+        vm.revertToState(snap2);
+
+        snap2 = vm.snapshotState();
+
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            $tempIdList,
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
+
+        vm.revertToState(snap2);
+
+        pp.burnOptions(
+            $posIdList[0],
+            new TokenId[](0),
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        snap2 = vm.snapshotState();
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+        );
+
+        vm.revertToState(snap2);
+
+        snap2 = vm.snapshotState();
+
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+        );
+
+        vm.revertToState(snap2);
+
+        snap2 = vm.snapshotState();
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+        );
+
+        vm.revertToState(snap2);
+
+        snap2 = vm.snapshotState();
+
+        pp.forceExercise(
+            Bob,
+            $posIdList[1],
+            new TokenId[](0),
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
+    }
+
+    // are delegations for ITM positions sufficient?
+    function test_success_exercise_crossDelegate() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        $posIdList.push(
+            TokenId.wrap(0).addPoolId(sfpm.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        vm.startPrank(Seller);
+
+        pp.mintOptions(
+            $posIdList,
+            2_000_000,
+            0,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        $posIdList[0] = TokenId.wrap(0).addPoolId(sfpm.getPoolId(address(uniPool))).addLeg(
+            0,
+            1,
+            1,
+            1,
+            0,
+            0,
+            15,
+            1
+        );
+
+        vm.startPrank(Alice);
+        pp.mintOptions(
+            $posIdList,
+            1_000_000,
+            type(uint64).max,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        editCollateral(ct1, Alice, 0);
+
+        vm.startPrank(Swapper);
+
+        twapTick = PanopticMath.twapFilter(uniPool, 600);
+
+        vm.warp(block.timestamp + 600);
+        vm.roll(block.number + 1);
+
+        swapperc.swapTo(uniPool, 10 * 2 ** 96);
+
+        vm.warp(block.timestamp + 600);
+        vm.roll(block.number + 1);
+
+        swapperc.mint(uniPool, -10, 10, 10 ** 18);
+        swapperc.burn(uniPool, -10, 10, 10 ** 18);
+
+        twapTick = PanopticMath.twapFilter(uniPool, 600);
+
+        vm.startPrank(Bob);
+        pp.forceExercise(
+            Alice,
+            $posIdList[0],
+            new TokenId[](0),
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
+    }
+
     function test_parity_maxmint_previewmint() public view {
         assertEq(ct0.previewMint(ct0.maxMint(Alice)), type(uint104).max);
     }
@@ -1669,7 +2078,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -1680,7 +2090,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1707,7 +2118,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         TokenId[] memory longPositionList = new TokenId[](257);
@@ -1720,7 +2132,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1797,7 +2210,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -1806,7 +2220,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         pp.mintOptions(
@@ -1814,7 +2229,8 @@ contract Misctest is Test, PositionUtils {
             900_000_000,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Swapper);
@@ -1837,14 +2253,16 @@ contract Misctest is Test, PositionUtils {
                 250_000_000,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             pp.burnOptions(
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -1853,7 +2271,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         uint256 delta0 = ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0;
@@ -1865,7 +2284,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // there is a small amount of error in token0 -- this is the commissions from Charlie
@@ -1904,7 +2324,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         $posIdList.push(
@@ -1924,7 +2345,8 @@ contract Misctest is Test, PositionUtils {
                 250_000,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             vm.startPrank(Bob);
@@ -1933,7 +2355,8 @@ contract Misctest is Test, PositionUtils {
                 250_000,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             vm.startPrank(Swapper);
@@ -1948,7 +2371,8 @@ contract Misctest is Test, PositionUtils {
                 $posIdList[1],
                 $tempIdList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             vm.startPrank(Alice);
@@ -1956,7 +2380,8 @@ contract Misctest is Test, PositionUtils {
                 $posIdList[1],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -1966,7 +2391,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -1995,7 +2421,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         $posIdList.push(
@@ -2013,7 +2440,8 @@ contract Misctest is Test, PositionUtils {
                 499_999,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
             vm.startPrank(Swapper);
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
@@ -2025,7 +2453,8 @@ contract Misctest is Test, PositionUtils {
                 $posIdList[1],
                 $tempIdList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -2034,7 +2463,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -2066,7 +2496,8 @@ contract Misctest is Test, PositionUtils {
             500_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -2076,7 +2507,8 @@ contract Misctest is Test, PositionUtils {
             250_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Charlie);
@@ -2086,7 +2518,8 @@ contract Misctest is Test, PositionUtils {
             250_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // sell unrelated, non-overlapping, dummy chunk (to buy for match testing)
@@ -2104,7 +2537,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000_000 - 9_884_444 * 3,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // position type A: 1-leg long primary
@@ -2122,7 +2556,8 @@ contract Misctest is Test, PositionUtils {
                 9_884_444,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -2142,7 +2577,8 @@ contract Misctest is Test, PositionUtils {
                 9_884_444,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -2162,7 +2598,8 @@ contract Misctest is Test, PositionUtils {
                 9_884_444,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -2181,7 +2618,8 @@ contract Misctest is Test, PositionUtils {
                 19_768_888,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -2348,7 +2786,7 @@ contract Misctest is Test, PositionUtils {
 
         // collect buyer 1's three relevant chunks
         for (uint256 i = 0; i < 3; ++i) {
-            pp.settleLongPremium(collateralIdLists[i], Buyers[0], 0);
+            pp.settleLongPremium(collateralIdLists[i], Buyers[0], 0, true);
         }
 
         assertEq(
@@ -2373,7 +2811,8 @@ contract Misctest is Test, PositionUtils {
             $posIdLists[0][0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(
@@ -2402,7 +2841,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assetsBefore0Arr.push(ct0.convertToAssets(ct0.balanceOf(Buyers[0])));
@@ -2415,9 +2855,9 @@ contract Misctest is Test, PositionUtils {
         // now, settle the dummy chunks for all the buyers/positions and see that the settled ratio for primary doesn't change
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1);
+            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
 
-            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0);
+            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -2466,7 +2906,8 @@ contract Misctest is Test, PositionUtils {
             $posIdLists[0][0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(
@@ -2489,9 +2930,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1);
+            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
 
-            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0);
+            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -2539,11 +2980,11 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0);
+            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
 
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 0);
+            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 0, true);
 
-            pp.settleLongPremium(collateralIdLists[2], Buyers[i], 0);
+            pp.settleLongPremium(collateralIdLists[2], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -2592,7 +3033,8 @@ contract Misctest is Test, PositionUtils {
             $posIdLists[0][0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(
@@ -2608,7 +3050,7 @@ contract Misctest is Test, PositionUtils {
 
         // test long leg validation
         vm.expectRevert(Errors.NotALongLeg.selector);
-        pp.settleLongPremium(collateralIdLists[2], Buyers[0], 1);
+        pp.settleLongPremium(collateralIdLists[2], Buyers[0], 1, true);
 
         // test positionIdList validation
         // snapshot so we don't have to reset changes to collateralIdLists array
@@ -2616,7 +3058,7 @@ contract Misctest is Test, PositionUtils {
 
         collateralIdLists[0].pop();
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.settleLongPremium(collateralIdLists[0], Buyers[0], 0);
+        pp.settleLongPremium(collateralIdLists[0], Buyers[0], 0, true);
         vm.revertTo(snap);
 
         // test collateral checking (basic)
@@ -2627,7 +3069,7 @@ contract Misctest is Test, PositionUtils {
             deal(address(ct0), Buyers[i], i ** 15);
             deal(address(ct1), Buyers[i], i ** 15);
             vm.expectRevert(Errors.AccountInsolvent.selector);
-            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0);
+            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
             vm.revertTo(snap);
         }
 
@@ -2640,7 +3082,8 @@ contract Misctest is Test, PositionUtils {
                 $posIdLists[2],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             // the positive premium is from the dummy short chunk
@@ -2656,6 +3099,156 @@ contract Misctest is Test, PositionUtils {
                 "Buyer paid premium twice"
             );
         }
+    }
+
+    function test_success_settleLongPremium_tokenSubstitution() public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(100));
+        vm.warp(block.timestamp + 12);
+        vm.roll(block.number + 1);
+        swapperc.swapTo(uniPool, 2 ** 96);
+
+        $posIdLists[0].push(
+            TokenId.wrap(0).addPoolId(sfpm.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                0,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        vm.startPrank(Alice);
+
+        pp.mintOptions(
+            $posIdLists[0],
+            100_000_000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        $posIdLists[1].push(
+            TokenId.wrap(0).addPoolId(sfpm.getPoolId(address(uniPool))).addLeg(
+                0,
+                1,
+                1,
+                1,
+                0,
+                0,
+                15,
+                1
+            )
+        );
+
+        for (uint256 i = 0; i < 3; ++i) {
+            vm.startPrank(Buyers[i]);
+            pp.mintOptions(
+                $posIdLists[1],
+                1_000_000,
+                type(uint64).max,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK,
+                true
+            );
+        }
+
+        vm.startPrank(Swapper);
+
+        //routerV4.swapTo(address(0), poolKey, Math.getSqrtRatioAtTick(10) + 1);
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(10) + 1);
+
+        accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1_000_000, 1_000_000_000);
+
+        int256 premium0 = 10388;
+        int256 premium1 = 10388989;
+
+        uint160 lastObservedPrice = Math.getSqrtRatioAtTick(100);
+
+        vm.startPrank(Alice);
+
+        uint256 settlerBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
+        uint256 settlerBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
+
+        // shortage of token1 - succeeds and token1 is converted to token0
+        editCollateral(ct1, Buyers[0], 0);
+
+        uint256 settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[0]));
+        uint256 settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[0]));
+
+        pp.settleLongPremium($posIdLists[1], Buyers[0], 0, true);
+
+        int256 balanceDelta0 = int256(ct0.convertToAssets(ct0.balanceOf(Buyers[0]))) -
+            int256(settleeBalanceBefore0);
+        int256 balanceDelta1 = int256(ct1.convertToAssets(ct1.balanceOf(Buyers[0]))) -
+            int256(settleeBalanceBefore1);
+
+        assertEq(
+            -balanceDelta0,
+            premium0 +
+                int256(PanopticMath.convert1to0RoundingUp(uint256(premium1), lastObservedPrice))
+        );
+        assertEq(balanceDelta1, 0);
+
+        assertEq(
+            int256(settlerBalanceBefore0) - int256(ct0.convertToAssets(ct0.balanceOf(Alice))),
+            balanceDelta0 + premium0
+        );
+        assertEq(
+            int256(settlerBalanceBefore1) - int256(ct1.convertToAssets(ct1.balanceOf(Alice))),
+            premium1 + 1
+        );
+
+        settlerBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
+        settlerBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
+
+        // shortage of token0 - succeeds and token0 is converted to token1
+        editCollateral(ct0, Buyers[1], 0);
+
+        settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[1]));
+        settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[1]));
+
+        pp.settleLongPremium($posIdLists[1], Buyers[1], 0, true);
+
+        balanceDelta0 =
+            int256(ct0.convertToAssets(ct0.balanceOf(Buyers[1]))) -
+            int256(settleeBalanceBefore0);
+        balanceDelta1 =
+            int256(ct1.convertToAssets(ct1.balanceOf(Buyers[1]))) -
+            int256(settleeBalanceBefore1);
+
+        assertEq(balanceDelta0, 0);
+        assertEq(
+            -balanceDelta1,
+            premium1 +
+                int256(PanopticMath.convert0to1RoundingUp(uint256(premium0), lastObservedPrice))
+        );
+
+        assertEq(
+            int256(settlerBalanceBefore0) - int256(ct0.convertToAssets(ct0.balanceOf(Alice))),
+            premium0 + 1
+        );
+        assertEq(
+            int256(settlerBalanceBefore1) - int256(ct1.convertToAssets(ct1.balanceOf(Alice))),
+            balanceDelta1 + premium1
+        );
+
+        // insolvent account - fails while revoking virtual shares
+        editCollateral(ct0, Buyers[2], 0);
+        editCollateral(ct1, Buyers[2], 0);
+
+        vm.expectRevert(stdError.arithmeticError);
+        pp.settleLongPremium($posIdLists[1], Buyers[2], 0, true);
     }
 
     function test_success_settledPremiumDistribution() public {
@@ -2691,7 +3284,8 @@ contract Misctest is Test, PositionUtils {
             500_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -2701,7 +3295,8 @@ contract Misctest is Test, PositionUtils {
             250_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Charlie);
@@ -2711,7 +3306,8 @@ contract Misctest is Test, PositionUtils {
             250_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         $posIdList.push(
@@ -2729,7 +3325,8 @@ contract Misctest is Test, PositionUtils {
             44_468,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -2740,7 +3337,8 @@ contract Misctest is Test, PositionUtils {
             44_468,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Swapper);
@@ -2765,7 +3363,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             $tempIdList,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(
@@ -2787,7 +3386,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         $tempIdList[0] = $posIdList[1];
@@ -2798,7 +3398,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             $tempIdList,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Alice);
@@ -2812,7 +3413,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(
@@ -2831,7 +3433,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Charlie);
@@ -2844,7 +3447,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(
@@ -2882,13 +3486,14 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct0, Bob, ct0.convertToShares(266263));
         editCollateral(ct1, Bob, 0);
 
-        pp.validateCollateralWithdrawable(Bob, $posIdList);
+        pp.validateCollateralWithdrawable(Bob, $posIdList, true);
     }
 
     function test_Success_WithdrawWithOpenPositions() public {
@@ -2914,13 +3519,14 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
 
-        ct0.withdraw(1_000_000 - 266263, Bob, Bob, $posIdList);
+        ct0.withdraw(1_000_000 - 266263, Bob, Bob, $posIdList, true);
     }
 
     function test_Fail_validateCollateralWithdrawable() public {
@@ -2946,14 +3552,15 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct0, Bob, ct0.convertToShares(266262));
         editCollateral(ct1, Bob, 0);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.validateCollateralWithdrawable(Bob, $posIdList);
+        pp.validateCollateralWithdrawable(Bob, $posIdList, true);
     }
 
     function test_Fail_WithdrawWithOpenPositions_AccountInsolvent() public {
@@ -2979,14 +3586,15 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        ct0.withdraw(1_000_000 - 266262, Bob, Bob, $posIdList);
+        ct0.withdraw(1_000_000 - 266262, Bob, Bob, $posIdList, true);
     }
 
     function test_Fail_InsolventAtCurrentTick_itmPut() public {
@@ -3040,7 +3648,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -3094,7 +3703,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -3151,7 +3761,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
         (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(
             pp,
@@ -3232,7 +3843,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (uint128 balance, uint64 utilization0, uint64 utilization1) = ph.optionPositionInfo(
@@ -3314,7 +3926,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
         (uint256 totalCollateralBalance0, uint256 totalCollateralRequired0) = ph.checkCollateral(
             pp,
@@ -3393,7 +4006,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (uint128 balance, uint64 utilization0, uint64 utilization1) = ph.optionPositionInfo(
@@ -3445,14 +4059,15 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct0, Bob, ct0.convertToShares(1_000_000));
         editCollateral(ct1, Bob, 0);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        ct0.withdraw(1_000_000 - 266262, Alice, Bob, $posIdList);
+        ct0.withdraw(1_000_000 - 266262, Alice, Bob, $posIdList, true);
     }
 
     function test_Success_SafeMode_down() public {
@@ -3605,7 +4220,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.revertTo(snap);
@@ -3633,7 +4249,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (uint128 balance, uint64 utilization0, uint64 utilization1) = ph.optionPositionInfo(
@@ -3701,7 +4318,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         ct0.withdraw(ct0.maxWithdraw(Bob), Bob, Bob);
@@ -3717,7 +4335,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (uint128 balance, uint64 utilization0, uint64 utilization1) = ph.optionPositionInfo(
@@ -3775,7 +4394,8 @@ contract Misctest is Test, PositionUtils {
             100_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Swapper);
@@ -3794,7 +4414,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         uint256 before0 = ct0.convertToAssets(ct0.balanceOf(Bob));
@@ -3807,7 +4428,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         uint256 after0 = ct0.convertToAssets(ct0.balanceOf(Bob));
@@ -3856,13 +4478,15 @@ contract Misctest is Test, PositionUtils {
             500_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
         pp.burnOptions(
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (, , int24 slowOracleTickStale, , uint256 medianDataStale) = pp.getOracleTicks();
@@ -3878,7 +4502,8 @@ contract Misctest is Test, PositionUtils {
             500_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (, , slowOracleTickStale, , medianDataStale) = pp.getOracleTicks();
@@ -3954,7 +4579,8 @@ contract Misctest is Test, PositionUtils {
             500_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (, , int24 slowOracleTickStale, , uint256 medianDataStale) = pp.getOracleTicks();
@@ -3969,7 +4595,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         (, , slowOracleTickStale, , medianDataStale) = pp.getOracleTicks();
@@ -4022,7 +4649,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 2 ** 95, 0, int24(887272), int24(-887272));
+        pp.mintOptions($posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
 
         (, , uint256[2][] memory positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Bob,
@@ -4056,7 +4683,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(requiredCross > 0, "zero collateral requirement");
         assertTrue(requiredCross <= balanceCross, "account is solvent");
 
-        pp.burnOptions($posIdList[0], new TokenId[](0), int24(887272), int24(-887272));
+        pp.burnOptions($posIdList[0], new TokenId[](0), int24(887272), int24(-887272), true);
     }
 
     function test_success_PremiumRollover() public {
@@ -4077,7 +4704,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // mint 1 liquidity unit of wideish centered position
-        pp.mintOptions(posIdList, 3, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(posIdList, 3, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK, true);
 
         vm.startPrank(Swapper);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
@@ -4097,7 +4724,8 @@ contract Misctest is Test, PositionUtils {
             tokenId,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         uint256 balanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
@@ -4111,7 +4739,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Swapper);
@@ -4146,7 +4775,8 @@ contract Misctest is Test, PositionUtils {
             tokenId,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // make sure Alice earns no fees on token 0 (her delta is slightly negative due to commission fees/precision etc)
@@ -4207,7 +4837,8 @@ contract Misctest is Test, PositionUtils {
             2_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // long put = 1.5, short put 1.25, short call 0.75, long call 0.5
@@ -4229,7 +4860,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // 0.25, 0.6, 0.9, 1.1, 1.4, 1.6
@@ -4245,7 +4877,8 @@ contract Misctest is Test, PositionUtils {
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             console2.log(
@@ -4311,7 +4944,8 @@ contract Misctest is Test, PositionUtils {
             2_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // long call = 1.25, short call = 1.5, short call = 1.75, long call = 2
@@ -4333,7 +4967,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // 1.3, 1.6, 1.8, 2.1
@@ -4349,7 +4984,8 @@ contract Misctest is Test, PositionUtils {
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             console2.log(
@@ -4397,7 +5033,8 @@ contract Misctest is Test, PositionUtils {
             2_000_000,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // long put = 0.25, short put = 0.5, short put = 0.75, short call = 0.9
@@ -4419,7 +5056,8 @@ contract Misctest is Test, PositionUtils {
             1_000_000,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // 0.2, 0.4, 0.6, 0.8, 1.1
@@ -4435,7 +5073,8 @@ contract Misctest is Test, PositionUtils {
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             console2.log(
@@ -4494,7 +5133,8 @@ contract Misctest is Test, PositionUtils {
             1_003_003,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Swapper);
@@ -4555,7 +5195,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -4704,7 +5345,14 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.mintOptions(posIdList, 3000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            posIdList,
+            3000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
     }
 
     function test_Fail_DivergentSolvencyCheck_burn() public {
@@ -4741,7 +5389,14 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(posIdList, 3000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            posIdList,
+            3000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
 
         TokenId[] memory posIdList2 = new TokenId[](2);
 
@@ -4755,7 +5410,14 @@ contract Misctest is Test, PositionUtils {
         posIdList2[1] = tokenId2;
 
         // mint second option
-        pp.mintOptions(posIdList2, 10, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            posIdList2,
+            10,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
 
         (currentTick, fastOracleTick, slowOracleTick, lastObservedTick, ) = pp.getOracleTicks();
 
@@ -4792,7 +5454,8 @@ contract Misctest is Test, PositionUtils {
             posIdList2[1],
             posIdList,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -4830,7 +5493,14 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        pp.mintOptions(posIdList, 3000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            posIdList,
+            3000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
 
         (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -4957,7 +5627,14 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        pp.mintOptions(posIdList, 3000, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.mintOptions(
+            posIdList,
+            3000,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
 
         (, currentTick, , , , , ) = uniPool.slot0();
 
@@ -5089,7 +5766,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5172,7 +5850,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5271,7 +5950,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5366,7 +6046,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5461,7 +6142,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5550,7 +6232,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5630,7 +6313,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5730,7 +6414,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5822,7 +6507,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5913,7 +6599,8 @@ contract Misctest is Test, PositionUtils {
                 3000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -5984,7 +6671,8 @@ contract Misctest is Test, PositionUtils {
                     1_000_000,
                     0,
                     Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    true
                 );
 
                 // create spread tokenId
@@ -6033,7 +6721,8 @@ contract Misctest is Test, PositionUtils {
                 10_000,
                 2 ** 30,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -6106,7 +6795,8 @@ contract Misctest is Test, PositionUtils {
                     1_000_000,
                     0,
                     Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    true
                 );
 
                 // create spread tokenId
@@ -6155,7 +6845,8 @@ contract Misctest is Test, PositionUtils {
                 10_000,
                 2 ** 30,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();
@@ -6227,7 +6918,8 @@ contract Misctest is Test, PositionUtils {
                     1_000_000,
                     0,
                     Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    true
                 );
 
                 // create spread tokenId
@@ -6276,7 +6968,8 @@ contract Misctest is Test, PositionUtils {
                 10_000,
                 2 ** 30,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (, currentTick, , , , , ) = uniPool.slot0();

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -1625,7 +1625,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSizes[0],
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -1654,7 +1655,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSizes[1],
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             twoWaySwap(swapSizeSeed);
@@ -1760,7 +1762,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         premiaSeed[0] = bound(premiaSeed[0], 2 ** 64, 2 ** 120);
@@ -1860,7 +1863,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize * 2,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Alice);
@@ -1888,7 +1892,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(
@@ -1982,7 +1987,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize * 2,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Alice);
@@ -2010,7 +2016,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             type(uint64).max - 1,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
@@ -2096,7 +2103,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize * 2,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Alice);
@@ -2110,7 +2118,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -2146,7 +2155,7 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK);
+        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -2238,7 +2247,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
@@ -2328,7 +2338,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
@@ -2443,7 +2454,7 @@ contract PanopticPoolTest is PositionUtils {
 
             // reversing the tick limits here to make sure they get entered into the SFPM properly
             // this test will fail if it does not (because no ITM swaps will occur)
-            pp.mintOptions(posIdList, positionSize, 0, TickMath.MAX_TICK, TickMath.MIN_TICK);
+            pp.mintOptions(posIdList, positionSize, 0, TickMath.MAX_TICK, TickMath.MIN_TICK, true);
         }
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
@@ -2548,7 +2559,7 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK);
+        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -2704,7 +2715,8 @@ contract PanopticPoolTest is PositionUtils {
                     positionSize,
                     0,
                     Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    true
                 );
             }
             (, currentTick, observationIndex, observationCardinality, , , ) = pool.slot0();
@@ -2860,7 +2872,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
         (, currentTick, observationIndex, observationCardinality, , , ) = pool.slot0();
@@ -3006,7 +3019,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSizes[0],
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -3105,7 +3119,8 @@ contract PanopticPoolTest is PositionUtils {
                     positionSizes[1],
                     type(uint64).max,
                     Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    true
                 );
             }
 
@@ -3229,7 +3244,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSizes[0],
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
 
@@ -3298,7 +3314,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSizes[1],
                 type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
 
@@ -3411,7 +3428,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.PriceBoundFail.selector);
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0);
+        pp.mintOptions(posIdList, positionSize, 0, 0, 0, true);
     }
 
     function test_Fail_mintOptions_LowerPriceBoundFail(
@@ -3447,7 +3464,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.PriceBoundFail.selector);
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MAX_TICK - 1, TickMath.MAX_TICK);
+        pp.mintOptions(posIdList, positionSize, 0, TickMath.MAX_TICK - 1, TickMath.MAX_TICK, true);
     }
 
     function test_Fail_mintOptions_UpperPriceBoundFail(
@@ -3483,7 +3500,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.PriceBoundFail.selector);
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MIN_TICK + 1);
+        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MIN_TICK + 1, true);
     }
 
     function test_Fail_mintOptions_IncorrectPool(
@@ -3524,7 +3541,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -3565,7 +3583,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         posIdList = new TokenId[](2);
@@ -3578,7 +3597,8 @@ contract PanopticPoolTest is PositionUtils {
             uint128(positionSize),
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -3620,7 +3640,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize * 0,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -3675,7 +3696,8 @@ contract PanopticPoolTest is PositionUtils {
             uint128(positionSize),
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
     }
 
@@ -3701,7 +3723,8 @@ contract PanopticPoolTest is PositionUtils {
                 1_000_000,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             if (i > 25) break;
@@ -3757,9 +3780,16 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
-        pp.burnOptions(tokenId, emptyList, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.burnOptions(
+            tokenId,
+            emptyList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), 0);
 
@@ -3858,7 +3888,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -3894,7 +3925,8 @@ contract PanopticPoolTest is PositionUtils {
                 tokenId,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), 0);
@@ -4027,7 +4059,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -4064,7 +4097,8 @@ contract PanopticPoolTest is PositionUtils {
                 tokenId,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), 0);
@@ -4203,7 +4237,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             // poke Uniswap pool to update tokens owed - needed because swap happens after mint
@@ -4228,7 +4263,8 @@ contract PanopticPoolTest is PositionUtils {
                 (positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             twoWaySwap(swapSizeSeed);
@@ -4255,7 +4291,8 @@ contract PanopticPoolTest is PositionUtils {
                 (((positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000) * 100) / 89,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             // poke Uniswap pool to update tokens owed - needed because swap happens after mint
@@ -4294,7 +4331,8 @@ contract PanopticPoolTest is PositionUtils {
                 tokenIds[0],
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -4412,7 +4450,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
 
             // poke Uniswap pool to update tokens owed - needed because swap happens after mint
@@ -4437,7 +4476,8 @@ contract PanopticPoolTest is PositionUtils {
                 (positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000,
                 type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
 
             twoWaySwap(swapSizeSeed);
@@ -4464,7 +4504,8 @@ contract PanopticPoolTest is PositionUtils {
                 (((positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000) * 100) / 89,
                 0,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
 
             // poke Uniswap pool to update tokens owed - needed because swap happens after mint
@@ -4503,7 +4544,8 @@ contract PanopticPoolTest is PositionUtils {
                 tokenIds[0],
                 emptyList,
                 Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK
+                Constants.MAX_V3POOL_TICK,
+                true
             );
         }
 
@@ -4612,7 +4654,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSizes[0],
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -4626,14 +4669,16 @@ contract PanopticPoolTest is PositionUtils {
                 uint128(positionSizes[1]),
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             pp.burnOptions(
                 posIdList,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             (uint256 token0Balance, , ) = ph.optionPositionInfo(pp, Alice, tokenId);
@@ -4719,7 +4764,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize * 10,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -4744,7 +4790,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             if ($posIdLists[3].length < legsToBurn) {
@@ -4764,14 +4811,16 @@ contract PanopticPoolTest is PositionUtils {
                     $posIdLists[3],
                     $posIdLists[2],
                     Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    true
                 );
             } else {
                 pp.burnOptions(
                     $posIdLists[3][0],
                     $posIdLists[2],
                     Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK
+                    Constants.MIN_V3POOL_TICK,
+                    true
                 );
             }
 
@@ -4880,14 +4929,16 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[3],
                 $posIdLists[2],
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         } else {
             pp.burnOptions(
                 $posIdLists[3][0],
                 $posIdLists[2],
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
     }
@@ -4929,12 +4980,19 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.expectRevert(Errors.InputListFail.selector);
 
-        pp.burnOptions(tokenId, posIdList, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK);
+        pp.burnOptions(
+            tokenId,
+            posIdList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
     }
 
     function test_fail_burnOptions_burnAllOptionsFrom(
@@ -5025,7 +5083,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSizes[0],
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             vm.expectRevert(Errors.InputListFail.selector);
@@ -5033,7 +5092,8 @@ contract PanopticPoolTest is PositionUtils {
                 tokenId,
                 posIdList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -5047,7 +5107,8 @@ contract PanopticPoolTest is PositionUtils {
                 uint128(positionSizes[1]),
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             vm.expectRevert(Errors.InputListFail.selector);
@@ -5055,7 +5116,8 @@ contract PanopticPoolTest is PositionUtils {
                 tokenId,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
         {
@@ -5069,7 +5131,8 @@ contract PanopticPoolTest is PositionUtils {
                 uint128(positionSizes[0]),
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             vm.expectRevert(Errors.InputListFail.selector);
@@ -5077,7 +5140,8 @@ contract PanopticPoolTest is PositionUtils {
                 tokenId,
                 posIdList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -5093,7 +5157,8 @@ contract PanopticPoolTest is PositionUtils {
                 uint128(positionSizes[1]),
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             TokenId[] memory burnIdList = new TokenId[](2);
@@ -5105,7 +5170,8 @@ contract PanopticPoolTest is PositionUtils {
                 burnIdList,
                 posIdList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
 
             TokenId[] memory leftoverIdList = new TokenId[](2);
@@ -5116,7 +5182,8 @@ contract PanopticPoolTest is PositionUtils {
                 burnIdList,
                 leftoverIdList,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
     }
@@ -5179,7 +5246,7 @@ contract PanopticPoolTest is PositionUtils {
             uint256 exerciseableCount;
             // make sure position is exercisable - the uniswap twap is used to determine exercisability
             // so it could potentially be both OTM and non-exercisable (in-range)
-            TWAPtick = pp.getUniV3TWAP_();
+            (, , , TWAPtick, ) = pp.getOracleTicks();
             for (uint256 i = 0; i < numLegs; ++i) {
                 if (
                     (TWAPtick < (numLegs == 1 ? tickLower : tickLowers[i]) ||
@@ -5206,7 +5273,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize * 2,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         // now we can mint the long option we are force exercising
@@ -5239,7 +5307,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             )
         {} catch (bytes memory reason) {
             if (bytes4(reason) == Errors.TransferFailed.selector) {
@@ -5292,8 +5361,8 @@ contract PanopticPoolTest is PositionUtils {
 
             rangesFromStrike = legRanges > rangesFromStrike ? legRanges : rangesFromStrike;
 
-            medianSqrtPriceX96 = TickMath.getSqrtRatioAtTick(TWAPtick);
-
+            (, , , TWAPtick, ) = pp.getOracleTicks();
+            uint160 lastObservedPrice = TickMath.getSqrtRatioAtTick(TWAPtick);
             LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
                 tokenId,
                 i,
@@ -5308,7 +5377,7 @@ contract PanopticPoolTest is PositionUtils {
             );
 
             (medianValue0, medianValue1) = LiquidityAmounts.getAmountsForLiquidity(
-                medianSqrtPriceX96,
+                lastObservedPrice,
                 TickMath.getSqrtRatioAtTick(liquidityChunk.tickLower()),
                 TickMath.getSqrtRatioAtTick(liquidityChunk.tickUpper()),
                 liquidityChunk.liquidity()
@@ -5330,7 +5399,13 @@ contract PanopticPoolTest is PositionUtils {
         exerciseFeeAmounts[0] += (longAmounts.rightSlot() * (-exerciseFee)) / 10_000;
         exerciseFeeAmounts[1] += (longAmounts.leftSlot() * (-exerciseFee)) / 10_000;
 
-        pp.forceExercise(Alice, posIdList[0], new TokenId[](0), new TokenId[](0));
+        pp.forceExercise(
+            Alice,
+            posIdList[0],
+            new TokenId[](0),
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
 
         assertApproxEqAbs(
             int256(ct0.balanceOf(Bob)) - int256(uint256(type(uint104).max)),
@@ -5421,7 +5496,7 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
-    function test_Success_getExerciseDeltas(
+    function test_Success_getRefundAmounts(
         uint256 x,
         uint256 balance0,
         uint256 balance1,
@@ -5455,7 +5530,7 @@ contract PanopticPoolTest is PositionUtils {
                 int256(ct0.balanceOf(Charlie)) -
                 int256(ct0.convertToShares(uint256(-refund0)));
 
-            LeftRightSigned refundAmounts = PanopticMath.getExerciseDeltas(
+            LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
                 Charlie,
                 LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
                 int24(atTick),
@@ -5586,7 +5661,7 @@ contract PanopticPoolTest is PositionUtils {
             uint256 exerciseableCount;
             // make sure position is exercisable - the uniswap twap is used to determine exercisability
             // so it could potentially be both OTM and non-exercisable (in-range)
-            TWAPtick = pp.getUniV3TWAP_();
+            (, , , TWAPtick, ) = pp.getOracleTicks();
             for (uint256 i = 0; i < numLegs; ++i) {
                 if (
                     (TWAPtick < (numLegs == 1 ? tickLower : tickLowers[i]) ||
@@ -5617,7 +5692,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize * 10,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -5657,7 +5733,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -5669,7 +5746,13 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             vm.startPrank(Bob);
-            pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], $posIdLists[0]);
+            pp.forceExercise(
+                Alice,
+                $posIdLists[2][0],
+                $posIdLists[3],
+                $posIdLists[0],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
 
             int256 balanceDelta0 = int256(ct0.balanceOf(Alice)) -
                 int256(lastCollateralBalance0[Alice]);
@@ -5683,17 +5766,18 @@ contract PanopticPoolTest is PositionUtils {
 
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
+        (, , , TWAPtick, ) = pp.getOracleTicks();
         (, uint256 totalCollateralRequired0) = ph.checkCollateral(
             pp,
             Bob,
-            pp.getUniV3TWAP_(),
+            TWAPtick,
             $posIdLists[0]
         );
 
-        if (pp.getUniV3TWAP_() > 0)
+        if (TWAPtick > 0)
             totalCollateralRequired0 = PanopticMath.convert1to0(
                 totalCollateralRequired0,
-                Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                Math.getSqrtRatioAtTick(TWAPtick)
             );
 
         uint256 totalCollateralB0 = bound(
@@ -5705,10 +5789,8 @@ contract PanopticPoolTest is PositionUtils {
         vm.assume(
             int256(totalCollateralRequired0) +
                 int256(
-                    PanopticMath.convert1to0(
-                        $balanceDelta1,
-                        Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
-                    ) + $balanceDelta0
+                    PanopticMath.convert1to0($balanceDelta1, Math.getSqrtRatioAtTick(TWAPtick)) +
+                        $balanceDelta0
                 ) *
                 2 >
                 int256(totalCollateralB0)
@@ -5728,7 +5810,7 @@ contract PanopticPoolTest is PositionUtils {
                 PanopticMath.convert0to1(
                     (totalCollateralB0 * (10_000 - bound(collateralRatioSeed, 5_000, 6_000))) /
                         10_000,
-                    Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                    Math.getSqrtRatioAtTick(TWAPtick)
                 )
             )
         );
@@ -5736,7 +5818,13 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert();
-        pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], $posIdLists[0]);
+        pp.forceExercise(
+            Alice,
+            $posIdLists[2][0],
+            $posIdLists[3],
+            $posIdLists[0],
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
     }
 
     function test_Fail_forceExercise_ExerciseeNotSolvent(
@@ -5797,7 +5885,7 @@ contract PanopticPoolTest is PositionUtils {
             uint256 exerciseableCount;
             // make sure position is exercisable - the uniswap twap is used to determine exercisability
             // so it could potentially be both OTM and non-exercisable (in-range)
-            TWAPtick = pp.getUniV3TWAP_();
+            (, , , TWAPtick, ) = pp.getOracleTicks();
             for (uint256 i = 0; i < numLegs; ++i) {
                 if (
                     (TWAPtick < (numLegs == 1 ? tickLower : tickLowers[i]) ||
@@ -5828,7 +5916,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize * 2,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -5868,7 +5957,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -5880,7 +5970,13 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             vm.startPrank(Bob);
-            pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], new TokenId[](0));
+            pp.forceExercise(
+                Alice,
+                $posIdLists[2][0],
+                $posIdLists[3],
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
 
             int256 balanceDelta0 = int256(ct0.balanceOf(Alice)) -
                 int256(lastCollateralBalance0[Alice]);
@@ -5894,17 +5990,19 @@ contract PanopticPoolTest is PositionUtils {
 
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
+        (, , , TWAPtick, ) = pp.getOracleTicks();
+
         (, uint256 totalCollateralRequired0) = ph.checkCollateral(
             pp,
             Alice,
-            pp.getUniV3TWAP_(),
+            TWAPtick,
             $posIdLists[3]
         );
 
-        if (pp.getUniV3TWAP_() > 0)
+        if (TWAPtick > 0)
             totalCollateralRequired0 = PanopticMath.convert1to0(
                 totalCollateralRequired0,
-                Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                Math.getSqrtRatioAtTick(TWAPtick)
             );
 
         uint256 totalCollateralB0 = bound(
@@ -5916,10 +6014,8 @@ contract PanopticPoolTest is PositionUtils {
         vm.assume(
             int256(totalCollateralRequired0) -
                 int256(
-                    PanopticMath.convert1to0(
-                        $balanceDelta1,
-                        Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
-                    ) + $balanceDelta0
+                    PanopticMath.convert1to0($balanceDelta1, Math.getSqrtRatioAtTick(TWAPtick)) +
+                        $balanceDelta0
                 ) *
                 2 >
                 int256(totalCollateralB0)
@@ -5938,7 +6034,7 @@ contract PanopticPoolTest is PositionUtils {
             ct1.convertToShares(
                 PanopticMath.convert0to1(
                     (totalCollateralB0 * (10_000 - bound(collateralRatioSeed, 0, 10_000))) / 10_000,
-                    Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                    Math.getSqrtRatioAtTick(TWAPtick)
                 )
             )
         );
@@ -5946,7 +6042,13 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert();
-        pp.forceExercise(Alice, $posIdLists[2][0], $posIdLists[3], new TokenId[](0));
+        pp.forceExercise(
+            Alice,
+            $posIdLists[2][0],
+            $posIdLists[3],
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
     }
 
     function test_Fail_forceExercise_InvalidExerciseeList(
@@ -6005,7 +6107,7 @@ contract PanopticPoolTest is PositionUtils {
             uint256 exerciseableCount;
             // make sure position is exercisable - the uniswap twap is used to determine exercisability
             // so it could potentially be both OTM and non-exercisable (in-range)
-            TWAPtick = pp.getUniV3TWAP_();
+            (, , , TWAPtick, ) = pp.getOracleTicks();
             for (uint256 i = 0; i < numLegs; ++i) {
                 if (
                     (TWAPtick < (numLegs == 1 ? tickLower : tickLowers[i]) ||
@@ -6036,7 +6138,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize * 2,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -6064,7 +6167,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         twoWaySwap(swapSizeSeed);
@@ -6072,7 +6176,13 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.forceExercise(Alice, $posIdLists[1][0], $posIdLists[0], new TokenId[](0));
+        pp.forceExercise(
+            Alice,
+            $posIdLists[1][0],
+            $posIdLists[0],
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
     }
 
     function test_Fail_forceExercise_InvalidExercisorList(
@@ -6121,7 +6231,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         posIdList = new TokenId[](2);
@@ -6145,7 +6256,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -6154,7 +6266,13 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId2;
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.forceExercise(Alice, TokenId.wrap(0), new TokenId[](0), posIdList);
+        pp.forceExercise(
+            Alice,
+            TokenId.wrap(0),
+            new TokenId[](0),
+            posIdList,
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
     }
 
     function test_Fail_forceExercise_PositionNotExercisable(uint256 x) public {
@@ -6188,13 +6306,20 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.NoLegsExercisable.selector);
-        pp.forceExercise(Alice, touchedIds[0], touchedIds, new TokenId[](0));
+        pp.forceExercise(
+            Alice,
+            touchedIds[0],
+            touchedIds,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -6276,7 +6401,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize * 2,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -6304,7 +6430,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -6316,19 +6443,20 @@ contract PanopticPoolTest is PositionUtils {
         }
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-        vm.assume(Math.abs(int256(currentTick) - pp.getUniV3TWAP_()) <= 513);
+        (, , , TWAPtick, ) = pp.getOracleTicks();
+        vm.assume(Math.abs(int256(currentTick) - TWAPtick) <= 513);
 
         (, uint256 totalCollateralRequired0) = ph.checkCollateral(
             pp,
             Alice,
-            pp.getUniV3TWAP_(),
+            TWAPtick,
             $posIdLists[1]
         );
 
-        if (pp.getUniV3TWAP_() > 0)
+        if (TWAPtick > 0)
             totalCollateralRequired0 = PanopticMath.convert1to0(
                 totalCollateralRequired0,
-                Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                Math.getSqrtRatioAtTick(TWAPtick)
             );
 
         uint256 totalCollateralB0 = bound(
@@ -6350,12 +6478,12 @@ contract PanopticPoolTest is PositionUtils {
             ct1.convertToShares(
                 PanopticMath.convert0to1(
                     (totalCollateralB0 * (10_000 - bound(collateralRatioSeed, 0, 10_000))) / 10_000,
-                    Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                    Math.getSqrtRatioAtTick(TWAPtick)
                 )
             )
         );
 
-        TWAPtick = pp.getUniV3TWAP_();
+        TWAPtick = TWAPtick;
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
         ($shortPremia, $longPremia, $positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
@@ -6537,7 +6665,7 @@ contract PanopticPoolTest is PositionUtils {
             (uint256 newBalance0, uint256 newRequired0) = ph.checkCollateral(
                 pp,
                 Alice,
-                pp.getUniV3TWAP_(),
+                TWAPtick,
                 $posIdLists[1]
             );
             vm.assume(newBalance0 < newRequired0);
@@ -6871,7 +6999,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize * 2,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         twoWaySwap(swapSizeSeed);
@@ -6897,7 +7026,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             type(uint64).max,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         twoWaySwap(swapSizeSeed);
@@ -6908,20 +7038,20 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
-
-        vm.assume(Math.abs(int256(currentTick) - pp.getUniV3TWAP_()) <= 513);
+        (, , , TWAPtick, ) = pp.getOracleTicks();
+        vm.assume(Math.abs(int256(currentTick) - TWAPtick) <= 513);
 
         (, uint256 totalCollateralRequired0) = ph.checkCollateral(
             pp,
             Alice,
-            pp.getUniV3TWAP_(),
+            TWAPtick,
             $posIdLists[1]
         );
 
-        if (pp.getUniV3TWAP_() > 0)
+        if (TWAPtick > 0)
             totalCollateralRequired0 = PanopticMath.convert1to0(
                 totalCollateralRequired0,
-                Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                Math.getSqrtRatioAtTick(TWAPtick)
             );
 
         uint256 totalCollateralB0 = bound(
@@ -6943,12 +7073,12 @@ contract PanopticPoolTest is PositionUtils {
             ct1.convertToShares(
                 PanopticMath.convert0to1(
                     (totalCollateralB0 * (10_000 - bound(collateralRatioSeed, 0, 10_000))) / 10_000,
-                    Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                    Math.getSqrtRatioAtTick(TWAPtick)
                 )
             )
         );
 
-        TWAPtick = pp.getUniV3TWAP_();
+        TWAPtick = TWAPtick;
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
         ($shortPremia, $longPremia, $positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
@@ -7112,7 +7242,7 @@ contract PanopticPoolTest is PositionUtils {
             (uint256 newBalance0, uint256 newRequired0) = ph.checkCollateral(
                 pp,
                 Alice,
-                pp.getUniV3TWAP_(),
+                TWAPtick,
                 $posIdLists[1]
             );
             vm.assume(newBalance0 < newRequired0);
@@ -7420,7 +7550,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         posIdList = new TokenId[](2);
@@ -7444,7 +7575,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -7494,7 +7626,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -7504,7 +7637,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct0, Alice, 2);
@@ -7552,7 +7686,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         vm.startPrank(Bob);
@@ -7562,7 +7697,8 @@ contract PanopticPoolTest is PositionUtils {
             positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK
+            Constants.MIN_V3POOL_TICK,
+            true
         );
 
         editCollateral(ct0, Alice, 2);
@@ -7588,8 +7724,8 @@ contract PanopticPoolTest is PositionUtils {
         vm.roll(block.number + 1);
         vm.warp(block.timestamp + 20);
         twoWaySwapBig();
-
-        vm.assume(Math.abs((int256(currentTick) + tickDelta) - pp.getUniV3TWAP_()) > 513);
+        (, , , TWAPtick, ) = pp.getOracleTicks();
+        vm.assume(Math.abs((int256(currentTick) + tickDelta) - TWAPtick) > 513);
 
         vm.store(
             address(pool),
@@ -7601,7 +7737,7 @@ contract PanopticPoolTest is PositionUtils {
             )
         );
 
-        vm.expectRevert(Errors.StaleTWAP.selector);
+        vm.expectRevert(Errors.StaleOracle.selector);
         pp.liquidate(new TokenId[](0), Alice, $posIdList);
     }
 
@@ -7680,7 +7816,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize * 2,
                 0,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -7708,7 +7845,8 @@ contract PanopticPoolTest is PositionUtils {
                 positionSize,
                 type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK
+                Constants.MIN_V3POOL_TICK,
+                true
             );
         }
 
@@ -7722,19 +7860,20 @@ contract PanopticPoolTest is PositionUtils {
 
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-        vm.assume(Math.abs(int256(currentTick) - pp.getUniV3TWAP_()) <= 513);
+        (, , , TWAPtick, ) = pp.getOracleTicks();
+        vm.assume(Math.abs(int256(currentTick) - TWAPtick) <= 513);
 
         (, uint256 twapCollateralRequired0) = ph.checkCollateral(
             pp,
             Alice,
-            pp.getUniV3TWAP_(),
+            TWAPtick,
             $posIdLists[1]
         );
 
-        if (pp.getUniV3TWAP_() > 0)
+        if (TWAPtick > 0)
             twapCollateralRequired0 = PanopticMath.convert1to0(
                 twapCollateralRequired0,
-                Math.getSqrtRatioAtTick(pp.getUniV3TWAP_())
+                Math.getSqrtRatioAtTick(TWAPtick)
             );
 
         (, uint256 currentCollateralRequired0) = ph.checkCollateral(
@@ -7784,7 +7923,7 @@ contract PanopticPoolTest is PositionUtils {
                     (totalCollateralB0 * (10_000 - bound(collateralRatioSeed, 0, 10_000))) / 10_000,
                     Math.getSqrtRatioAtTick(
                         twapCollateralRequired0 > currentCollateralRequired0
-                            ? pp.getUniV3TWAP_()
+                            ? TWAPtick
                             : currentTick
                     )
                 )
@@ -7795,7 +7934,7 @@ contract PanopticPoolTest is PositionUtils {
             (uint256 newBalance0, uint256 newRequired0) = ph.checkCollateral(
                 pp,
                 Alice,
-                pp.getUniV3TWAP_(),
+                TWAPtick,
                 $posIdLists[1]
             );
             vm.assume(newBalance0 > newRequired0);
@@ -7830,7 +7969,7 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         vm.startPrank(Bob);
-        vm.assume(Math.abs(int256(currentTick) - pp.getUniV3TWAP_()) < 953);
+        vm.assume(Math.abs(int256(currentTick) - TWAPtick) < 953);
 
         try pp.liquidate(new TokenId[](0), Alice, $posIdLists[1]) {
             assertFalse(true, "liquidation should have failed");


### PR DESCRIPTION
This PR added the same features that were implemented for v1.1's launch:

- feat: add virtual share delegation to `settleLongPremium` https://github.com/panoptic-labs/panoptic-v1-core/pull/25
- feat: allow users to skip earned premium calculation https://github.com/panoptic-labs/panoptic-v1-core/pull/26


@coderabbitai: do not review this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added premia-as-collateral mode across mint, burn, withdraw, settle and force-exercise flows (new trailing flag) and ERC‑1155 receipt support.

- **Refactor**
  - Unified premia-as-collateral computations and collateral-aware solvency checks; moved pricing to oracle-driven ticks and renamed stale-price error to StaleOracle; refund/substitution logic refined.

- **Tests**
  - Updated tests for new APIs and oracle flows; added token-substitution settlement test.

- **Chores**
  - Adjusted CI optimizer settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->