### PR TITLE
Feat0: remove MEV commission fee from CollateralTracker deposit/mint functions

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -374,15 +374,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param assets The amount of assets to be deposited
     /// @return shares The amount of shares that can be minted
     function previewDeposit(uint256 assets) public view returns (uint256 shares) {
-        // compute the MEV tax, which is equal to a single payment of the commissionRate on the FINAL (post mev-tax) assets paid
-        unchecked {
-            shares = Math.mulDiv(assets, totalSupply, totalAssets());
-        }
+        shares = Math.mulDiv(assets, totalSupply, totalAssets());
     }
 
     /// @notice Deposit underlying tokens (assets) to the Panoptic pool from the LP and mint corresponding amount of shares.
     /// @dev There is a maximum asset deposit limit of `2^104 - 1`.
-    /// @dev An "MEV tax" is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP (`receiver`).
     /// @param assets Amount of assets deposited
     /// @param receiver User to receive the shares
@@ -413,9 +409,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Returns the maximum shares received for a deposit.
     /// @return maxShares The maximum amount of shares that can be minted
     function maxMint(address) external view returns (uint256 maxShares) {
-        unchecked {
-            return convertToShares(type(uint104).max);
-        }
+        return convertToShares(type(uint104).max);
     }
 
     /// @notice Returns the amount of assets that would be deposited to mint a given amount of shares.
@@ -429,7 +423,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice Deposit required amount of assets to receive specified amount of shares.
     /// @dev There is a maximum asset deposit limit of `2^104 - 1`.
-    /// @dev An "MEV tax" is levied, which is equal to a single payment of the commissionRate BEFORE adding the funds.
     /// @dev Shares are minted and sent to the LP (`receiver`).
     /// @param shares Amount of shares to be minted
     /// @param receiver User to receive the shares

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -376,11 +376,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function previewDeposit(uint256 assets) public view returns (uint256 shares) {
         // compute the MEV tax, which is equal to a single payment of the commissionRate on the FINAL (post mev-tax) assets paid
         unchecked {
-            shares = Math.mulDiv(
-                assets * (DECIMALS - COMMISSION_FEE),
-                totalSupply,
-                totalAssets() * DECIMALS
-            );
+            shares = Math.mulDiv(assets, totalSupply, totalAssets());
         }
     }
 
@@ -418,7 +414,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @return maxShares The maximum amount of shares that can be minted
     function maxMint(address) external view returns (uint256 maxShares) {
         unchecked {
-            return (convertToShares(type(uint104).max) * (DECIMALS - COMMISSION_FEE)) / DECIMALS;
+            return convertToShares(type(uint104).max);
         }
     }
 
@@ -428,16 +424,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function previewMint(uint256 shares) public view returns (uint256 assets) {
         // round up depositing assets to avoid protocol loss
         // This prevents minting of shares where the assets provided is rounded down to zero
-        // compute the MEV tax, which is equal to a single payment of the commissionRate on the FINAL (post mev-tax) assets paid
-        // finalAssets - convertedAssets = commissionRate * finalAssets
-        // finalAssets - commissionRate * finalAssets = convertedAssets
-        // finalAssets * (1 - commissionRate) = convertedAssets
-        // finalAssets = convertedAssets / (1 - commissionRate)
-        assets = Math.mulDivRoundingUp(
-            shares * DECIMALS,
-            totalAssets(),
-            totalSupply * (DECIMALS - COMMISSION_FEE)
-        );
+        assets = Math.mulDivRoundingUp(shares, totalAssets(), totalSupply);
     }
 
     /// @notice Deposit required amount of assets to receive specified amount of shares.

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -598,14 +598,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // the amount of shares that can be minted
         // supply == 0 ? assets : FullMath.mulDiv(assets, supply, totalAssets());
         uint256 sharesToken0 = FullMath.mulDiv(
-            uint256(assets) * 9_990,
+            uint256(assets),
             collateralToken0.totalSupply(),
-            collateralToken0.totalAssets() * 10_000
+            collateralToken0.totalAssets()
         );
         uint256 sharesToken1 = FullMath.mulDiv(
-            uint256(assets) * 9_990,
+            uint256(assets),
             collateralToken1.totalSupply(),
-            collateralToken1.totalAssets() * 10_000
+            collateralToken1.totalAssets()
         );
 
         // deposit a number of assets determined via fuzzing
@@ -1199,7 +1199,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // give Bob the max amount of tokens
         _grantTokens(Bob);
 
-        shares = uint104(bound(shares, 0, (uint256(type(uint104).max) * 1000) / 1001));
+        shares = uint104(bound(shares, 0, (uint256(type(uint104).max))));
 
         console2.log("test shares", shares);
         console2.log("test totalassets", collateralToken0.totalAssets());
@@ -5879,7 +5879,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // real value
         uint256 actualValue = collateralToken0.previewWithdraw(1000);
 
-        assertEq(actualValue, 999001000);
+        assertEq(actualValue, 1000000000);
     }
 
     // maxWithdraw
@@ -5944,7 +5944,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // real value
         uint256 actualValue = collateralToken0.previewMint(shares);
 
-        assertApproxEqAbs(((expectedValue * 10_000) / 9_990), actualValue, 5);
+        assertApproxEqAbs(((expectedValue)), actualValue, 5);
     }
 
     // maxMint
@@ -5952,7 +5952,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         _initWorld(x);
 
         // use a fixed amount for single test
-        uint256 expectedValue = (collateralToken0.convertToShares(type(uint104).max) * 999) / 1000;
+        uint256 expectedValue = (collateralToken0.convertToShares(type(uint104).max));
 
         // real value
         uint256 actualValue = collateralToken0.maxMint(Bob);
@@ -5970,7 +5970,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // real value
         uint256 actualValue = collateralToken0.previewDeposit(1000);
 
-        assertEq((expectedValue * 9_990) / 10_000, actualValue);
+        assertEq((expectedValue), actualValue);
     }
 
     // maxDeposit

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1611,12 +1611,9 @@ contract Misctest is Test, PositionUtils {
         CollateralTracker(collateralReference).deposit(type(uint104).max, Bob);
 
         vm.startPrank(Alice);
-        token0.mint(Alice, (uint256(1_000_000_000_000_000) * 10_000) / 9_990);
-        token0.approve(collateralReference, (uint256(1_000_000_000_000_000) * 10_000) / 9_990);
-        CollateralTracker(collateralReference).deposit(
-            (uint256(1_000_000_000_000_000) * 10_000) / 9_990,
-            Alice
-        );
+        token0.mint(Alice, (uint256(1_000_000_000_000_000)));
+        token0.approve(collateralReference, (uint256(1_000_000_000_000_000)));
+        CollateralTracker(collateralReference).deposit((uint256(1_000_000_000_000_000)), Alice);
 
         vm.startPrank(address(pp));
         CollateralTracker(collateralReference).takeCommissionAddData(
@@ -1632,7 +1629,7 @@ contract Misctest is Test, PositionUtils {
                 CollateralTracker(collateralReference).convertToAssets(
                     CollateralTracker(collateralReference).balanceOf(Alice)
                 ),
-            1_000_000_000 + 2000
+            1_000_000_000 + 1999
         );
     }
 
@@ -4154,7 +4151,7 @@ contract Misctest is Test, PositionUtils {
         // she could have still earned some fees, but now the accumulation is frozen forever.
         assertEq(
             int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore0),
-            -1244790
+            -1245199
         );
 
         // but she earns all of fees on token 1 since the premium accumulator did not overflow (!)

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -417,14 +417,7 @@ contract PanopticPoolTest is PositionUtils {
         ct0.deposit(type(uint104).max, Seller);
         ct1.deposit(type(uint104).max, Seller);
 
-        // cancel out MEV tax and push exchange rate back to 1
-        deal(address(ct0), Seller, type(uint104).max, true);
-        deal(address(ct1), Seller, type(uint104).max, true);
-
         vm.startPrank(Bob);
-        // account for MEV tax
-        deal(token0, Bob, (type(uint104).max * uint256(1010)) / 1000);
-        deal(token1, Bob, (type(uint104).max * uint256(1010)) / 1000);
 
         IERC20Partial(token0).approve(address(router), type(uint256).max);
         IERC20Partial(token1).approve(address(router), type(uint256).max);
@@ -435,10 +428,6 @@ contract PanopticPoolTest is PositionUtils {
 
         ct0.deposit(type(uint104).max, Bob);
         ct1.deposit(type(uint104).max, Bob);
-
-        // cancel out MEV tax and push exchange rate back to 1
-        deal(address(ct0), Bob, type(uint104).max, true);
-        deal(address(ct1), Bob, type(uint104).max, true);
 
         vm.startPrank(Alice);
 
@@ -454,10 +443,6 @@ contract PanopticPoolTest is PositionUtils {
 
         ct0.deposit(type(uint104).max, Alice);
         ct1.deposit(type(uint104).max, Alice);
-
-        // cancel out MEV tax and push exchange rate back to 1
-        deal(address(ct0), Alice, type(uint104).max, true);
-        deal(address(ct1), Alice, type(uint104).max, true);
     }
 
     function setUp() public {

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -419,6 +419,9 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.startPrank(Bob);
 
+        deal(token0, Bob, type(uint104).max);
+        deal(token1, Bob, type(uint104).max);
+
         IERC20Partial(token0).approve(address(router), type(uint256).max);
         IERC20Partial(token1).approve(address(router), type(uint256).max);
         IERC20Partial(token0).approve(address(pp), type(uint256).max);


### PR DESCRIPTION
## Summary
Removes the MEV commission fee (1% tax) from the CollateralTracker's deposit and mint operations, simplifying the share calculation logic and making the vault implementation more standard.

## Changes

### Contract Changes (`CollateralTracker.sol`)
- **`previewDeposit()`**: Removed commission fee calculation, now uses direct proportion (`assets * totalSupply / totalAssets`)
- **`maxMint()`**: Removed commission fee adjustment, returns direct share conversion
- **`previewMint()`**: Simplified to standard vault math without commission fee deduction

## Technical Details

**Before:** 
- Deposits were taxed with a `COMMISSION_FEE` = 20bps
- Share calculations: `shares = assets * (DECIMALS - COMMISSION_FEE) * totalSupply / (totalAssets * DECIMALS)`
- Tests had to artificially inflate balances to compensate

**After:**
- Standard ERC4626 vault math without fees
- Share calculations: `shares = assets * totalSupply / totalAssets`
- Clean test setup without artificial adjustments

## Motivation
1. **Simplification**: Removes complexity from core deposit/withdraw logic
2. **Standard Compliance**: Aligns with standard ERC4626 vault implementations
3. **Gas Optimization**: Simpler calculations mean lower gas costs
4. **Test Clarity**: Tests no longer need workarounds for the fee mechanism

## Impact
- Users will receive more shares for the same asset deposits (no 1% haircut)
- Existing integrations expecting the fee may need updates
- More predictable and transparent vault behavior

## Breaking Changes
⚠️ **This is a breaking change** - removes a fee mechanism that was previously applied to all deposits and mints. Any existing deployments or integrations expecting this fee behavior will need to be updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversion previews and limits now use pure pro‑rata calculations with no commission/MEV tax applied, so deposits, mints, withdrawals and previews align exactly to total assets and supply.
  * Estimates are more predictable and consistent across the app.

* **Tests**
  * Test scenarios and expected values updated to reflect tax‑free conversions and exact proportional calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->