### PR TITLE
Feat4: refactor: PanopticPool interface with unified dispatch system

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -113,10 +113,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @notice Amount of assets moved from the Panoptic Pool to the AMM.
     uint128 internal s_inAMM;
 
-    /// @notice Additional risk premium charged on intrinsic value of ITM positions,
-    /// denominated in hundredths of basis points.
-    uint128 internal s_ITMSpreadFee;
-
     /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
 
@@ -149,10 +145,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @dev i.e 90% -> 0.9 * 10_000 = 9_000.
     uint256 immutable SATURATED_POOL_UTIL;
 
-    /// @notice Multiplier, in basis points, to the pool fee that is charged on the intrinsic value of ITM positions.
-    /// @dev e.g. ITM_SPREAD_MULTIPLIER = 20_000, s_ITMSpreadFee = 2 * s_poolFee.
-    uint256 immutable ITM_SPREAD_MULTIPLIER;
-
     /*//////////////////////////////////////////////////////////////
                             ACCESS CONTROL
     //////////////////////////////////////////////////////////////*/
@@ -174,15 +166,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param _forceExerciseCost Basal cost (in bps of notional) to force exercise an out-of-range position
     /// @param _targetPoolUtilization Target pool utilization below which buying+selling is optimal, represented as percentage * 10_000
     /// @param _saturatedPoolUtilization Pool utilization above which selling is 100% collateral backed, represented as percentage * 10_000
-    /// @param _ITMSpreadMultiplier Multiplier, in basis points, to the pool fee that is charged on the intrinsic value of ITM positions
     constructor(
         uint256 _commissionFee,
         uint256 _sellerCollateralRatio,
         uint256 _buyerCollateralRatio,
         int256 _forceExerciseCost,
         uint256 _targetPoolUtilization,
-        uint256 _saturatedPoolUtilization,
-        uint256 _ITMSpreadMultiplier
+        uint256 _saturatedPoolUtilization
     ) {
         COMMISSION_FEE = _commissionFee;
         SELLER_COLLATERAL_RATIO = _sellerCollateralRatio;
@@ -190,7 +180,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         FORCE_EXERCISE_COST = _forceExerciseCost;
         TARGET_POOL_UTIL = _targetPoolUtilization;
         SATURATED_POOL_UTIL = _saturatedPoolUtilization;
-        ITM_SPREAD_MULTIPLIER = _ITMSpreadMultiplier;
     }
 
     /// @notice Initialize a new collateral tracker for a specific token corresponding to the Panoptic Pool being created by the factory that called it.
@@ -235,11 +224,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         // store whether the current collateral token is token0 (true) or token1 (false)
         s_underlyingIsToken0 = underlyingIsToken0;
-
-        // Additional risk premium charged on intrinsic value of ITM positions
-        unchecked {
-            s_ITMSpreadFee = uint128((ITM_SPREAD_MULTIPLIER * fee) / DECIMALS);
-        }
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1062,14 +1062,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @return The final utilization of the collateral vault
-    /// @return The total amount of commission (base rate + ITM spread) paid
+    /// @return The final utilization of the collateral vault (rightSlot) and the total amount of commission (base rate + ITM spread) paid (leftSlot)
     function settleMint(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount
-    ) external onlyPanopticPool returns (uint32, uint128) {
+    ) external onlyPanopticPool returns (LeftRightUnsigned, int128) {
         (uint32 utilization, uint128 commission, int128 tokenPaid) = _updateBalancesAndSettle(
             true, // isCreation = true
             optionOwner,
@@ -1078,7 +1077,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             swappedAmount,
             0 // realizedPremium not used
         );
-        return (utilization, commission);
+        return (
+            LeftRightUnsigned.wrap(0).toRightSlot(utilization).toLeftSlot(commission),
+            tokenPaid
+        );
     }
 
     /// @notice Exercise an option and pay to the seller what is owed from the buyer.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -984,6 +984,79 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                      OPTION EXERCISE AND COMMISSION
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Internal function to handle all balance and state updates for position creation and closing.
+    /// @param isCreation A boolean flag to indicate if this is for option creation (true) or closing (false).
+    /// @param optionOwner The user minting the option
+    /// @param longAmount The amount of longs
+    /// @param shortAmount The amount of shorts
+    /// @param swappedAmount The amount of tokens moved during creation of the option position
+    ///
+    function _updateBalancesAndSettle(
+        bool isCreation,
+        address optionOwner,
+        int128 longAmount,
+        int128 shortAmount,
+        int128 swappedAmount,
+        int128 realizedPremium
+    ) internal returns (uint32, uint128, int128) {
+        unchecked {
+            int256 tokenToPay;
+            uint128 commission;
+
+            // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
+            int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
+
+            if (isCreation) {
+                {
+                    int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
+
+                    // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
+                    commission = uint128(
+                        Math.unsafeDivRoundingUp(
+                            uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
+                            DECIMALS
+                        )
+                    );
+
+                    tokenToPay = intrinsicValue + int128(commission);
+                }
+            } else {
+                // add premium and token deltas not covered by swap to be paid/collected on position close
+                tokenToPay = int256(swappedAmount) - (longAmount - shortAmount) - realizedPremium;
+            }
+
+            // Mint/Burn Shares
+            if (tokenToPay > 0) {
+                uint256 sharesToBurn = Math.mulDivRoundingUp(
+                    uint256(tokenToPay),
+                    totalSupply,
+                    totalAssets()
+                );
+                _burn(optionOwner, sharesToBurn);
+            } else if (tokenToPay < 0) {
+                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
+                _mint(optionOwner, sharesToMint);
+            }
+
+            // Update Pool Assets
+            if (isCreation) {
+                s_poolAssets = uint256(updatedAssets).toUint128();
+            } else {
+                s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
+            }
+
+            // Update s_inAMM
+            s_inAMM = uint256(
+                int256(uint256(s_inAMM)) +
+                    (isCreation ? (shortAmount - longAmount) : -(shortAmount - longAmount))
+            ).toUint128();
+
+            uint32 utilization = isCreation ? uint32(_poolUtilization()) : 0;
+
+            return (utilization, commission, int128(tokenToPay));
+        }
+    }
+
     /// @notice Take commission and settle ITM amounts on option creation.
     /// @param optionOwner The user minting the option
     /// @param longAmount The amount of longs
@@ -997,52 +1070,15 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 shortAmount,
         int128 swappedAmount
     ) external onlyPanopticPool returns (uint32, uint128) {
-        unchecked {
-            // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
-            int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
-
-            int256 tokenToPay;
-            uint128 commission;
-
-            {
-                int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
-
-                // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
-                commission = uint128(
-                    Math.unsafeDivRoundingUp(
-                        uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
-                        DECIMALS
-                    )
-                );
-
-                tokenToPay = intrinsicValue + int128(commission);
-            }
-
-            // compute tokens to be paid due to swap
-            // mint or burn tokens due to minting in-the-money
-            if (tokenToPay > 0) {
-                // if user must pay tokens, burn them from user balance
-                uint256 sharesToBurn = Math.mulDivRoundingUp(
-                    uint256(tokenToPay),
-                    totalSupply,
-                    totalAssets()
-                );
-                _burn(optionOwner, sharesToBurn);
-            } else if (tokenToPay < 0) {
-                // if user must receive tokens, mint them
-                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
-                _mint(optionOwner, sharesToMint);
-            }
-
-            // update stored asset balances with net moved amounts
-            // the inflow or outflow of pool assets is defined by the swappedAmount: it includes both the ITM swap amounts and the short/long amounts used to create the position
-            // however, any intrinsic value is paid for by the users, so we only add the portion that comes from PLPs: the short/long amounts
-            // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
-            s_poolAssets = uint256(updatedAssets).toUint128();
-            s_inAMM = uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)).toUint128();
-
-            return (uint32(_poolUtilization()), commission);
-        }
+        (uint32 utilization, uint128 commission, int128 tokenPaid) = _updateBalancesAndSettle(
+            true, // isCreation = true
+            optionOwner,
+            longAmount,
+            shortAmount,
+            swappedAmount,
+            0 // realizedPremium not used
+        );
+        return (utilization, commission);
     }
 
     /// @notice Exercise an option and pay to the seller what is owed from the buyer.
@@ -1060,37 +1096,15 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 swappedAmount,
         int128 realizedPremium
     ) external onlyPanopticPool returns (int128) {
-        unchecked {
-            // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
-            int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
-
-            // add premium and token deltas not covered by swap to be paid/collected on position close
-            int256 tokenToPay = int256(swappedAmount) -
-                (longAmount - shortAmount) -
-                realizedPremium;
-
-            if (tokenToPay > 0) {
-                // if user must pay tokens, burn them from user balance (revert if balance too small)
-                uint256 sharesToBurn = Math.mulDivRoundingUp(
-                    uint256(tokenToPay),
-                    totalSupply,
-                    totalAssets()
-                );
-                _burn(optionOwner, sharesToBurn);
-            } else if (tokenToPay < 0) {
-                // if user must receive tokens, mint them
-                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
-                _mint(optionOwner, sharesToMint);
-            }
-
-            // update stored asset balances with net moved amounts
-            // any intrinsic value is paid for by the users, so we do not add it to s_inAMM
-            // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
-            s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
-            s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
-
-            return (int128(tokenToPay));
-        }
+        (, , int128 tokenPaid) = _updateBalancesAndSettle(
+            false, // isCreation = false
+            optionOwner,
+            longAmount,
+            shortAmount,
+            swappedAmount,
+            realizedPremium
+        );
+        return tokenPaid;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -991,7 +991,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param swappedAmount The amount of tokens moved during creation of the option position
     /// @return The final utilization of the collateral vault
     /// @return The total amount of commission (base rate + ITM spread) paid
-    function takeCommissionAddData(
+    function settleMint(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
@@ -1053,7 +1053,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param swappedAmount The amount of tokens moved during the option close
     /// @param realizedPremium Premium to settle on the current positions
     /// @return The amount of tokens paid when closing that position
-    function exercise(
+    function settleBurn(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -989,15 +989,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @param isCovered Whether the option was minted as covered (no swap occurred if ITM)
     /// @return The final utilization of the collateral vault
     /// @return The total amount of commission (base rate + ITM spread) paid
     function takeCommissionAddData(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount,
-        bool isCovered
+        int128 swappedAmount
     ) external onlyPanopticPool returns (uint32, uint128) {
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
@@ -1006,8 +1004,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             (int256 tokenToPay, uint128 commission) = _getExchangedAmount(
                 longAmount,
                 shortAmount,
-                swappedAmount,
-                isCovered
+                swappedAmount
             );
 
             // compute tokens to be paid due to swap
@@ -1089,14 +1086,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of long options held
     /// @param shortAmount The amount of short options held
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @param isCovered Whether the option was minted as covered (no swap occurred if ITM)
     /// @return The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
     /// @return The total commission (base rate + ITM spread) paid for minting the option
     function _getExchangedAmount(
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount,
-        bool isCovered
+        int128 swappedAmount
     ) internal view returns (int256, uint128) {
         unchecked {
             int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
@@ -1105,15 +1100,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             uint256 commission = Math.unsafeDivRoundingUp(
                 uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
                 DECIMALS
-            ) +
-                (
-                    intrinsicValue == 0 || isCovered
-                        ? 0
-                        : Math.unsafeDivRoundingUp(
-                            s_ITMSpreadFee * uint256(Math.abs(intrinsicValue)),
-                            DECIMALS * 100
-                        )
-                );
+            );
 
             return (intrinsicValue + int256(commission), uint128(commission));
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1001,11 +1001,22 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
-            (int256 tokenToPay, uint128 commission) = _getExchangedAmount(
-                longAmount,
-                shortAmount,
-                swappedAmount
-            );
+            int256 tokenToPay;
+            uint128 commission;
+
+            {
+                int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
+
+                // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
+                commission = uint128(
+                    Math.unsafeDivRoundingUp(
+                        uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
+                        DECIMALS
+                    )
+                );
+
+                tokenToPay = intrinsicValue + int128(commission);
+            }
 
             // compute tokens to be paid due to swap
             // mint or burn tokens due to minting in-the-money
@@ -1079,30 +1090,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
 
             return (int128(tokenToPay));
-        }
-    }
-
-    /// @notice Get the amount exchanged to mint an option, including any fees.
-    /// @param longAmount The amount of long options held
-    /// @param shortAmount The amount of short options held
-    /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @return The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
-    /// @return The total commission (base rate + ITM spread) paid for minting the option
-    function _getExchangedAmount(
-        int128 longAmount,
-        int128 shortAmount,
-        int128 swappedAmount
-    ) internal view returns (int256, uint128) {
-        unchecked {
-            int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
-
-            // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
-            uint256 commission = Math.unsafeDivRoundingUp(
-                uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
-                DECIMALS
-            );
-
-            return (intrinsicValue + int256(commission), uint128(commission));
         }
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -546,6 +546,9 @@ contract PanopticPool is Multicall {
                     tickLimitHigh
                 );
             }
+            unchecked {
+                ++i;
+            }
         }
 
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
@@ -1666,7 +1669,7 @@ contract PanopticPool is Multicall {
         _updatePositionsHash(msg.sender, tokenId, ADD);
 
         uint256 numLegs = tokenId.countLegs();
-        for (uint256 leg = 0; leg < numLegs; ++leg) {
+        for (uint256 leg = 0; leg < numLegs; ) {
             uint256 isLong = tokenId.isLong(leg);
 
             bytes32 chunkKey = keccak256(
@@ -1755,6 +1758,10 @@ contract PanopticPool is Multicall {
                             )
                         );
                 }
+            }
+
+            unchecked {
+                ++leg;
             }
         }
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -610,11 +610,13 @@ contract PanopticPool is Multicall {
         uint96 tickData;
         // update the users options balance of position `tokenId`
         // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
-        s_positionBalance[owner][tokenId] = PositionBalanceLibrary.storeBalanceData(
+        PositionBalance balanceData = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
             tickData
         );
+
+        s_positionBalance[owner][tokenId] = balanceData;
 
         emit OptionMinted(owner, tokenId, balanceData, commissions);
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 // Interfaces
-
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
 import {IUniswapV3Pool} from "univ3-core/interfaces/IUniswapV3Pool.sol";
@@ -642,13 +641,13 @@ contract PanopticPool is Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (uint32 utilization0, uint128 commission0) = s_collateralToken0.settleMint(
+        (LeftRightUnsigned utilizationAndCommission0, ) = s_collateralToken0.settleMint(
             owner,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
             totalSwapped.rightSlot()
         );
-        (uint32 utilization1, uint128 commission1) = s_collateralToken1.settleMint(
+        (LeftRightUnsigned utilizationAndCommission1, ) = s_collateralToken1.settleMint(
             owner,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
@@ -658,8 +657,13 @@ contract PanopticPool is Multicall {
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
             return (
-                utilization0 + (utilization1 << 16),
-                LeftRightUnsigned.wrap(commission0).toLeftSlot(commission1)
+                uint32(
+                    utilizationAndCommission0.rightSlot() +
+                        (utilizationAndCommission1.rightSlot() << 16)
+                ),
+                LeftRightUnsigned.wrap(utilizationAndCommission0.leftSlot()).toLeftSlot(
+                    utilizationAndCommission1.leftSlot()
+                )
             );
         }
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -533,6 +533,7 @@ contract PanopticPool is Multicall {
                     tokenId,
                     positionSizes[i],
                     effectiveLiquidityLimitsX32[i],
+                    msg.sender,
                     tickLimitLow,
                     tickLimitHigh
                 );
@@ -573,12 +574,14 @@ contract PanopticPool is Multicall {
     /// @param positionSize The size of the position to be minted, expressed in terms of the asset
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
+    /// @param owner The owner of the option position to be minted
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function _mintOptions(
         TokenId tokenId,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
+        address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal {
@@ -587,6 +590,7 @@ contract PanopticPool is Multicall {
             tokenId,
             positionSize,
             effectiveLiquidityLimitX32,
+            owner,
             tickLimitLow,
             tickLimitHigh
         );
@@ -600,15 +604,16 @@ contract PanopticPool is Multicall {
 
         // update the users options balance of position `tokenId`
         // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
-        s_positionBalance[msg.sender][tokenId] = balanceData;
+        s_positionBalance[owner][tokenId] = balanceData;
 
-        emit OptionMinted(msg.sender, tokenId, balanceData, commissions);
+        emit OptionMinted(owner, tokenId, balanceData, commissions);
     }
 
     /// @notice Move all the required liquidity to/from the AMM and settle any required collateral deltas.
     /// @param tokenId The option position to be minted
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity`
+    /// @param owner The owner of the option position to be minted
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @return poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool) at the time of minting,
@@ -618,6 +623,7 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
+        address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (uint32 poolUtilizations, LeftRightUnsigned commissions) {
@@ -637,12 +643,14 @@ contract PanopticPool is Multicall {
             tokenId,
             collectedByLeg,
             positionSize,
-            effectiveLiquidityLimitX32
+            effectiveLiquidityLimitX32,
+            owner
         );
 
         (poolUtilizations, commissions) = _payCommissionAndWriteData(
             tokenId,
             positionSize,
+            owner,
             totalSwapped,
             tickLimitLow < tickLimitHigh
         );
@@ -653,6 +661,7 @@ contract PanopticPool is Multicall {
     /// @notice Take the commission fees for minting `tokenId` and settle any other required collateral deltas.
     /// @param tokenId The option position
     /// @param positionSize The size of the position, expressed in terms of the asset
+    /// @param owner The owner of the option position to be minted
     /// @param totalSwapped The amount of tokens moved during creation of the option position
     /// @param isCovered Whether the option was minted as covered (no swap occurred if ITM)
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
@@ -662,6 +671,7 @@ contract PanopticPool is Multicall {
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
+        address owner,
         LeftRightSigned totalSwapped,
         bool isCovered
     ) internal returns (uint32, LeftRightUnsigned) {
@@ -670,14 +680,14 @@ contract PanopticPool is Multicall {
             .computeExercisedAmounts(tokenId, positionSize);
 
         (uint32 utilization0, uint128 commission0) = s_collateralToken0.takeCommissionAddData(
-            msg.sender,
+            owner,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
             totalSwapped.rightSlot(),
             isCovered
         );
         (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
-            msg.sender,
+            owner,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
             totalSwapped.leftSlot(),
@@ -1658,15 +1668,17 @@ contract PanopticPool is Multicall {
     /// @param collectedByLeg The amount of tokens collected in the corresponding chunk for each leg of the position
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity`
+    /// @param owner The owner of the option position to be minted
     function _updateSettlementPostMint(
         TokenId tokenId,
         LeftRightUnsigned[4] memory collectedByLeg,
         uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32
+        uint64 effectiveLiquidityLimitX32,
+        address owner
     ) internal {
         // ADD the current tokenId to the position list hash (hash = XOR of all keccak256(tokenId))
         // and increase the number of positions counter by 1.
-        _updatePositionsHash(msg.sender, tokenId, ADD);
+        _updatePositionsHash(owner, tokenId, ADD);
 
         uint256 numLegs = tokenId.countLegs();
         for (uint256 leg = 0; leg < numLegs; ) {
@@ -1700,7 +1712,7 @@ contract PanopticPool is Multicall {
                     isLong
                 );
 
-                s_options[msg.sender][tokenId][leg] = LeftRightUnsigned
+                s_options[owner][tokenId][leg] = LeftRightUnsigned
                     .wrap(uint128(grossCurrent0))
                     .toLeftSlot(uint128(grossCurrent1));
             }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1131,13 +1131,12 @@ contract PanopticPool is Multicall {
                 positionSize
             );
 
-            TokenId _tokenId = tokenId;
             // Compute the exerciseFee, this will decrease the further away the price is from the exercised position
             // Include any deltas in long legs between the current and oracle tick in the exercise fee
             exerciseFees = ct0.exerciseCost(
                 currentTick,
                 twapTick,
-                _tokenId,
+                tokenId,
                 positionSize,
                 longAmounts
             );
@@ -1148,14 +1147,13 @@ contract PanopticPool is Multicall {
         ct1.delegate(account);
 
         {
-            address _account = account;
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
             _burnOptions(
                 COMMIT_LONG_SETTLED,
                 tokenId,
                 positionSize,
-                _account,
+                account,
                 MIN_SWAP_TICK,
                 MAX_SWAP_TICK
             );

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -886,10 +886,9 @@ contract PanopticPool is Multicall {
     ) external {
         // Assert the account we are liquidating is actually insolvent
         int24 twapTick = getUniV3TWAP();
-
         int24 currentTick;
-
         uint256 path;
+
         TokenId tokenId;
 
         uint256 solvent;
@@ -928,7 +927,7 @@ contract PanopticPool is Multicall {
             numberOfTicks = atTicks.length;
         }
         {
-            // if account is solvent at all ticks, this is a force exercise
+            // if account is solvent at all ticks, this is a force exercise or a settleLongPremium.
             if (solvent == numberOfTicks) {
                 uint256 toLength = positionIdListTo.length;
                 uint256 finalLength = positionIdListToFinal.length;
@@ -945,51 +944,60 @@ contract PanopticPool is Multicall {
                         }
                         path = 0;
                     } else if (toLength == (finalLength + 1)) {
-                        // final is one shorter, that's a force exercise
+                        // final is one element shorter, that's a force exercise
                         tokenId.validateIsExercisable(twapTick);
                         path = 1;
                     } else if (finalLength == 0) {
+                        // if final length was zero, this was intended to be liquidaton, but revert because not marging called
                         revert Errors.NotMarginCalled();
                     } else {
+                        // otherwise, wrong input lists
                         revert Errors.InputListFail();
                     }
                 }
             } else if (solvent == 0) {
                 // if account is insolvent at all ticks, this is a liquidation
+
+                // if the positions lengths are the same, this was intended as a settleLongPremia, but revert because account is insolvent
                 if (positionIdListToFinal.length == positionIdListTo.length)
                     revert Errors.AccountInsolvent();
+
+                // if the final position list has a non-zero length, this can't be a complete liquidation, revert
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
                 path = 2;
             } else {
+                // otherwise, revert because the account is not fully margin called
                 revert Errors.NotMarginCalled();
             }
         }
 
-        if (path == 2) {
-            _liquidate(account, positionIdListTo, twapTick, currentTick);
-            // no need to check that the liquidatee is solvent as all positions are burnt
-        } else {
-            // if path = 0, settleLongPremium
-            if (path == 0) {
-                _settleLongPremium(account, tokenId, twapTick, currentTick);
+        {
+            LeftRightSigned exchangedAmounts;
+            if (path == 2) {
+                exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
+                // no need to check that the liquidatee is solvent as all positions are burnt
+            } else {
+                // if path = 0, settleLongPremium
+                if (path == 0) {
+                    exchangedAmounts = _settleLongPremium(account, tokenId, twapTick, currentTick);
+                }
+
+                // if path = 1, force exercise
+
+                if (path == 1) {
+                    // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
+                    exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
+                }
+
+                // ensure the callee is still solvent after the operation
+                _validateSolvency(
+                    account,
+                    positionIdListToFinal,
+                    NO_BUFFER,
+                    usePremiaAsCollateral.rightSlot() > 0
+                );
             }
-
-            // if path = 1, force exercise
-
-            if (path == 1) {
-                // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-                _forceExercise(account, tokenId, twapTick, currentTick);
-            }
-
-            // ensure the callee is still solvent after the operation
-            _validateSolvency(
-                account,
-                positionIdListToFinal,
-                NO_BUFFER,
-                usePremiaAsCollateral.rightSlot() > 0
-            );
         }
-
         // ensure the caller is still solvent after the operation
         _validateSolvency(
             msg.sender,
@@ -1008,7 +1016,7 @@ contract PanopticPool is Multicall {
         TokenId[] calldata positionIdList,
         int24 twapTick,
         int24 currentTick
-    ) internal {
+    ) internal returns (LeftRightSigned bonusAmounts) {
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
         LeftRightUnsigned shortPremium;
@@ -1044,7 +1052,6 @@ contract PanopticPool is Multicall {
         s_collateralToken0.delegate(liquidatee);
         s_collateralToken1.delegate(liquidatee);
 
-        LeftRightSigned bonusAmounts;
         {
             LeftRightSigned netPaid;
             LeftRightSigned[4][] memory premiasByLeg;
@@ -1112,7 +1119,7 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         int24 twapTick,
         int24 currentTick
-    ) internal {
+    ) internal returns (LeftRightSigned refundAmounts) {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
@@ -1154,13 +1161,7 @@ contract PanopticPool is Multicall {
             );
         }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
-        LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
-            account,
-            exerciseFees,
-            twapTick,
-            ct0,
-            ct1
-        );
+        refundAmounts = PanopticMath.getRefundAmounts(account, exerciseFees, twapTick, ct0, ct1);
 
         // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
         ct0.refund(account, msg.sender, refundAmounts.rightSlot());
@@ -1183,15 +1184,13 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         int24 twapTick,
         int24 currentTick
-    ) internal {
+    ) internal returns (LeftRightSigned refundAmounts) {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
         // The protocol delegates some virtual shares to ensure the premia can be settled.
         ct0.delegate(owner);
         ct1.delegate(owner);
-
-        LeftRightSigned refundAmounts;
 
         uint128 positionSize = s_positionBalance[owner][tokenId].positionSize();
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -888,13 +888,21 @@ contract PanopticPool is Multicall {
         TokenId[] calldata positionIdListFrom,
         address account,
         TokenId[] calldata positionIdListTo,
-        TokenId[] calldata positionIdListFinal
+        TokenId[] calldata positionIdListToFinal,
+        LeftRightUnsigned usePremiaAsCollateral
     ) external {
         // Assert the account we are liquidating is actually insolvent
         int24 twapTick = getUniV3TWAP();
-
         int24 currentTick;
+
+        uint256 path;
+        TokenId tokenId;
+
+        uint256 solvent;
+        uint256 numberOfTicks;
         {
+            _validatePositionList(account, positionIdListTo);
+
             // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
             int24 fastOracleTick;
             int24 lastObservedTick;
@@ -914,9 +922,8 @@ contract PanopticPool is Multicall {
             atTicks[1] = twapTick;
             atTicks[2] = lastObservedTick;
             atTicks[3] = currentTick;
-            _validatePositionList(account, positionIdListTo);
 
-            uint256 solvent = _checkSolvencyAtTicks(
+            solvent = _checkSolvencyAtTicks(
                 account,
                 positionIdListTo,
                 currentTick,
@@ -924,7 +931,84 @@ contract PanopticPool is Multicall {
                 NO_BUFFER,
                 COMPUTE_PREMIA_AS_COLLATERAL
             );
+            numberOfTicks = atTicks.length;
         }
+        {
+            // if account is solvent at all ticks, this is a force exercise
+            if (solvent == numberOfTicks) {
+                uint256 toLength = positionIdListTo.length;
+                uint256 finalLength = positionIdListToFinal.length;
+                unchecked {
+                    if (toLength == finalLength) {
+                        // same length, that's a settle
+                        {
+                            bytes32 toHash = keccak256(abi.encodePacked(positionIdListTo));
+                            bytes32 finalHash = keccak256(abi.encodePacked(positionIdListToFinal));
+                            if (toHash != finalHash) {
+                                revert Errors.InputListFail();
+                            }
+                        }
+                        path = 0;
+                    } else if (toLength == (finalLength + 1)) {
+                        // final is one shorter, that's a force exercise
+                        path == 1;
+                    } else {
+                        revert Errors.InputListFail();
+                    }
+
+                    tokenId = positionIdListTo[toLength - 1];
+                }
+            }
+
+            // if account is insolvent at all ticks, this is a liquidation
+            if (solvent == 0) {
+                path = 2;
+                if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
+            }
+
+            revert Errors.NotMarginCalled();
+        }
+
+        // if path = 2, settleLongPremium
+        if (path == 0) {
+            _settleLongPremium(account, tokenId, twapTick, currentTick);
+
+            _validateSolvency(
+                account,
+                positionIdListToFinal,
+                NO_BUFFER,
+                usePremiaAsCollateral.rightSlot() > 0
+            );
+        }
+
+        // if path = 1, force exercise
+
+        if (path == 1) {
+            // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
+            tokenId.validateIsExercisable(twapTick);
+            _forceExercise(account, tokenId, twapTick, currentTick);
+
+            // ensure the callee is still solvent after the operation
+            _validateSolvency(
+                account,
+                positionIdListToFinal,
+                NO_BUFFER,
+                usePremiaAsCollateral.rightSlot() > 0
+            );
+        }
+        // if path = 2, liquidate
+        if (path == 2) {
+            _liquidate(positionIdListFrom, account, positionIdListTo, twapTick, currentTick);
+            // no need to check that the liquidatee is solvent as all positions are burnt
+        }
+
+        // ensure the caller is still solvent after the operation
+        _validateSolvency(
+            msg.sender,
+            positionIdListFrom,
+            NO_BUFFER,
+            usePremiaAsCollateral.leftSlot() > 0
+        );
     }
 
     /// @notice Liquidates a distressed account. Will burn all positions and issue a bonus to the liquidator.
@@ -932,50 +1016,13 @@ contract PanopticPool is Multicall {
     /// @param positionIdListLiquidator List of positions owned by the liquidator
     /// @param liquidatee Address of the distressed account
     /// @param positionIdList List of positions owned by the user. Written as `[tokenId1, tokenId2, ...]`
-    function liquidate(
+    function _liquidate(
         TokenId[] calldata positionIdListLiquidator,
         address liquidatee,
-        TokenId[] calldata positionIdList
-    ) external {
-        _validatePositionList(liquidatee, positionIdList);
-
-        // Assert the account we are liquidating is actually insolvent
-        int24 twapTick = getUniV3TWAP();
-
-        int24 currentTick;
-        {
-            // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
-            int24 fastOracleTick;
-            int24 lastObservedTick;
-            (currentTick, fastOracleTick, , lastObservedTick, ) = PanopticMath.getOracleTicks(
-                s_univ3pool,
-                s_miniMedian
-            );
-
-            unchecked {
-                if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
-                    revert Errors.StaleOracle();
-            }
-
-            // Ensure the account is insolvent at twapTick (in place of slowOracleTick), currentTick, fastOracleTick, and lastObservedTick
-            int24[] memory atTicks = new int24[](4);
-            atTicks[0] = fastOracleTick;
-            atTicks[1] = twapTick;
-            atTicks[2] = lastObservedTick;
-            atTicks[3] = currentTick;
-
-            uint256 solvent = _checkSolvencyAtTicks(
-                liquidatee,
-                positionIdList,
-                currentTick,
-                atTicks,
-                NO_BUFFER,
-                COMPUTE_PREMIA_AS_COLLATERAL
-            );
-            uint256 numberOfTicks = atTicks.length;
-            if (solvent != 0) revert Errors.NotMarginCalled();
-        }
-
+        TokenId[] calldata positionIdList,
+        int24 twapTick,
+        int24 currentTick
+    ) internal {
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
         LeftRightUnsigned shortPremium;
@@ -1068,50 +1115,18 @@ contract PanopticPool is Multicall {
         s_collateralToken0.settleLiquidation(msg.sender, liquidatee, bonusAmounts.rightSlot());
         s_collateralToken1.settleLiquidation(msg.sender, liquidatee, bonusAmounts.leftSlot());
 
-        // ensure the liquidator is still solvent after the liquidation
-        _validateSolvency(
-            msg.sender,
-            positionIdListLiquidator,
-            NO_BUFFER,
-            COMPUTE_PREMIA_AS_COLLATERAL
-        );
-
         emit AccountLiquidated(msg.sender, liquidatee, bonusAmounts);
     }
 
     /// @notice Force the exercise of a single position. Exercisor will have to pay a fee to the force exercisee.
     /// @param account Address of the distressed account
     /// @param tokenId The position to be force exercised; this position must contain at least one out-of-range long leg
-    /// @param positionIdListExercisee Post-burn list of open positions in the exercisee's (`account`) account
-    /// @param positionIdListExercisor List of open positions in the exercisor's (`msg.sender`) account
-    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the exercisee(right slot)/exercisor(left slot) for collateral (>0), or just owed premia for long legs (0)
-    function forceExercise(
+    function _forceExercise(
         address account,
         TokenId tokenId,
-        TokenId[] calldata positionIdListExercisee,
-        TokenId[] calldata positionIdListExercisor,
-        LeftRightUnsigned usePremiaAsCollateral
-    ) external {
-        // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
-        _validatePositionList(msg.sender, positionIdListExercisor);
-
-        int24 currentTick;
-        int24 lastObservedTick;
-        {
-            int24 fastOracleTick;
-            int24 slowOracleTick;
-            (fastOracleTick, slowOracleTick, lastObservedTick, currentTick, ) = PanopticMath
-                .getOracleTicks(s_univ3pool, s_miniMedian);
-
-            if (
-                Math.abs(lastObservedTick - fastOracleTick) > MAX_TICK_DELTA_SUBSTITUTION ||
-                Math.abs(lastObservedTick - slowOracleTick) > MAX_TICK_DELTA_SUBSTITUTION
-            ) revert Errors.StaleOracle();
-
-            // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-            tokenId.validateIsExercisable(lastObservedTick);
-        }
-
+        int24 twapTick,
+        int24 currentTick
+    ) internal {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
@@ -1130,7 +1145,7 @@ contract PanopticPool is Multicall {
             // Include any deltas in long legs between the current and oracle tick in the exercise fee
             exerciseFees = ct0.exerciseCost(
                 currentTick,
-                lastObservedTick,
+                twapTick,
                 _tokenId,
                 positionSize,
                 longAmounts
@@ -1158,7 +1173,7 @@ contract PanopticPool is Multicall {
         LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
             account,
             exerciseFees,
-            lastObservedTick,
+            twapTick,
             ct0,
             ct1
         );
@@ -1171,26 +1186,120 @@ contract PanopticPool is Multicall {
         ct0.revoke(account);
         ct1.revoke(account);
 
-        _validateSolvency(
-            account,
-            positionIdListExercisee,
-            NO_BUFFER,
-            usePremiaAsCollateral.rightSlot() > 0
-        );
-
-        // the exercisor's position list is validated above
-        // we need to assert their solvency against their collateral requirement plus a buffer
-        // force exercises involve a collateral decrease with open positions, so there is a higher standard for solvency
-        // a similar buffer is also invoked when minting options, which also decreases the available collateral
-        if (positionIdListExercisor.length > 0)
-            _validateSolvency(
-                msg.sender,
-                positionIdListExercisor,
-                BP_DECREASE_BUFFER,
-                usePremiaAsCollateral.leftSlot() > 0
-            );
-
         emit ForcedExercised(msg.sender, account, tokenId, exerciseFees);
+    }
+
+    /// @notice Settle unpaid premium for one `legIndex` on a position owned by `owner`.
+    /// @dev Called by sellers on buyers of their chunk to increase the available premium for withdrawal (before closing their position).
+    /// @dev This feature is only available when `owner` is solvent and has the requisite tokens to settle the premium.
+    /// @param owner The owner of the option position to make premium payments on
+    /// @param tokenId The position to be force exercised; this position must contain at least one out-of-range long leg
+    function _settleLongPremium(
+        address owner,
+        TokenId tokenId,
+        int24 twapTick,
+        int24 currentTick
+    ) internal {
+        CollateralTracker ct0 = s_collateralToken0;
+        CollateralTracker ct1 = s_collateralToken1;
+
+        // The protocol delegates some virtual shares to ensure the premia can be settled.
+        ct0.delegate(owner);
+        ct1.delegate(owner);
+
+        LeftRightSigned refundAmounts;
+
+        uint256 numLegs = tokenId.countLegs();
+        for (uint256 leg = 0; leg < numLegs; ) {
+            if (tokenId.isLong(leg) != 0) {
+                LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                    tokenId,
+                    leg,
+                    s_positionBalance[owner][tokenId].positionSize()
+                );
+
+                LeftRightUnsigned accumulatedPremium;
+                {
+                    {
+                        uint256 tokenType = tokenId.tokenType(leg);
+                        int24 _currentTick = currentTick;
+                        (uint128 premiumAccumulator0, uint128 premiumAccumulator1) = SFPM
+                            .getAccountPremium(
+                                address(s_univ3pool),
+                                address(this),
+                                tokenType,
+                                liquidityChunk.tickLower(),
+                                liquidityChunk.tickUpper(),
+                                _currentTick,
+                                1
+                            );
+                        accumulatedPremium = LeftRightUnsigned.wrap(premiumAccumulator0).toLeftSlot(
+                            premiumAccumulator1
+                        );
+                    }
+                    {
+                        // update the premium accumulator for the long position to the latest value
+                        // (the entire premia delta will be settled)
+                        LeftRightUnsigned premiumAccumulatorsLast = s_options[owner][tokenId][leg];
+                        s_options[owner][tokenId][leg] = accumulatedPremium;
+
+                        accumulatedPremium = accumulatedPremium.sub(premiumAccumulatorsLast);
+                    }
+                }
+
+                unchecked {
+                    LeftRightSigned realizedPremia;
+
+                    {
+                        uint256 liquidity = liquidityChunk.liquidity();
+
+                        // update the realized premia
+                        realizedPremia = LeftRightSigned
+                            .wrap(0)
+                            .toRightSlot(
+                                int128(
+                                    int256((accumulatedPremium.rightSlot() * liquidity) / 2 ** 64)
+                                )
+                            )
+                            .toLeftSlot(
+                                int128(
+                                    int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64)
+                                )
+                            );
+                    }
+                    // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
+                    ct0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
+                    ct1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
+
+                    bytes32 chunkKey = keccak256(
+                        abi.encodePacked(
+                            tokenId.strike(leg),
+                            tokenId.width(leg),
+                            tokenId.tokenType(leg)
+                        )
+                    );
+                    // commit the delta in settled tokens (all of the premium paid by long chunks in the tokenIds list) to storage
+                    s_settledTokens[chunkKey] = s_settledTokens[chunkKey].add(
+                        LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(realizedPremia)))
+                    );
+
+                    emit PremiumSettled(owner, tokenId, leg, realizedPremia);
+                }
+
+                refundAmounts = PanopticMath
+                    .getRefundAmounts(owner, LeftRightSigned.wrap(0), twapTick, ct0, ct1)
+                    .add(refundAmounts);
+            }
+            unchecked {
+                ++leg;
+            }
+        }
+        // allow the caller to settle tokens owed to the protocol by the settlee in exchange for the surplus token
+        ct0.refund(owner, msg.sender, refundAmounts.rightSlot());
+        ct1.refund(owner, msg.sender, refundAmounts.leftSlot());
+
+        ct0.revoke(owner);
+        ct1.revoke(owner);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1555,135 +1664,6 @@ contract PanopticPool is Multicall {
     /*//////////////////////////////////////////////////////////////
                         AVAILABLE PREMIUM LOGIC
     //////////////////////////////////////////////////////////////*/
-
-    /// @notice Settle unpaid premium for one `legIndex` on a position owned by `owner`.
-    /// @dev Called by sellers on buyers of their chunk to increase the available premium for withdrawal (before closing their position).
-    /// @dev This feature is only available when `owner` is solvent and has the requisite tokens to settle the premium.
-    /// @param positionIdList Exhaustive list of open positions for `owner` used for solvency checks where the tokenId to settle is placed at the last index
-    /// @param owner The owner of the option position to make premium payments on
-    /// @param legIndex the index of the leg in tokenId that is to be collected on (must be isLong=1)
-    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the settlee for collateral (true), or just owed premia for long legs (false)
-    function settleLongPremium(
-        TokenId[] calldata positionIdList,
-        address owner,
-        uint256 legIndex,
-        bool usePremiaAsCollateral
-    ) external {
-        _validatePositionList(owner, positionIdList);
-
-        TokenId tokenId;
-        unchecked {
-            tokenId = positionIdList[positionIdList.length - 1];
-        }
-
-        if (tokenId.isLong(legIndex) == 0 || legIndex > 3) revert Errors.NotALongLeg();
-
-        CollateralTracker ct0 = s_collateralToken0;
-        CollateralTracker ct1 = s_collateralToken1;
-
-        // The protocol delegates some virtual shares to ensure the premia can be settled.
-        ct0.delegate(owner);
-        ct1.delegate(owner);
-
-        LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-            tokenId,
-            legIndex,
-            s_positionBalance[owner][tokenId].positionSize()
-        );
-
-        (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-
-        LeftRightUnsigned accumulatedPremium;
-        {
-            (uint128 premiumAccumulator0, uint128 premiumAccumulator1) = SFPM.getAccountPremium(
-                address(s_univ3pool),
-                address(this),
-                tokenId.tokenType(legIndex),
-                liquidityChunk.tickLower(),
-                liquidityChunk.tickUpper(),
-                currentTick,
-                1
-            );
-            accumulatedPremium = LeftRightUnsigned.wrap(premiumAccumulator0).toLeftSlot(
-                premiumAccumulator1
-            );
-
-            // update the premium accumulator for the long position to the latest value
-            // (the entire premia delta will be settled)
-            LeftRightUnsigned premiumAccumulatorsLast = s_options[owner][tokenId][legIndex];
-            s_options[owner][tokenId][legIndex] = accumulatedPremium;
-
-            accumulatedPremium = accumulatedPremium.sub(premiumAccumulatorsLast);
-        }
-
-        unchecked {
-            uint256 liquidity = liquidityChunk.liquidity();
-
-            // update the realized premia
-            LeftRightSigned realizedPremia = LeftRightSigned
-                .wrap(0)
-                .toRightSlot(int128(int256((accumulatedPremium.rightSlot() * liquidity) / 2 ** 64)))
-                .toLeftSlot(int128(int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64)));
-
-            // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-            ct0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
-            ct1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
-
-            bytes32 chunkKey = keccak256(
-                abi.encodePacked(
-                    tokenId.strike(legIndex),
-                    tokenId.width(legIndex),
-                    tokenId.tokenType(legIndex)
-                )
-            );
-            // commit the delta in settled tokens (all of the premium paid by long chunks in the tokenIds list) to storage
-            s_settledTokens[chunkKey] = s_settledTokens[chunkKey].add(
-                LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(realizedPremia)))
-            );
-
-            emit PremiumSettled(owner, tokenId, legIndex, realizedPremia);
-        }
-
-        int24 lastObservedTick;
-        uint96 tickData;
-        {
-            int24 fastOracleTick;
-            int24 slowOracleTick;
-            (fastOracleTick, slowOracleTick, lastObservedTick, , ) = PanopticMath.getOracleTicks(
-                s_univ3pool,
-                s_miniMedian
-            );
-
-            if (
-                Math.abs(lastObservedTick - fastOracleTick) > MAX_TICK_DELTA_SUBSTITUTION ||
-                Math.abs(lastObservedTick - slowOracleTick) > MAX_TICK_DELTA_SUBSTITUTION
-            ) revert Errors.StaleOracle();
-            tickData = PositionBalanceLibrary.packTickData(
-                currentTick,
-                fastOracleTick,
-                slowOracleTick,
-                lastObservedTick
-            );
-        }
-
-        LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
-            owner,
-            LeftRightSigned.wrap(0),
-            lastObservedTick,
-            ct0,
-            ct1
-        );
-
-        // allow the caller to settle tokens owed to the protocol by the settlee in exchange for the surplus token
-        ct0.refund(owner, msg.sender, refundAmounts.rightSlot());
-        ct1.refund(owner, msg.sender, refundAmounts.leftSlot());
-
-        ct0.revoke(owner);
-        ct1.revoke(owner);
-
-        // ensure the owner is solvent (insolvent accounts are not permitted to pay premium unless they are being liquidated)
-        _checkSolvency(owner, positionIdList, tickData, NO_BUFFER, usePremiaAsCollateral);
-    }
 
     /// @notice Adds collected tokens to `s_settledTokens` and adjusts `s_grossPremiumLast` for any liquidity added.
     /// @dev Always called after `mintTokenizedPosition`.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -867,20 +867,65 @@ contract PanopticPool is Multicall {
             atTicks[0] = fastOracleTick;
         }
 
-        _checkSolvencyAtTicks(
+        uint256 solvent = _checkSolvencyAtTicks(
             user,
             positionIdList,
             currentTick,
             atTicks,
             buffer,
-            ASSERT_SOLVENCY,
             usePremiaAsCollateral
         );
+        uint256 numberOfTicks = atTicks.length;
+
+        if (solvent != numberOfTicks) revert Errors.AccountInsolvent();
     }
 
     /*//////////////////////////////////////////////////////////////
                     LIQUIDATIONS & FORCED EXERCISES
     //////////////////////////////////////////////////////////////*/
+
+    function dispatchFrom(
+        TokenId[] calldata positionIdListFrom,
+        address account,
+        TokenId[] calldata positionIdListTo,
+        TokenId[] calldata positionIdListFinal
+    ) external {
+        // Assert the account we are liquidating is actually insolvent
+        int24 twapTick = getUniV3TWAP();
+
+        int24 currentTick;
+        {
+            // Enforce maximum delta between TWAP and currentTick to prevent extreme price manipulation
+            int24 fastOracleTick;
+            int24 lastObservedTick;
+            (currentTick, fastOracleTick, , lastObservedTick, ) = PanopticMath.getOracleTicks(
+                s_univ3pool,
+                s_miniMedian
+            );
+
+            unchecked {
+                if (Math.abs(currentTick - twapTick) > MAX_TWAP_DELTA_LIQUIDATION)
+                    revert Errors.StaleOracle();
+            }
+
+            // Ensure the account is insolvent at twapTick (in place of slowOracleTick), currentTick, fastOracleTick, and lastObservedTick
+            int24[] memory atTicks = new int24[](4);
+            atTicks[0] = fastOracleTick;
+            atTicks[1] = twapTick;
+            atTicks[2] = lastObservedTick;
+            atTicks[3] = currentTick;
+            _validatePositionList(account, positionIdListTo, 0);
+
+            uint256 solvent = _checkSolvencyAtTicks(
+                account,
+                positionIdListTo,
+                currentTick,
+                atTicks,
+                NO_BUFFER,
+                COMPUTE_PREMIA_AS_COLLATERAL
+            );
+        }
+    }
 
     /// @notice Liquidates a distressed account. Will burn all positions and issue a bonus to the liquidator.
     /// @dev Will revert if liquidated account is solvent at one of the oracle ticks or if TWAP tick is too far away from the current tick.
@@ -919,15 +964,16 @@ contract PanopticPool is Multicall {
             atTicks[2] = lastObservedTick;
             atTicks[3] = currentTick;
 
-            _checkSolvencyAtTicks(
+            uint256 solvent = _checkSolvencyAtTicks(
                 liquidatee,
                 positionIdList,
                 currentTick,
                 atTicks,
                 NO_BUFFER,
-                ASSERT_INSOLVENCY,
                 COMPUTE_PREMIA_AS_COLLATERAL
             );
+            uint256 numberOfTicks = atTicks.length;
+            if (solvent != 0) revert Errors.NotMarginCalled();
         }
 
         LeftRightUnsigned tokenData0;
@@ -1158,17 +1204,16 @@ contract PanopticPool is Multicall {
     /// @param currentTick The current tick of the Uniswap pool (needed for fee calculations)
     /// @param atTicks An array of ticks to check solvency at
     /// @param buffer The buffer to apply to the collateral requirement
-    /// @param expectedSolvent Whether the account is expected to be solvent (true) or insolvent (false) at all provided `atTicks`
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
+    /// @return boolean flag that determines if account is solvent
     function _checkSolvencyAtTicks(
         address account,
         TokenId[] calldata positionIdList,
         int24 currentTick,
         int24[] memory atTicks,
         uint256 buffer,
-        bool expectedSolvent,
         bool usePremiaAsCollateral
-    ) internal view {
+    ) internal view returns (uint256) {
         (
             LeftRightUnsigned shortPremium,
             LeftRightUnsigned longPremium,
@@ -1201,8 +1246,9 @@ contract PanopticPool is Multicall {
             }
         }
 
-        if (expectedSolvent && solvent != numberOfTicks) revert Errors.AccountInsolvent();
-        if (!expectedSolvent && solvent != 0) revert Errors.NotMarginCalled();
+        return solvent;
+        //if (expectedSolvent && solvent != numberOfTicks) revert Errors.AccountInsolvent();
+        //if (!expectedSolvent && solvent != 0) revert Errors.NotMarginCalled();
     }
 
     /// @notice Check whether an account is solvent at a given `atTick` with a collateral requirement of `buffer/10_000` multiplied by the requirement of `positionBalanceArray`.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -631,7 +631,8 @@ contract PanopticPool is Multicall {
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
-    /// @return The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
+    /// @return The total amount of commissions (base rate) paid for token0 (right) and token1 (left)
+    /// @return The amount of tokens paid when creating that option for token0 (right) and token1 (left)
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
@@ -872,6 +873,22 @@ contract PanopticPool is Multicall {
                     LIQUIDATIONS & FORCED EXERCISES
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Dispatches liquidations, forced exercises, or long premium settlements based on account solvency
+    /// @dev This function determines the appropriate action based on solvency checks at multiple price points:
+    ///      - If insolvent at all ticks: Execute liquidation (burns all positions)
+    ///      - If solvent at all ticks: Execute force exercise or settle long premium based on list lengths
+    ///      - Otherwise: Revert as account is not fully margin called
+    /// @dev The function uses position list lengths to determine the specific operation:
+    ///      - Same length lists between positionIdListTo and positionIdListToFinal: Settle long premium
+    ///      - Final list one shorter: Force exercise
+    ///      - Final list empty: Liquidation
+    /// @param positionIdListFrom List of positions held by the caller (msg.sender)
+    /// @param account The account being acted upon (liquidated, exercised, or settled)
+    /// @param positionIdListTo Current positions of the target account
+    /// @param positionIdListToFinal Expected positions after the operation completes
+    /// @param usePremiaAsCollateral Packed value indicating whether to use premia as collateral:
+    ///        - leftSlot: For the caller (msg.sender)
+    ///        - rightSlot: For the target account
     function dispatchFrom(
         TokenId[] calldata positionIdListFrom,
         address account,
@@ -882,7 +899,6 @@ contract PanopticPool is Multicall {
         // Assert the account we are liquidating is actually insolvent
         int24 twapTick = getUniV3TWAP();
         int24 currentTick;
-        uint256 path;
 
         TokenId tokenId;
 
@@ -921,6 +937,7 @@ contract PanopticPool is Multicall {
             );
             numberOfTicks = atTicks.length;
         }
+        LeftRightSigned exchangedAmounts;
         {
             // if account is solvent at all ticks, this is a force exercise or a settleLongPremium.
             if (solvent == numberOfTicks) {
@@ -937,18 +954,31 @@ contract PanopticPool is Multicall {
                                 revert Errors.InputListFail();
                             }
                         }
-                        path = 0;
+                        exchangedAmounts = _settleLongPremium(
+                            account,
+                            tokenId,
+                            twapTick,
+                            currentTick
+                        );
                     } else if (toLength == (finalLength + 1)) {
                         // final is one element shorter, that's a force exercise
                         tokenId.validateIsExercisable(twapTick);
-                        path = 1;
+                        exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
                     } else if (finalLength == 0) {
-                        // if final length was zero, this was intended to be liquidaton, but revert because not marging called
+                        // if final length was zero, this was intended to be liquidation, but revert because not margin called and solvent at some of the tested ticks
                         revert Errors.NotMarginCalled();
                     } else {
                         // otherwise, wrong input lists
                         revert Errors.InputListFail();
                     }
+                    // ensure the callee is still solvent after the operation
+                    bool premiaAsCollateral = usePremiaAsCollateral.rightSlot() > 0;
+                    _validateSolvency(
+                        account,
+                        positionIdListToFinal,
+                        NO_BUFFER,
+                        premiaAsCollateral
+                    );
                 }
             } else if (solvent == 0) {
                 // if account is insolvent at all ticks, this is a liquidation
@@ -959,40 +989,13 @@ contract PanopticPool is Multicall {
 
                 // if the final position list has a non-zero length, this can't be a complete liquidation, revert
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
-                path = 2;
+                exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
             } else {
                 // otherwise, revert because the account is not fully margin called
                 revert Errors.NotMarginCalled();
             }
         }
 
-        {
-            LeftRightSigned exchangedAmounts;
-            if (path == 2) {
-                exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
-                // no need to check that the liquidatee is solvent as all positions are burnt
-            } else {
-                // if path = 0, settleLongPremium
-                if (path == 0) {
-                    exchangedAmounts = _settleLongPremium(account, tokenId, twapTick, currentTick);
-                }
-
-                // if path = 1, force exercise
-
-                if (path == 1) {
-                    // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-                    exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
-                }
-
-                // ensure the callee is still solvent after the operation
-                _validateSolvency(
-                    account,
-                    positionIdListToFinal,
-                    NO_BUFFER,
-                    usePremiaAsCollateral.rightSlot() > 0
-                );
-            }
-        }
         // ensure the caller is still solvent after the operation
         _validateSolvency(
             msg.sender,
@@ -1329,8 +1332,6 @@ contract PanopticPool is Multicall {
         }
 
         return solvent;
-        //if (expectedSolvent && solvent != numberOfTicks) revert Errors.AccountInsolvent();
-        //if (!expectedSolvent && solvent != 0) revert Errors.NotMarginCalled();
     }
 
     /// @notice Check whether an account is solvent at a given `atTick` with a collateral requirement of `buffer/10_000` multiplied by the requirement of `positionBalanceArray`.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -646,15 +646,13 @@ contract PanopticPool is Multicall {
             owner,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
-            totalSwapped.rightSlot(),
-            isCovered
+            totalSwapped.rightSlot()
         );
         (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
             owner,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
-            totalSwapped.leftSlot(),
-            isCovered
+            totalSwapped.leftSlot()
         );
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -500,25 +500,18 @@ contract PanopticPool is Multicall {
     /// @param positionSizes The list of positionSize for the position to be minted (0 for burns)
     /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param tickLimits The lower and lower bounds of an acceptable open interval for the ending price
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function dispatch(
         TokenId[] calldata positionIdList,
         TokenId[] calldata finalPositionIdList,
         uint128[] calldata positionSizes,
         uint64[] calldata effectiveLiquidityLimitsX32,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
+        int24[2][] calldata tickLimits,
         bool usePremiaAsCollateral
     ) external {
         // if safeMode, enforce covered at mint and exercise at burn
-        if (isSafeMode()) {
-            if (tickLimitLow > tickLimitHigh) {
-                (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
-            }
-        }
-
+        bool safeMode = isSafeMode();
         for (uint256 i = 0; i < positionIdList.length; ) {
             TokenId tokenId = positionIdList[i];
 
@@ -527,6 +520,14 @@ contract PanopticPool is Multicall {
                 revert Errors.InvalidTokenIdParameter(0);
 
             PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId];
+
+            int24 tickLimitLow = tickLimits[i][0];
+            int24 tickLimitHigh = tickLimits[i][1];
+            if (safeMode) {
+                if (tickLimitLow > tickLimitHigh) {
+                    (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
+                }
+            }
 
             if (PositionBalance.unwrap(positionBalanceData) == 0) {
                 _mintOptions(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -540,12 +540,12 @@ contract PanopticPool is Multicall {
                 );
             } else {
                 _burnOptions(
-                    COMMIT_LONG_SETTLED,
                     tokenId,
                     positionBalanceData.positionSize(),
-                    msg.sender,
                     tickLimitLow,
-                    tickLimitHigh
+                    tickLimitHigh,
+                    msg.sender,
+                    COMMIT_LONG_SETTLED
                 );
             }
             unchecked {
@@ -691,12 +691,12 @@ contract PanopticPool is Multicall {
             uint128 positionSize = s_positionBalance[owner][positionIdList[i]].positionSize();
             LeftRightSigned paidAmounts;
             (paidAmounts, premiasByLeg[i]) = _burnOptions(
-                commitLongSettled,
                 positionIdList[i],
                 positionSize,
-                owner,
                 tickLimitLow,
-                tickLimitHigh
+                tickLimitHigh,
+                owner,
+                commitLongSettled
             );
             netPaid = netPaid.add(paidAmounts);
             unchecked {
@@ -708,19 +708,19 @@ contract PanopticPool is Multicall {
     /// @notice Close a single option position.
     /// @param tokenId The option position to burn
     /// @param positionSize The size of the position to burn
-    /// @param owner The owner of the option position to be burned
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
+    /// @param owner The owner of the option position to be burned
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @return paidAmounts The net amount of tokens paid after closing the position
     /// @return premiaByLeg The amount of premia settled by the user for each leg of the position
     function _burnOptions(
-        bool commitLongSettled,
         TokenId tokenId,
         uint128 positionSize,
-        address owner,
         int24 tickLimitLow,
-        int24 tickLimitHigh
+        int24 tickLimitHigh,
+        address owner,
+        bool commitLongSettled
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .burnTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
@@ -1127,12 +1127,12 @@ contract PanopticPool is Multicall {
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
             _burnOptions(
-                COMMIT_LONG_SETTLED,
                 tokenId,
                 positionSize,
-                account,
                 MIN_SWAP_TICK,
-                MAX_SWAP_TICK
+                MAX_SWAP_TICK,
+                account,
+                COMMIT_LONG_SETTLED
             );
         }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -586,56 +586,6 @@ contract PanopticPool is Multicall {
         int24 tickLimitHigh
     ) internal {
         // Mint in the SFPM and update state of collateral
-        (uint32 poolUtilizations, LeftRightUnsigned commissions) = _mintInSFPMAndUpdateCollateral(
-            tokenId,
-            positionSize,
-            effectiveLiquidityLimitX32,
-            owner,
-            tickLimitLow,
-            tickLimitHigh
-        );
-
-        uint96 tickData;
-        PositionBalance balanceData = PositionBalanceLibrary.storeBalanceData(
-            positionSize,
-            poolUtilizations,
-            tickData
-        );
-
-        // update the users options balance of position `tokenId`
-        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
-        s_positionBalance[owner][tokenId] = balanceData;
-
-        emit OptionMinted(owner, tokenId, balanceData, commissions);
-    }
-
-    /// @notice Move all the required liquidity to/from the AMM and settle any required collateral deltas.
-    /// @param tokenId The option position to be minted
-    /// @param positionSize The size of the position, expressed in terms of the asset
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity`
-    /// @param owner The owner of the option position to be minted
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
-    /// @return poolUtilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool) at the time of minting,
-    /// right 64bits for token0 and left 64bits for token1. When safeMode is active, it returns 100% pool utilization for both tokens
-    /// @return commissions The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
-    function _mintInSFPMAndUpdateCollateral(
-        TokenId tokenId,
-        uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
-        address owner,
-        int24 tickLimitLow,
-        int24 tickLimitHigh
-    ) internal returns (uint32 poolUtilizations, LeftRightUnsigned commissions) {
-        bool safeMode = isSafeMode();
-
-        // if safeMode, enforce covered deployment
-        if (safeMode) {
-            if (tickLimitLow > tickLimitHigh) {
-                (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
-            }
-        }
-
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
@@ -647,7 +597,7 @@ contract PanopticPool is Multicall {
             owner
         );
 
-        (poolUtilizations, commissions) = _payCommissionAndWriteData(
+        (uint32 poolUtilizations, LeftRightUnsigned commissions) = _payCommissionAndWriteData(
             tokenId,
             positionSize,
             owner,
@@ -655,7 +605,18 @@ contract PanopticPool is Multicall {
             tickLimitLow < tickLimitHigh
         );
 
-        if (safeMode) poolUtilizations = uint32(10_000 + (10_000 << 16));
+        if (isSafeMode()) poolUtilizations = uint32(10_000 + (10_000 << 16));
+
+        uint96 tickData;
+        // update the users options balance of position `tokenId`
+        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
+        s_positionBalance[owner][tokenId] = PositionBalanceLibrary.storeBalanceData(
+            positionSize,
+            poolUtilizations,
+            tickData
+        );
+
+        emit OptionMinted(owner, tokenId, balanceData, commissions);
     }
 
     /// @notice Take the commission fees for minting `tokenId` and settle any other required collateral deltas.
@@ -794,8 +755,6 @@ contract PanopticPool is Multicall {
             );
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }
-
-        emit OptionBurnt(owner, positionSize, tokenId, premiaByLeg);
 
         emit OptionBurnt(owner, positionSize, tokenId, premiaByLeg);
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -518,6 +518,9 @@ contract PanopticPool is Multicall {
             }
         }
 
+        LeftRightSigned netPaid;
+        LeftRightSigned[4][] memory premiasByLeg;
+
         for (uint256 i = 0; i < positionIdList.length; ) {
             TokenId tokenId = positionIdList[i];
 
@@ -527,8 +530,9 @@ contract PanopticPool is Multicall {
 
             PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId];
 
+            LeftRightSigned paidAmounts;
             if (PositionBalance.unwrap(positionBalanceData) == 0) {
-                _mintOptions(
+                paidAmounts = _mintOptions(
                     tokenId,
                     positionSizes[i],
                     effectiveLiquidityLimitsX32[i],
@@ -536,8 +540,9 @@ contract PanopticPool is Multicall {
                     tickLimitLow,
                     tickLimitHigh
                 );
+                netPaid = netPaid.add(paidAmounts);
             } else {
-                _burnOptions(
+                (paidAmounts, premiasByLeg[i]) = _burnOptions(
                     COMMIT_LONG_SETTLED,
                     tokenId,
                     positionBalanceData.positionSize(),
@@ -545,6 +550,7 @@ contract PanopticPool is Multicall {
                     tickLimitLow,
                     tickLimitHigh
                 );
+                netPaid = netPaid.add(paidAmounts);
             }
             unchecked {
                 ++i;
@@ -583,7 +589,7 @@ contract PanopticPool is Multicall {
         address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
-    ) internal {
+    ) internal returns (LeftRightSigned paidAmounts) {
         // Mint in the SFPM and update state of collateral
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
@@ -596,12 +602,14 @@ contract PanopticPool is Multicall {
             owner
         );
 
-        (uint32 poolUtilizations, LeftRightUnsigned commissions) = _payCommissionAndWriteData(
+        uint32 poolUtilizations;
+        LeftRightUnsigned commissions;
+
+        (poolUtilizations, commissions, paidAmounts) = _payCommissionAndWriteData(
             tokenId,
             positionSize,
             owner,
-            totalSwapped,
-            tickLimitLow < tickLimitHigh
+            totalSwapped
         );
 
         if (isSafeMode()) poolUtilizations = uint32(10_000 + (10_000 << 16));
@@ -625,7 +633,6 @@ contract PanopticPool is Multicall {
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param owner The owner of the option position to be minted
     /// @param totalSwapped The amount of tokens moved during creation of the option position
-    /// @param isCovered Whether the option was minted as covered (no swap occurred if ITM)
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
@@ -634,37 +641,47 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         uint128 positionSize,
         address owner,
-        LeftRightSigned totalSwapped,
-        bool isCovered
-    ) internal returns (uint32, LeftRightUnsigned) {
+        LeftRightSigned totalSwapped
+    ) internal returns (uint32, LeftRightUnsigned, LeftRightSigned) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (LeftRightUnsigned utilizationAndCommission0, ) = s_collateralToken0.settleMint(
-            owner,
-            longAmounts.rightSlot(),
-            shortAmounts.rightSlot(),
-            totalSwapped.rightSlot()
-        );
-        (LeftRightUnsigned utilizationAndCommission1, ) = s_collateralToken1.settleMint(
-            owner,
-            longAmounts.leftSlot(),
-            shortAmounts.leftSlot(),
-            totalSwapped.leftSlot()
-        );
+        uint32 commissions;
+        LeftRightUnsigned utilizations;
+        LeftRightSigned paidAmounts;
+
+        // stack too deep
+        LeftRightSigned _totalSwapped = totalSwapped;
+
+        {
+            (LeftRightUnsigned utilizationAndCommission0, int128 paid0) = s_collateralToken0
+                .settleMint(
+                    owner,
+                    longAmounts.rightSlot(),
+                    shortAmounts.rightSlot(),
+                    _totalSwapped.rightSlot()
+                );
+            commissions = uint32(utilizationAndCommission0.rightSlot());
+            utilizations = utilizations.toRightSlot(utilizationAndCommission0.leftSlot());
+            paidAmounts = paidAmounts.toRightSlot(paid0);
+        }
+        {
+            (LeftRightUnsigned utilizationAndCommission1, int128 paid1) = s_collateralToken1
+                .settleMint(
+                    owner,
+                    longAmounts.leftSlot(),
+                    shortAmounts.leftSlot(),
+                    _totalSwapped.leftSlot()
+                );
+            commissions = uint32(utilizationAndCommission1.rightSlot() << 16);
+            utilizations = utilizations.toLeftSlot(utilizationAndCommission1.leftSlot());
+            paidAmounts = paidAmounts.toLeftSlot(paid1);
+        }
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
-            return (
-                uint32(
-                    utilizationAndCommission0.rightSlot() +
-                        (utilizationAndCommission1.rightSlot() << 16)
-                ),
-                LeftRightUnsigned.wrap(utilizationAndCommission0.leftSlot()).toLeftSlot(
-                    utilizationAndCommission1.leftSlot()
-                )
-            );
+            return (commissions, utilizations, paidAmounts);
         }
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 // Interfaces
+
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
 import {IUniswapV3Pool} from "univ3-core/interfaces/IUniswapV3Pool.sol";
@@ -866,6 +867,7 @@ contract PanopticPool is Multicall {
     ) external {
         // Assert the account we are liquidating is actually insolvent
         int24 twapTick = getUniV3TWAP();
+
         int24 currentTick;
 
         uint256 path;
@@ -935,6 +937,8 @@ contract PanopticPool is Multicall {
                 }
             } else if (solvent == 0) {
                 // if account is insolvent at all ticks, this is a liquidation
+                if (positionIdListToFinal.length == positionIdListTo.length)
+                    revert Errors.AccountInsolvent();
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
                 path = 2;
             } else {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
-
 // Interfaces
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
@@ -913,6 +912,7 @@ contract PanopticPool is Multicall {
                 uint256 toLength = positionIdListTo.length;
                 uint256 finalLength = positionIdListToFinal.length;
                 unchecked {
+                    tokenId = positionIdListTo[toLength - 1];
                     if (toLength == finalLength) {
                         // same length, that's a settle
                         {
@@ -925,17 +925,16 @@ contract PanopticPool is Multicall {
                         path = 0;
                     } else if (toLength == (finalLength + 1)) {
                         // final is one shorter, that's a force exercise
-                        path == 1;
+                        tokenId.validateIsExercisable(twapTick);
+                        path = 1;
+                    } else if (finalLength == 0) {
+                        revert Errors.NotMarginCalled();
                     } else {
                         revert Errors.InputListFail();
                     }
-
-                    tokenId = positionIdListTo[toLength - 1];
                 }
-            }
-
-            // if account is insolvent at all ticks, this is a liquidation
-            if (solvent == 0) {
+            } else if (solvent == 0) {
+                // if account is insolvent at all ticks, this is a liquidation
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
                 path = 2;
             } else {
@@ -956,7 +955,6 @@ contract PanopticPool is Multicall {
 
             if (path == 1) {
                 // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-                tokenId.validateIsExercisable(twapTick);
                 _forceExercise(account, tokenId, twapTick, currentTick);
             }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -642,13 +642,13 @@ contract PanopticPool is Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (uint32 utilization0, uint128 commission0) = s_collateralToken0.takeCommissionAddData(
+        (uint32 utilization0, uint128 commission0) = s_collateralToken0.settleMint(
             owner,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
             totalSwapped.rightSlot()
         );
-        (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
+        (uint32 utilization1, uint128 commission1) = s_collateralToken1.settleMint(
             owner,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
@@ -735,7 +735,7 @@ contract PanopticPool is Multicall {
             .computeExercisedAmounts(tokenId, positionSize);
 
         {
-            int128 paid0 = s_collateralToken0.exercise(
+            int128 paid0 = s_collateralToken0.settleBurn(
                 owner,
                 longAmounts.rightSlot(),
                 shortAmounts.rightSlot(),
@@ -746,7 +746,7 @@ contract PanopticPool is Multicall {
         }
 
         {
-            int128 paid1 = s_collateralToken1.exercise(
+            int128 paid1 = s_collateralToken1.settleBurn(
                 owner,
                 longAmounts.leftSlot(),
                 shortAmounts.leftSlot(),
@@ -1227,8 +1227,8 @@ contract PanopticPool is Multicall {
                 }
                 {
                     // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-                    ct0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
-                    ct1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
+                    ct0.settleBurn(owner, 0, 0, 0, -realizedPremia.rightSlot());
+                    ct1.settleBurn(owner, 0, 0, 0, -realizedPremia.leftSlot());
 
                     bytes32 chunkKey;
                     {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -835,7 +835,7 @@ contract PanopticPool is Multicall {
         bool usePremiaAsCollateral
     ) internal view {
         // check that the provided positionIdList matches the positions in memory
-        _validatePositionList(user, positionIdList, 0);
+        _validatePositionList(user, positionIdList);
 
         (
             int24 currentTick,
@@ -914,7 +914,7 @@ contract PanopticPool is Multicall {
             atTicks[1] = twapTick;
             atTicks[2] = lastObservedTick;
             atTicks[3] = currentTick;
-            _validatePositionList(account, positionIdListTo, 0);
+            _validatePositionList(account, positionIdListTo);
 
             uint256 solvent = _checkSolvencyAtTicks(
                 account,
@@ -937,7 +937,7 @@ contract PanopticPool is Multicall {
         address liquidatee,
         TokenId[] calldata positionIdList
     ) external {
-        _validatePositionList(liquidatee, positionIdList, 0);
+        _validatePositionList(liquidatee, positionIdList);
 
         // Assert the account we are liquidating is actually insolvent
         int24 twapTick = getUniV3TWAP();
@@ -1093,7 +1093,7 @@ contract PanopticPool is Multicall {
         LeftRightUnsigned usePremiaAsCollateral
     ) external {
         // validate the exercisor's position list (the exercisee's list will be evaluated after their position is force exercised)
-        _validatePositionList(msg.sender, positionIdListExercisor, 0);
+        _validatePositionList(msg.sender, positionIdListExercisor);
 
         int24 currentTick;
         int24 lastObservedTick;
@@ -1320,17 +1320,11 @@ contract PanopticPool is Multicall {
     /// @notice Makes sure that the positions in the incoming user's list match the existing active option positions.
     /// @param account The owner of the incoming list of positions
     /// @param positionIdList The existing list of active options for the owner
-    /// @param offset The amount of positions from the end of the list to exclude from validation
     function _validatePositionList(
         address account,
-        TokenId[] calldata positionIdList,
-        uint256 offset
+        TokenId[] calldata positionIdList
     ) internal view {
-        uint256 pLength;
-
-        unchecked {
-            pLength = positionIdList.length - offset;
-        }
+        uint256 pLength = positionIdList.length;
 
         uint256 fingerprintIncomingList;
 
@@ -1575,7 +1569,7 @@ contract PanopticPool is Multicall {
         uint256 legIndex,
         bool usePremiaAsCollateral
     ) external {
-        _validatePositionList(owner, positionIdList, 0);
+        _validatePositionList(owner, positionIdList);
 
         TokenId tokenId;
         unchecked {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
+
 // Interfaces
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
@@ -499,7 +500,7 @@ contract PanopticPool is Multicall {
     /// @param positionSizes The list of positionSize for the position to be minted (0 for burns)
     /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
-    /// @param tickLimits The lower and lower bounds of an acceptable open interval for the ending price
+    /// @param tickLimits The lower and upper bounds of an acceptable open interval for the ending price
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function dispatch(
         TokenId[] calldata positionIdList,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -494,82 +494,66 @@ contract PanopticPool is Multicall {
                           MINT/BURN INTERFACE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Validates the current options of the user, and mints a new position.
-    /// @param positionIdList The list of currently held positions by the user, where the newly minted position(token) will be the last element in `positionIdList`
-    /// @param positionSize The size of the position to be minted, expressed in terms of the asset
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
+    /// @notice Mints or burns each `tokenId` in `positionIdList.
+    /// @param positionIdList The list of tokenIds for the option positions to be minted or burnt
+    /// @param finalPositionIdList The final positionIdList after all the tokens have been minted/burnt
+    /// @param positionSizes The list of positionSize for the position to be minted (0 for burns)
+    /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
-    function mintOptions(
-        TokenId[] calldata positionIdList,
-        uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool usePremiaAsCollateral
-    ) external {
-        _mintOptions(
-            positionIdList,
-            positionSize,
-            effectiveLiquidityLimitX32,
-            tickLimitLow,
-            tickLimitHigh,
-            usePremiaAsCollateral
-        );
-    }
-
-    /// @notice Closes and burns the caller's entire balance of `tokenId`.
-    /// @param tokenId The tokenId of the option position to be burnt
-    /// @param newPositionIdList The new positionIdList without the token being burnt
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
-    function burnOptions(
-        TokenId tokenId,
-        TokenId[] calldata newPositionIdList,
+    function dispatch(
+        TokenId[] calldata positionIdList,
+        TokenId[] calldata finalPositionIdList,
+        uint128[] calldata positionSizes,
+        uint64[] calldata effectiveLiquidityLimitsX32,
         int24 tickLimitLow,
         int24 tickLimitHigh,
         bool usePremiaAsCollateral
     ) external {
-        _burnOptions(COMMIT_LONG_SETTLED, tokenId, msg.sender, tickLimitLow, tickLimitHigh);
+        // if safeMode, enforce covered at mint and exercise at burn
+        if (isSafeMode()) {
+            if (tickLimitLow > tickLimitHigh) {
+                (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
+            }
+        }
 
+        for (uint256 i = 0; i < positionIdList.length; ) {
+            TokenId tokenId = positionIdList[i];
+
+            // make sure the tokenId is for this Panoptic pool
+            if (tokenId.poolId() != SFPM.getPoolId(address(s_univ3pool)))
+                revert Errors.InvalidTokenIdParameter(0);
+
+            PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId];
+
+            if (PositionBalance.unwrap(positionBalanceData) == 0) {
+                _mintOptions(
+                    tokenId,
+                    positionSizes[i],
+                    effectiveLiquidityLimitsX32[i],
+                    tickLimitLow,
+                    tickLimitHigh
+                );
+            } else {
+                _burnOptions(
+                    COMMIT_LONG_SETTLED,
+                    tokenId,
+                    positionBalanceData.positionSize(),
+                    msg.sender,
+                    tickLimitLow,
+                    tickLimitHigh
+                );
+            }
+        }
+
+        // Perform solvency check on user's account to ensure they had enough buying power to mint the option
+        // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         uint256 medianData = _validateSolvency(
             msg.sender,
-            newPositionIdList,
-            NO_BUFFER,
-            usePremiaAsCollateral
-        );
-
-        // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
-        if (medianData != 0) s_miniMedian = medianData;
-    }
-
-    /// @notice Closes and burns the caller's entire balance of each `tokenId` in `positionIdList.
-    /// @param positionIdList The list of tokenIds for the option positions to be burnt
-    /// @param newPositionIdList The new positionIdList without the token(s) being burnt
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
-    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
-    function burnOptions(
-        TokenId[] calldata positionIdList,
-        TokenId[] calldata newPositionIdList,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool usePremiaAsCollateral
-    ) external {
-        _burnAllOptionsFrom(
-            msg.sender,
-            tickLimitLow,
-            tickLimitHigh,
-            COMMIT_LONG_SETTLED,
-            positionIdList
-        );
-
-        uint256 medianData = _validateSolvency(
-            msg.sender,
-            newPositionIdList,
-            NO_BUFFER,
+            finalPositionIdList,
+            BP_DECREASE_BUFFER,
             usePremiaAsCollateral
         );
 
@@ -582,39 +566,19 @@ contract PanopticPool is Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Validates the current options of the user, and mints a new position.
-    /// @param positionIdList The list of currently held positions by the user, where the newly minted position(token) will be the last element in `positionIdList`
+    /// @param tokenId The tokenId of the newly minted position
     /// @param positionSize The size of the position to be minted, expressed in terms of the asset
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
-    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function _mintOptions(
-        TokenId[] calldata positionIdList,
+        TokenId tokenId,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
         int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool usePremiaAsCollateral
+        int24 tickLimitHigh
     ) internal {
-        // the new tokenId will be the last element in `positionIdList`
-        TokenId tokenId;
-        unchecked {
-            tokenId = positionIdList[positionIdList.length - 1];
-        }
-
-        // do duplicate checks and the checks related to minting and positions
-        _validatePositionList(msg.sender, positionIdList, 1);
-
-        // make sure the tokenId is for this Panoptic pool
-        if (tokenId.poolId() != SFPM.getPoolId(address(s_univ3pool)))
-            revert Errors.InvalidTokenIdParameter(0);
-
-        // disallow user to mint exact same position
-        // in order to do it, user should burn it first and then mint
-        if (PositionBalance.unwrap(s_positionBalance[msg.sender][tokenId]) != 0)
-            revert Errors.PositionAlreadyMinted();
-
         // Mint in the SFPM and update state of collateral
         (uint32 poolUtilizations, LeftRightUnsigned commissions) = _mintInSFPMAndUpdateCollateral(
             tokenId,
@@ -625,26 +589,6 @@ contract PanopticPool is Multicall {
         );
 
         uint96 tickData;
-        {
-            (
-                int24 currentTick,
-                int24 fastOracleTick,
-                int24 slowOracleTick,
-                int24 lastObservedTick,
-                uint256 medianData
-            ) = PanopticMath.getOracleTicks(s_univ3pool, s_miniMedian);
-
-            tickData = PositionBalanceLibrary.packTickData(
-                currentTick,
-                fastOracleTick,
-                slowOracleTick,
-                lastObservedTick
-            );
-
-            // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
-            if (medianData != 0) s_miniMedian = medianData;
-        }
-
         PositionBalance balanceData = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
@@ -654,16 +598,6 @@ contract PanopticPool is Multicall {
         // update the users options balance of position `tokenId`
         // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
         s_positionBalance[msg.sender][tokenId] = balanceData;
-
-        // Perform solvency check on user's account to ensure they had enough buying power to mint the option
-        // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
-        _checkSolvency(
-            msg.sender,
-            positionIdList,
-            tickData,
-            BP_DECREASE_BUFFER,
-            usePremiaAsCollateral
-        );
 
         emit OptionMinted(msg.sender, tokenId, balanceData, commissions);
     }
@@ -777,10 +711,12 @@ contract PanopticPool is Multicall {
     ) internal returns (LeftRightSigned netPaid, LeftRightSigned[4][] memory premiasByLeg) {
         premiasByLeg = new LeftRightSigned[4][](positionIdList.length);
         for (uint256 i = 0; i < positionIdList.length; ) {
+            uint128 positionSize = s_positionBalance[owner][positionIdList[i]].positionSize();
             LeftRightSigned paidAmounts;
             (paidAmounts, premiasByLeg[i]) = _burnOptions(
                 commitLongSettled,
                 positionIdList[i],
+                positionSize,
                 owner,
                 tickLimitLow,
                 tickLimitHigh
@@ -794,6 +730,7 @@ contract PanopticPool is Multicall {
 
     /// @notice Close a single option position.
     /// @param tokenId The option position to burn
+    /// @param positionSize The size of the position to burn
     /// @param owner The owner of the option position to be burned
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
@@ -803,21 +740,49 @@ contract PanopticPool is Multicall {
     function _burnOptions(
         bool commitLongSettled,
         TokenId tokenId,
+        uint128 positionSize,
         address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
-        uint128 positionSize = s_positionBalance[owner][tokenId].positionSize();
+        (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
+            .burnTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
-        // burn position and do exercise checks
-        (premiaByLeg, paidAmounts) = _burnAndHandleExercise(
-            commitLongSettled,
-            tickLimitLow,
-            tickLimitHigh,
+        LeftRightSigned realizedPremia;
+        (realizedPremia, premiaByLeg) = _updateSettlementPostBurn(
+            owner,
             tokenId,
+            collectedByLeg,
             positionSize,
-            owner
+            commitLongSettled
         );
+
+        (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
+            .computeExercisedAmounts(tokenId, positionSize);
+
+        {
+            int128 paid0 = s_collateralToken0.exercise(
+                owner,
+                longAmounts.rightSlot(),
+                shortAmounts.rightSlot(),
+                totalSwapped.rightSlot(),
+                realizedPremia.rightSlot()
+            );
+            paidAmounts = paidAmounts.toRightSlot(paid0);
+        }
+
+        {
+            int128 paid1 = s_collateralToken1.exercise(
+                owner,
+                longAmounts.leftSlot(),
+                shortAmounts.leftSlot(),
+                totalSwapped.leftSlot(),
+                realizedPremia.leftSlot()
+            );
+            paidAmounts = paidAmounts.toLeftSlot(paid1);
+        }
+
+        emit OptionBurnt(owner, positionSize, tokenId, premiaByLeg);
 
         emit OptionBurnt(owner, positionSize, tokenId, premiaByLeg);
     }
@@ -911,66 +876,6 @@ contract PanopticPool is Multicall {
             ASSERT_SOLVENCY,
             usePremiaAsCollateral
         );
-    }
-
-    /// @notice Burns and handles the exercise of options.
-    /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
-    /// @param tokenId The option position to burn
-    /// @param positionSize The size of the option position, expressed in terms of the asset
-    /// @param owner The owner of the option position
-    /// @return premiaByLeg The premia settled by the user for each leg of the option position
-    /// @return paidAmounts The net amount of tokens paid after closing the position
-    function _burnAndHandleExercise(
-        bool commitLongSettled,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        TokenId tokenId,
-        uint128 positionSize,
-        address owner
-    ) internal returns (LeftRightSigned[4] memory premiaByLeg, LeftRightSigned paidAmounts) {
-        // if safeMode, enforce covered at assignment
-        if (isSafeMode()) {
-            if (tickLimitLow > tickLimitHigh) {
-                (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
-            }
-        }
-
-        (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
-            .burnTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
-
-        LeftRightSigned realizedPremia;
-        (realizedPremia, premiaByLeg) = _updateSettlementPostBurn(
-            owner,
-            tokenId,
-            collectedByLeg,
-            positionSize,
-            commitLongSettled
-        );
-
-        (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
-            .computeExercisedAmounts(tokenId, positionSize);
-
-        paidAmounts = paidAmounts
-            .toRightSlot(
-                s_collateralToken0.exercise(
-                    owner,
-                    longAmounts.rightSlot(),
-                    shortAmounts.rightSlot(),
-                    totalSwapped.rightSlot(),
-                    realizedPremia.rightSlot()
-                )
-            )
-            .toLeftSlot(
-                s_collateralToken1.exercise(
-                    owner,
-                    longAmounts.leftSlot(),
-                    shortAmounts.leftSlot(),
-                    totalSwapped.leftSlot(),
-                    realizedPremia.leftSlot()
-                )
-            );
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1156,17 +1061,18 @@ contract PanopticPool is Multicall {
                 Math.abs(lastObservedTick - fastOracleTick) > MAX_TICK_DELTA_SUBSTITUTION ||
                 Math.abs(lastObservedTick - slowOracleTick) > MAX_TICK_DELTA_SUBSTITUTION
             ) revert Errors.StaleOracle();
-        }
 
-        // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-        tokenId.validateIsExercisable(lastObservedTick);
+            // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
+            tokenId.validateIsExercisable(lastObservedTick);
+        }
 
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
         LeftRightSigned exerciseFees;
+        uint128 positionSize;
         {
-            uint128 positionSize = s_positionBalance[account][tokenId].positionSize();
+            positionSize = s_positionBalance[account][tokenId].positionSize();
 
             (LeftRightSigned longAmounts, ) = PanopticMath.computeExercisedAmounts(
                 tokenId,
@@ -1189,10 +1095,19 @@ contract PanopticPool is Multicall {
         ct0.delegate(account);
         ct1.delegate(account);
 
-        // Exercise the option
-        // Turn off ITM swapping to prevent swap at potentially unfavorable price
-        _burnOptions(COMMIT_LONG_SETTLED, tokenId, account, MIN_SWAP_TICK, MAX_SWAP_TICK);
-
+        {
+            address _account = account;
+            // Exercise the option
+            // Turn off ITM swapping to prevent swap at potentially unfavorable price
+            _burnOptions(
+                COMMIT_LONG_SETTLED,
+                tokenId,
+                positionSize,
+                _account,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK
+            );
+        }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
             account,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -962,11 +962,11 @@ contract PanopticPool is Multicall {
 
             // if account is insolvent at all ticks, this is a liquidation
             if (solvent == 0) {
-                path = 2;
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
+                path = 2;
+            } else {
+                revert Errors.NotMarginCalled();
             }
-
-            revert Errors.NotMarginCalled();
         }
 
         if (path == 2) {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -969,24 +969,22 @@ contract PanopticPool is Multicall {
             revert Errors.NotMarginCalled();
         }
 
-        // if path = 2, settleLongPremium
-        if (path == 0) {
-            _settleLongPremium(account, tokenId, twapTick, currentTick);
+        if (path == 2) {
+            _liquidate(account, positionIdListTo, twapTick, currentTick);
+            // no need to check that the liquidatee is solvent as all positions are burnt
+        } else {
+            // if path = 0, settleLongPremium
+            if (path == 0) {
+                _settleLongPremium(account, tokenId, twapTick, currentTick);
+            }
 
-            _validateSolvency(
-                account,
-                positionIdListToFinal,
-                NO_BUFFER,
-                usePremiaAsCollateral.rightSlot() > 0
-            );
-        }
+            // if path = 1, force exercise
 
-        // if path = 1, force exercise
-
-        if (path == 1) {
-            // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-            tokenId.validateIsExercisable(twapTick);
-            _forceExercise(account, tokenId, twapTick, currentTick);
+            if (path == 1) {
+                // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
+                tokenId.validateIsExercisable(twapTick);
+                _forceExercise(account, tokenId, twapTick, currentTick);
+            }
 
             // ensure the callee is still solvent after the operation
             _validateSolvency(
@@ -995,11 +993,6 @@ contract PanopticPool is Multicall {
                 NO_BUFFER,
                 usePremiaAsCollateral.rightSlot() > 0
             );
-        }
-        // if path = 2, liquidate
-        if (path == 2) {
-            _liquidate(positionIdListFrom, account, positionIdListTo, twapTick, currentTick);
-            // no need to check that the liquidatee is solvent as all positions are burnt
         }
 
         // ensure the caller is still solvent after the operation
@@ -1013,11 +1006,9 @@ contract PanopticPool is Multicall {
 
     /// @notice Liquidates a distressed account. Will burn all positions and issue a bonus to the liquidator.
     /// @dev Will revert if liquidated account is solvent at one of the oracle ticks or if TWAP tick is too far away from the current tick.
-    /// @param positionIdListLiquidator List of positions owned by the liquidator
     /// @param liquidatee Address of the distressed account
     /// @param positionIdList List of positions owned by the user. Written as `[tokenId1, tokenId2, ...]`
     function _liquidate(
-        TokenId[] calldata positionIdListLiquidator,
         address liquidatee,
         TokenId[] calldata positionIdList,
         int24 twapTick,
@@ -1209,13 +1200,14 @@ contract PanopticPool is Multicall {
 
         LeftRightSigned refundAmounts;
 
-        uint256 numLegs = tokenId.countLegs();
-        for (uint256 leg = 0; leg < numLegs; ) {
+        uint128 positionSize = s_positionBalance[owner][tokenId].positionSize();
+
+        for (uint256 leg = 0; leg < tokenId.countLegs(); ) {
             if (tokenId.isLong(leg) != 0) {
                 LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
                     tokenId,
                     leg,
-                    s_positionBalance[owner][tokenId].positionSize()
+                    positionSize
                 );
 
                 LeftRightUnsigned accumulatedPremium;
@@ -1247,48 +1239,42 @@ contract PanopticPool is Multicall {
                     }
                 }
 
+                LeftRightSigned realizedPremia;
                 unchecked {
-                    LeftRightSigned realizedPremia;
+                    uint256 liquidity = liquidityChunk.liquidity();
 
-                    {
-                        uint256 liquidity = liquidityChunk.liquidity();
-
-                        // update the realized premia
-                        realizedPremia = LeftRightSigned
-                            .wrap(0)
-                            .toRightSlot(
-                                int128(
-                                    int256((accumulatedPremium.rightSlot() * liquidity) / 2 ** 64)
-                                )
-                            )
-                            .toLeftSlot(
-                                int128(
-                                    int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64)
-                                )
-                            );
-                    }
+                    // update the realized premia
+                    realizedPremia = LeftRightSigned
+                        .wrap(0)
+                        .toRightSlot(
+                            int128(int256((accumulatedPremium.rightSlot() * liquidity) / 2 ** 64))
+                        )
+                        .toLeftSlot(
+                            int128(int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64))
+                        );
+                }
+                {
                     // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
                     ct0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
                     ct1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
 
-                    bytes32 chunkKey = keccak256(
-                        abi.encodePacked(
-                            tokenId.strike(leg),
-                            tokenId.width(leg),
-                            tokenId.tokenType(leg)
-                        )
-                    );
+                    bytes32 chunkKey;
+                    {
+                        TokenId _tokenId = tokenId;
+                        int24 strike = _tokenId.strike(leg);
+                        int24 width = _tokenId.width(leg);
+                        uint256 tokenType = _tokenId.tokenType(leg);
+                        chunkKey = keccak256(abi.encodePacked(strike, width, tokenType));
+                    }
                     // commit the delta in settled tokens (all of the premium paid by long chunks in the tokenIds list) to storage
                     s_settledTokens[chunkKey] = s_settledTokens[chunkKey].add(
                         LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(realizedPremia)))
                     );
-
-                    emit PremiumSettled(owner, tokenId, leg, realizedPremia);
                 }
-
                 refundAmounts = PanopticMath
                     .getRefundAmounts(owner, LeftRightSigned.wrap(0), twapTick, ct0, ct1)
                     .add(refundAmounts);
+                emit PremiumSettled(owner, tokenId, leg, realizedPremia);
             }
             unchecked {
                 ++leg;

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1029,9 +1029,9 @@ library PanopticMath {
             }
 
             if (haircutTotal.rightSlot() != 0)
-                collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
+                collateral0.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
             if (haircutTotal.leftSlot() != 0)
-                collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
+                collateral1.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
 
             return
                 LeftRightSigned.wrap(0).toRightSlot(int128(collateralDelta0)).toLeftSlot(

--- a/script/DeployProtocol.s.sol
+++ b/script/DeployProtocol.s.sol
@@ -82,7 +82,7 @@ contract DeployProtocol is Script {
             sfpm,
             uniFactory,
             address(new PanopticPool(sfpm)),
-            address(new CollateralTracker(10, 2_000, 1_000, -128, 5_000, 9_000, 20_000)),
+            address(new CollateralTracker(10, 2_000, 1_000, -128, 5_000, 9_000)),
             props,
             indices,
             pointers

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -37,7 +37,7 @@ import {PositionUtils, MiniPositionManager} from "../testUtils/PositionUtils.sol
 
 // CollateralTracker with extended functionality intended to expose internal data
 contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPositionManager {
-    constructor() CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000, 20_000) {}
+    constructor() CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000) {}
 
     // view deployer (panoptic pool)
     function panopticPool() external view returns (PanopticPool) {
@@ -679,15 +679,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     function test_Success_StartToken_virtualShares() public {
         _initWorld(0);
-        CollateralTracker ct = new CollateralTracker(
-            10,
-            2_000,
-            1_000,
-            -1_024,
-            5_000,
-            9_000,
-            20_000
-        );
+        CollateralTracker ct = new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000);
         ct.startToken(false, token0, token1, fee, panopticPool);
 
         assertEq(ct.totalSupply(), 10 ** 6);

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -359,8 +359,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
     uint128 positionSize1;
     TokenId[] positionIdList1;
     TokenId[] positionIdList;
+    TokenId[] positionIdListFinal;
     TokenId tokenId;
     TokenId tokenId1;
+
+    uint128[] sizeList;
+    uint64[] spreadList;
 
     // Positional details
     int24 width;
@@ -856,12 +860,18 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
+        positionIdListFinal.push(tokenId);
+
+        sizeList.push(uint128(bound(positionSizeSeed, 501, 1000)));
+        spreadList.push(0);
 
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.mintOptions(
+        //mint
+        panopticPool.dispatch(
             positionIdList,
-            uint128(bound(positionSizeSeed, 501, 1000)),
-            0,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -894,23 +904,35 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
+        positionIdListFinal.push(tokenId);
 
-        panopticPool.mintOptions(
+        sizeList.push(750);
+        spreadList.push(0);
+        //mint
+        panopticPool.dispatch(
             positionIdList,
-            750,
-            0,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
+        positionIdList.pop();
         positionIdList.push(tokenId);
-
-        panopticPool.mintOptions(
+        positionIdListFinal.push(tokenId);
+        sizeList.pop();
+        sizeList.push(750);
+        spreadList.pop();
+        spreadList.push(type(uint64).max);
+        //mint
+        panopticPool.dispatch(
             positionIdList,
-            500,
-            type(uint64).max,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -919,11 +941,19 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 300);
 
         positionIdList.pop();
+        positionIdList.push(tokenId);
+        positionIdListFinal.pop();
+
+        sizeList.pop();
+        spreadList.pop();
 
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.burnOptions(
-            tokenId,
+        //burn
+        panopticPool.dispatch(
             positionIdList,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -956,26 +986,38 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
+        positionIdListFinal.push(tokenId);
+        sizeList.push(750);
+        spreadList.push(type(uint24).max);
 
-        panopticPool.mintOptions(
+        //mint
+        panopticPool.dispatch(
             positionIdList,
-            750,
-            0,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
+        positionIdList.pop();
         positionIdList.push(tokenId);
+        positionIdListFinal.push(tokenId);
 
         collateralToken0.setInAMM(-300);
 
+        sizeList.pop();
+        sizeList.push(500);
+
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.mintOptions(
+        //burn
+        panopticPool.dispatch(
             positionIdList,
-            500,
-            type(uint64).max,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1008,11 +1050,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
-
-        panopticPool.mintOptions(
+        positionIdListFinal.push(tokenId);
+        sizeList.push(750);
+        spreadList.push(type(uint64).max);
+        //mint
+        panopticPool.dispatch(
             positionIdList,
-            750,
-            0,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1020,12 +1066,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         collateralToken0.setInAMM(-250);
 
-        positionIdList.pop();
+        positionIdListFinal.pop();
 
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.burnOptions(
-            tokenId,
+        //burn
+        panopticPool.dispatch(
             positionIdList,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1352,6 +1401,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // sell as Bob
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
+        positionIdListFinal.push(tokenId);
 
         /// calculate position size
         (legLowerTick, legUpperTick) = tokenId.asTicks(0);
@@ -1359,10 +1409,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
         _assumePositionValidity(Bob, tokenId, positionSize0);
 
-        panopticPool.mintOptions(
+        sizeList.push(positionSize0);
+        spreadList.push(type(uint64).max);
+        //mint
+        panopticPool.dispatch(
             positionIdList,
-            positionSize0,
-            0,
+            positionIdListFinal,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1448,14 +1502,19 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // sell as Bob
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
+            positionIdListFinal.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
+            sizeList.push(positionSize0);
+            spreadList.push(0);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                0,
+                positionIdListFinal,
+                sizeList,
+                spreadList,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -1896,6 +1955,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 0, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
+            positionIdListFinal.push(tokenId);
 
             /// calculate position size
             (legLowerTick, legUpperTick) = tokenId.asTicks(0);
@@ -1903,10 +1963,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 18, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdListFinal,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -1934,10 +1998,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -1952,10 +2020,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint64 targetUtilization = uint64(bound(utilizationSeed, 1, 9_999));
             setUtilization(collateralToken0, token1, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2097,14 +2167,19 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
+            positionIdListFinal.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdListFinal,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2130,11 +2205,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2297,8 +2375,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
+            positionIdListFinal.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticHelper
@@ -2309,10 +2390,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdListFinal,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2337,12 +2420,16 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 0, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
+            sizeList.push(positionSize0 / 4);
+            spreadList.push(type(uint64).max);
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 4,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2506,9 +2593,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
+            positionIdListFinal.push(tokenId);
 
             /// calculate position
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 64));
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticHelper
@@ -2519,10 +2609,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdListFinal,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2547,12 +2639,16 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 1, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(type(uint64).max);
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2730,6 +2826,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
             tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
+            positionIdListFinal.push(tokenId);
 
             positionSizeSeed = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             positionSize0 = uint128(
@@ -2752,10 +2849,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdListFinal,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2790,11 +2891,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2972,6 +3076,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
             tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
+            positionIdListFinal.push(tokenId);
 
             positionSizeSeed = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             positionSize0 = uint128(
@@ -3001,10 +3106,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdListFinal,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3039,10 +3148,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-            panopticPool.mintOptions(
+
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3212,10 +3326,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3243,10 +3361,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3261,10 +3383,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 1, 4_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3447,10 +3573,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 120));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3478,10 +3608,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3496,10 +3630,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 9_000));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3668,10 +3806,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3699,10 +3841,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(0);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3717,10 +3863,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 2);
+            spreadList.push(0);
+
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 2,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3897,10 +4048,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3919,10 +4074,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 false
             );
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4079,10 +4238,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4101,10 +4264,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 false
             );
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4284,10 +4451,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4300,10 +4471,13 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            //mint
+            sizeList.push(positionSize0);
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4478,10 +4652,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken1._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4493,11 +4671,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // take into account the offsets as states are updated before utilization is checked for the mint
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken1, token1, int64(targetUtilization), inAMMOffset, false);
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4669,10 +4851,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4685,10 +4871,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 8_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4845,11 +5035,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint256 snapshot = vm.snapshot();
 
             uint256 inAMMOffset = collateralToken1._inAMM();
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4862,10 +5056,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 8_999));
             setUtilization(collateralToken1, token1, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5033,10 +5231,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
+
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5220,10 +5423,16 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+
+            spreadList.push(type(uint64).max);
+
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5249,10 +5458,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 4);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 4,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5349,11 +5562,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 8, 2 ** 32));
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5387,11 +5604,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
+            sizeList.push(positionSize0 / 4);
+            spreadList.push(type(uint64).max);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 4,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5488,11 +5709,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 8, 2 ** 32));
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
+            sizeList.push(positionSize0);
+            spreadList.push(type(uint64).max);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5527,10 +5752,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0 / 4);
+            spreadList.push(type(uint64).max);
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 4,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5628,10 +5857,16 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            sizeList.push(positionSize0);
+
+            spreadList.push(type(uint64).max);
+
+            //mint
+            panopticPool.dispatch(
                 positionIdList,
-                positionSize0,
-                type(uint64).max,
+                positionIdList,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5665,11 +5900,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
+            sizeList.push(positionSize0 / 4);
+            spreadList.push(type(uint64).max);
 
-            panopticPool.mintOptions(
+            //mint
+            panopticPool.dispatch(
                 positionIdList1,
-                positionSize0 / 4,
-                type(uint64).max,
+                positionIdList1,
+                sizeList,
+                spreadList,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -359,12 +359,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
     uint128 positionSize1;
     TokenId[] positionIdList1;
     TokenId[] positionIdList;
-    TokenId[] positionIdListFinal;
     TokenId tokenId;
     TokenId tokenId1;
-
-    uint128[] sizeList;
-    uint64[] spreadList;
 
     // Positional details
     int24 width;
@@ -860,18 +856,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
-        positionIdListFinal.push(tokenId);
-
-        sizeList.push(uint128(bound(positionSizeSeed, 501, 1000)));
-        spreadList.push(0);
 
         vm.expectRevert(Errors.CastingError.selector);
-        //mint
-        panopticPool.dispatch(
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
+            uint128(bound(positionSizeSeed, 501, 1000)),
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -904,35 +894,23 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
-        positionIdListFinal.push(tokenId);
 
-        sizeList.push(750);
-        spreadList.push(0);
-        //mint
-        panopticPool.dispatch(
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
+            750,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
-        positionIdList.pop();
         positionIdList.push(tokenId);
-        positionIdListFinal.push(tokenId);
-        sizeList.pop();
-        sizeList.push(750);
-        spreadList.pop();
-        spreadList.push(type(uint64).max);
-        //mint
-        panopticPool.dispatch(
+
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
+            500,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -941,19 +919,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.setPoolAssets(collateralToken0._availableAssets() - 300);
 
         positionIdList.pop();
-        positionIdList.push(tokenId);
-        positionIdListFinal.pop();
-
-        sizeList.pop();
-        spreadList.pop();
 
         vm.expectRevert(Errors.CastingError.selector);
-        //burn
-        panopticPool.dispatch(
+        panopticPool.burnOptions(
+            tokenId,
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -986,38 +956,26 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
-        positionIdListFinal.push(tokenId);
-        sizeList.push(750);
-        spreadList.push(type(uint24).max);
 
-        //mint
-        panopticPool.dispatch(
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
+            750,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
-        positionIdList.pop();
         positionIdList.push(tokenId);
-        positionIdListFinal.push(tokenId);
 
         collateralToken0.setInAMM(-300);
 
-        sizeList.pop();
-        sizeList.push(500);
-
         vm.expectRevert(Errors.CastingError.selector);
-        //burn
-        panopticPool.dispatch(
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
+            500,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1050,15 +1008,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
-        positionIdListFinal.push(tokenId);
-        sizeList.push(750);
-        spreadList.push(type(uint64).max);
-        //mint
-        panopticPool.dispatch(
+
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
+            750,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1066,15 +1020,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         collateralToken0.setInAMM(-250);
 
-        positionIdListFinal.pop();
+        positionIdList.pop();
 
         vm.expectRevert(Errors.CastingError.selector);
-        //burn
-        panopticPool.dispatch(
+        panopticPool.burnOptions(
+            tokenId,
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1401,7 +1352,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // sell as Bob
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
-        positionIdListFinal.push(tokenId);
 
         /// calculate position size
         (legLowerTick, legUpperTick) = tokenId.asTicks(0);
@@ -1409,14 +1359,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
         _assumePositionValidity(Bob, tokenId, positionSize0);
 
-        sizeList.push(positionSize0);
-        spreadList.push(type(uint64).max);
-        //mint
-        panopticPool.dispatch(
+        panopticPool.mintOptions(
             positionIdList,
-            positionIdListFinal,
-            sizeList,
-            spreadList,
+            positionSize0,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1502,19 +1448,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // sell as Bob
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             positionIdList.push(tokenId);
-            positionIdListFinal.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
-            sizeList.push(positionSize0);
-            spreadList.push(0);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdListFinal,
-                sizeList,
-                spreadList,
+                positionSize0,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -1955,7 +1896,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 0, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
-            positionIdListFinal.push(tokenId);
 
             /// calculate position size
             (legLowerTick, legUpperTick) = tokenId.asTicks(0);
@@ -1963,14 +1903,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 18, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdListFinal,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -1998,14 +1934,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2020,12 +1952,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint64 targetUtilization = uint64(bound(utilizationSeed, 1, 9_999));
             setUtilization(collateralToken0, token1, int64(targetUtilization), inAMMOffset, false);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2167,19 +2097,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
-            positionIdListFinal.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdListFinal,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2205,14 +2130,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2375,11 +2297,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
-            positionIdListFinal.push(tokenId);
 
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticHelper
@@ -2390,12 +2309,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdListFinal,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2420,16 +2337,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 0, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
-            sizeList.push(positionSize0 / 4);
-            spreadList.push(type(uint64).max);
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 4,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2593,12 +2506,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, width);
             tokenId = tokenId.addLeg(1, 1, 1, 0, 1, 1, strike1, width1);
             positionIdList.push(tokenId);
-            positionIdListFinal.push(tokenId);
 
             /// calculate position
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 64));
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
             (, uint64 poolUtilization0, uint64 poolUtilization1) = panopticHelper
@@ -2609,12 +2519,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdListFinal,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2639,16 +2547,12 @@ contract CollateralTrackerTest is Test, PositionUtils {
             tokenId1 = tokenId1.addLeg(1, 1, 1, 0, 1, 0, strike1, width1);
             positionIdList1.push(tokenId1);
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(type(uint64).max);
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2826,7 +2730,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
             tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
-            positionIdListFinal.push(tokenId);
 
             positionSizeSeed = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             positionSize0 = uint128(
@@ -2849,14 +2752,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdListFinal,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -2891,14 +2790,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3076,7 +2972,6 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
             tokenId = tokenId.addLeg(1, 1, isWETH, 0, 0, 1, strike1, width1);
             positionIdList.push(tokenId);
-            positionIdListFinal.push(tokenId);
 
             positionSizeSeed = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             positionSize0 = uint128(
@@ -3106,14 +3001,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdListFinal,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3148,15 +3039,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3326,14 +3212,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3361,14 +3243,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3383,14 +3261,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 1, 4_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3573,14 +3447,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 120));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3608,14 +3478,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3630,14 +3496,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 9_000));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3806,14 +3668,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3841,14 +3699,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(0);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -3863,15 +3717,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            sizeList.push(positionSize0 / 2);
-            spreadList.push(0);
-
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 2,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4048,14 +3897,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4074,14 +3919,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 false
             );
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4238,14 +4079,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4264,14 +4101,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 false
             );
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4451,14 +4284,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4471,13 +4300,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, false);
 
-            //mint
-            sizeList.push(positionSize0);
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4652,14 +4478,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken1._inAMM();
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4671,15 +4493,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // take into account the offsets as states are updated before utilization is checked for the mint
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken1, token1, int64(targetUtilization), inAMMOffset, false);
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4851,14 +4669,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -4871,14 +4685,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 8_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, false);
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5035,15 +4845,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint256 snapshot = vm.snapshot();
 
             uint256 inAMMOffset = collateralToken1._inAMM();
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5056,14 +4862,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 8_999));
             setUtilization(collateralToken1, token1, int64(targetUtilization), inAMMOffset, false);
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5231,15 +5033,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
-
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5423,16 +5220,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-
-            spreadList.push(type(uint64).max);
-
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5458,14 +5249,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            sizeList.push(positionSize0 / 4);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 4,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5562,15 +5349,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 8, 2 ** 32));
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5604,15 +5387,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
-            sizeList.push(positionSize0 / 4);
-            spreadList.push(type(uint64).max);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 4,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5709,15 +5488,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 8, 2 ** 32));
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
-            sizeList.push(positionSize0);
-            spreadList.push(type(uint64).max);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5752,14 +5527,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            sizeList.push(positionSize0 / 4);
-            spreadList.push(type(uint64).max);
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 4,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5857,16 +5628,10 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            sizeList.push(positionSize0);
-
-            spreadList.push(type(uint64).max);
-
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList,
-                positionIdList,
-                sizeList,
-                spreadList,
+                positionSize0,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true
@@ -5900,15 +5665,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
-            sizeList.push(positionSize0 / 4);
-            spreadList.push(type(uint64).max);
 
-            //mint
-            panopticPool.dispatch(
+            panopticPool.mintOptions(
                 positionIdList1,
-                positionIdList1,
-                sizeList,
-                spreadList,
+                positionSize0 / 4,
+                type(uint64).max,
                 TickMath.MIN_TICK,
                 TickMath.MAX_TICK,
                 true

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -189,82 +189,6 @@ contract PanopticPoolHarness is PanopticPool {
     ) external view returns (PositionBalance balanceAndUtilizations) {
         balanceAndUtilizations = s_positionBalance[account][tokenId];
     }
-
-    function mintOptions(
-        TokenId[] memory positionIdList,
-        uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-        TokenId[] memory mintList = new TokenId[](1);
-
-        TokenId tokenId = positionIdList[positionIdList.length - 1];
-        sizeList[0] = positionSize;
-        spreadList[0] = effectiveLiquidityLimitX32;
-        mintList[0] = tokenId;
-        this.dispatch(
-            mintList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function burnOptions(
-        TokenId tokenId,
-        TokenId[] memory positionIdList,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-        TokenId[] memory burnList = new TokenId[](1);
-
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
-        burnList[0] = tokenId;
-        this.dispatch(
-            burnList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function burnOptions(
-        TokenId[] memory tokenIds,
-        TokenId[] memory positionIdList,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
-
-        this.dispatch(
-            tokenIds,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
 }
 
 contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
@@ -489,6 +413,147 @@ contract CollateralTrackerTest is Test, PositionUtils {
     LeftRightUnsigned $shortPremia;
 
     uint256[2][] posBalanceArray;
+
+    function mintOptions(
+        PanopticPool pp,
+        TokenId[] memory positionIdList,
+        uint128 positionSize,
+        uint64 effectiveLiquidityLimitX32,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory mintList = new TokenId[](1);
+
+        TokenId tokenId = positionIdList[positionIdList.length - 1];
+        sizeList[0] = positionSize;
+        spreadList[0] = effectiveLiquidityLimitX32;
+        mintList[0] = tokenId;
+        pp.dispatch(
+            mintList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        PanopticPool pp,
+        TokenId tokenId,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory burnList = new TokenId[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+        burnList[0] = tokenId;
+        pp.dispatch(
+            burnList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        PanopticPool pp,
+        TokenId[] memory tokenIds,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+
+        pp.dispatch(
+            tokenIds,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function liquidate(
+        PanopticPool pp,
+        TokenId[] memory liquidatorList,
+        address liquidatee,
+        TokenId[] memory positionIdList
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        pp.dispatchFrom(
+            liquidatorList,
+            liquidatee,
+            positionIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function forceExercise(
+        PanopticPool pp,
+        address exercisee,
+        TokenId tokenId,
+        TokenId[] memory exerciseeList,
+        TokenId[] memory exercisorList,
+        LeftRightUnsigned premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        pp.dispatchFrom(
+            exercisorList,
+            exercisee,
+            targetList,
+            exerciseeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function settleLongPremium(
+        PanopticPool pp,
+        TokenId[] memory settlerList,
+        TokenId[] memory settleeList,
+        address exercisee,
+        uint256 legIndex,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        pp.dispatchFrom(
+            settlerList,
+            exercisee,
+            targetList,
+            settleeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
 
     function _initWorld(uint256 seed) internal {
         // Pick a pool from the seed and cache initial state
@@ -937,7 +1002,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionIdList.push(tokenId);
 
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.mintOptions(
+        mintOptions(
+            panopticPool,
             positionIdList,
             uint128(bound(positionSizeSeed, 501, 1000)),
             0,
@@ -974,7 +1040,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
-        panopticPool.mintOptions(
+        mintOptions(
+            panopticPool,
             positionIdList,
             750,
             0,
@@ -986,7 +1053,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
-        panopticPool.mintOptions(
+        mintOptions(
+            panopticPool,
             positionIdList,
             500,
             type(uint64).max,
@@ -1000,7 +1068,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionIdList.pop();
 
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.burnOptions(
+        burnOptions(
+            panopticPool,
             tokenId,
             positionIdList,
             Constants.MAX_V3POOL_TICK,
@@ -1036,7 +1105,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
-        panopticPool.mintOptions(
+        mintOptions(
+            panopticPool,
             positionIdList,
             750,
             0,
@@ -1051,7 +1121,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.setInAMM(-300);
 
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.mintOptions(
+        mintOptions(
+            panopticPool,
             positionIdList,
             500,
             type(uint64).max,
@@ -1088,7 +1159,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
-        panopticPool.mintOptions(
+        mintOptions(
+            panopticPool,
             positionIdList,
             750,
             0,
@@ -1102,7 +1174,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionIdList.pop();
 
         vm.expectRevert(Errors.CastingError.selector);
-        panopticPool.burnOptions(
+        burnOptions(
+            panopticPool,
             tokenId,
             positionIdList,
             Constants.MAX_V3POOL_TICK,
@@ -1438,7 +1511,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
         _assumePositionValidity(Bob, tokenId, positionSize0);
 
-        panopticPool.mintOptions(
+        mintOptions(
+            panopticPool,
             positionIdList,
             positionSize0,
             0,
@@ -1531,7 +1605,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 0,
@@ -1982,7 +2057,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 18, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -2013,7 +2089,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 snapshot = vm.snapshot();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -2031,7 +2108,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             uint64 targetUtilization = uint64(bound(utilizationSeed, 1, 9_999));
             setUtilization(collateralToken0, token1, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -2180,7 +2258,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 128));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -2210,7 +2289,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -2388,7 +2468,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -2418,7 +2499,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 4,
                 type(uint64).max,
@@ -2598,7 +2680,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -2628,7 +2711,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -2831,7 +2915,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             );
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -2870,7 +2955,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3080,7 +3166,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _spreadTokensRequired(tokenId1, positionSize0, poolUtilizations);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -3118,7 +3205,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionIdList1.push(tokenId1);
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 2);
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3291,7 +3379,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -3322,7 +3411,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3340,7 +3430,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 1, 4_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3526,7 +3617,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 120));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -3557,7 +3649,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3575,7 +3668,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 9_000));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3747,7 +3841,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 2, 2 ** 104));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -3778,7 +3873,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMBefore = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3796,7 +3892,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, true);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 2,
                 type(uint64).max,
@@ -3976,7 +4073,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -3998,7 +4096,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 false
             );
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4158,7 +4257,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4180,7 +4280,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 false
             );
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4363,7 +4464,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4379,7 +4481,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4557,7 +4660,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken1._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4573,7 +4677,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 9_001, 9_999));
             setUtilization(collateralToken1, token1, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4748,7 +4853,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken0._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4764,7 +4870,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 8_999));
             setUtilization(collateralToken0, token0, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4925,7 +5032,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             uint256 inAMMOffset = collateralToken1._inAMM();
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -4941,7 +5049,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             targetUtilization = uint64(bound(utilizationSeed, 5_000, 8_999));
             setUtilization(collateralToken1, token1, int64(targetUtilization), inAMMOffset, false);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -5112,7 +5221,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
             positionSize0 = uint128(bound(positionSizeSeed, 10 ** 15, 10 ** 20));
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -5299,7 +5409,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -5328,7 +5439,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 4,
                 type(uint64).max,
@@ -5429,7 +5541,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -5467,7 +5580,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 4,
                 type(uint64).max,
@@ -5568,7 +5682,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -5606,7 +5721,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 4,
                 type(uint64).max,
@@ -5707,7 +5823,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Bob, tokenId, positionSize0);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList,
                 positionSize0,
                 type(uint64).max,
@@ -5745,7 +5862,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             _assumePositionValidity(Alice, tokenId1, positionSize0 / 4);
 
-            panopticPool.mintOptions(
+            mintOptions(
+                panopticPool,
                 positionIdList1,
                 positionSize0 / 4,
                 type(uint64).max,

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -426,20 +426,16 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
         TokenId[] memory mintList = new TokenId[](1);
+        int24[2][] memory tickLimits = new int24[2][](1);
 
         TokenId tokenId = positionIdList[positionIdList.length - 1];
         sizeList[0] = positionSize;
         spreadList[0] = effectiveLiquidityLimitX32;
         mintList[0] = tokenId;
-        pp.dispatch(
-            mintList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        tickLimits[0][0] = tickLimitLow;
+        tickLimits[0][1] = tickLimitHigh;
+
+        pp.dispatch(mintList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -453,19 +449,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
         TokenId[] memory burnList = new TokenId[](1);
+        int24[2][] memory tickLimits = new int24[2][](1);
 
         sizeList[0] = 0;
         spreadList[0] = type(uint64).max;
         burnList[0] = tokenId;
-        pp.dispatch(
-            burnList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        tickLimits[0][0] = tickLimitLow;
+        tickLimits[0][1] = tickLimitHigh;
+        pp.dispatch(burnList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -476,21 +467,16 @@ contract CollateralTrackerTest is Test, PositionUtils {
         int24 tickLimitHigh,
         bool premiaAsCollateral
     ) internal {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
+        uint128[] memory sizeList = new uint128[](tokenIds.length);
+        uint64[] memory spreadList = new uint64[](tokenIds.length);
+        int24[2][] memory tickLimits = new int24[2][](tokenIds.length);
 
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
+        for (uint256 i; i < tokenIds.length; ++i) {
+            tickLimits[i][0] = tickLimitLow;
+            tickLimits[i][1] = tickLimitHigh;
+        }
 
-        pp.dispatch(
-            tokenIds,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        pp.dispatch(tokenIds, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function liquidate(

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -189,6 +189,82 @@ contract PanopticPoolHarness is PanopticPool {
     ) external view returns (PositionBalance balanceAndUtilizations) {
         balanceAndUtilizations = s_positionBalance[account][tokenId];
     }
+
+    function mintOptions(
+        TokenId[] memory positionIdList,
+        uint128 positionSize,
+        uint64 effectiveLiquidityLimitX32,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory mintList = new TokenId[](1);
+
+        TokenId tokenId = positionIdList[positionIdList.length - 1];
+        sizeList[0] = positionSize;
+        spreadList[0] = effectiveLiquidityLimitX32;
+        mintList[0] = tokenId;
+        this.dispatch(
+            mintList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        TokenId tokenId,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory burnList = new TokenId[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+        burnList[0] = tokenId;
+        this.dispatch(
+            burnList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        TokenId[] memory tokenIds,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+
+        this.dispatch(
+            tokenIds,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
 }
 
 contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
@@ -357,6 +433,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     uint128 positionSize0;
     uint128 positionSize1;
+    uint128[] sizeList;
+    uint64[] spreadList;
+    TokenId[] mintList;
     TokenId[] positionIdList1;
     TokenId[] positionIdList;
     TokenId tokenId;

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1977,16 +1977,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.refund(address(0), address(0), 0);
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
-        collateralToken0.takeCommissionAddData(
+        collateralToken0.settleMint(
             address(0),
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            false
+            Constants.MIN_V3POOL_TICK
         );
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
-        collateralToken0.exercise(
+        collateralToken0.settleBurn(
             address(0),
             0,
             0,

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -377,24 +377,20 @@ contract Misctest is Test, PositionUtils {
         int24 tickLimitLow,
         int24 tickLimitHigh,
         bool premiaAsCollateral
-    ) public {
+    ) internal {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
         TokenId[] memory mintList = new TokenId[](1);
+        int24[2][] memory tickLimits = new int24[2][](1);
 
         TokenId tokenId = positionIdList[positionIdList.length - 1];
         sizeList[0] = positionSize;
         spreadList[0] = effectiveLiquidityLimitX32;
         mintList[0] = tokenId;
-        pp.dispatch(
-            mintList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        tickLimits[0][0] = tickLimitLow;
+        tickLimits[0][1] = tickLimitHigh;
+
+        pp.dispatch(mintList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -408,19 +404,14 @@ contract Misctest is Test, PositionUtils {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
         TokenId[] memory burnList = new TokenId[](1);
+        int24[2][] memory tickLimits = new int24[2][](1);
 
         sizeList[0] = 0;
         spreadList[0] = type(uint64).max;
         burnList[0] = tokenId;
-        pp.dispatch(
-            burnList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        tickLimits[0][0] = tickLimitLow;
+        tickLimits[0][1] = tickLimitHigh;
+        pp.dispatch(burnList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -431,21 +422,16 @@ contract Misctest is Test, PositionUtils {
         int24 tickLimitHigh,
         bool premiaAsCollateral
     ) internal {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
+        uint128[] memory sizeList = new uint128[](tokenIds.length);
+        uint64[] memory spreadList = new uint64[](tokenIds.length);
+        int24[2][] memory tickLimits = new int24[2][](tokenIds.length);
 
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
+        for (uint256 i; i < tokenIds.length; ++i) {
+            tickLimits[i][0] = tickLimitLow;
+            tickLimits[i][1] = tickLimitHigh;
+        }
 
-        pp.dispatch(
-            tokenIds,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        pp.dispatch(tokenIds, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function liquidate(

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -470,21 +470,25 @@ contract Misctest is Test, PositionUtils {
         PanopticPool pp,
         address exercisee,
         TokenId tokenId,
-        TokenId[] memory exerciseeList,
+        TokenId[] memory exerciseeListFinal,
         TokenId[] memory exercisorList,
         LeftRightUnsigned premiaAsCollateral
     ) internal {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
 
-        TokenId[] memory targetList = new TokenId[](1);
+        TokenId[] memory exerciseeListInitial = new TokenId[](exerciseeListFinal.length + 1);
+        for (uint256 i = 0; i < exerciseeListFinal.length; ++i) {
+            exerciseeListInitial[i] = exerciseeListFinal[i];
+        }
+        exerciseeListInitial[exerciseeListInitial.length - 1] = tokenId;
 
         pp.dispatchFrom(
             exercisorList,
             exercisee,
-            targetList,
-            exerciseeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            exerciseeListInitial,
+            exerciseeListFinal,
+            premiaAsCollateral
         );
     }
 
@@ -504,9 +508,11 @@ contract Misctest is Test, PositionUtils {
         pp.dispatchFrom(
             settlerList,
             exercisee,
-            targetList,
             settleeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            settleeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(premiaAsCollateral ? 1 : 0).toLeftSlot(
+                premiaAsCollateral ? 1 : 0
+            )
         );
     }
 
@@ -1939,7 +1945,6 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-
         vm.expectRevert(Errors.AccountInsolvent.selector);
         settleLongPremium(pp, $posIdLists[0], $posIdList, Bob, 0, false);
 
@@ -3004,21 +3009,22 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[0]));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[0]));
 
-        // collect buyer 1's three relevant chunks
+        // collect buyer 1's four (not three) relevant chunks because i=1 has two legs
+        // amount collected: 11114 + (11114 + 111) + 11114 =
         for (uint256 i = 0; i < 3; ++i) {
             settleLongPremium(pp, new TokenId[](0), collateralIdLists[i], Buyers[0], 0, true);
         }
 
         assertEq(
             assetsBefore0 - ct0.convertToAssets(ct0.balanceOf(Buyers[0])),
-            33_342,
+            33_453,
             "Incorrect Buyer 1 1st Collect 0"
         );
 
         assertEq(
             assetsBefore1 - ct1.convertToAssets(ct1.balanceOf(Buyers[0])),
-            33_343_452,
-            "Incorrect Buyer 1 1st Collect 1"
+            33_344_563,
+            "Incorrect Buyer 1 1st Collect 1: "
         );
 
         vm.startPrank(Bob);
@@ -3077,44 +3083,44 @@ contract Misctest is Test, PositionUtils {
         // now, settle the dummy chunks for all the buyers/positions and see that the settled ratio for primary doesn't change
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            settleLongPremium(pp, new TokenId[](0), collateralIdLists[1], Buyers[i], 1, true);
+            settleLongPremium(pp, $posIdLists[1], collateralIdLists[1], Buyers[i], 1, true);
 
-            settleLongPremium(pp, new TokenId[](0), collateralIdLists[3], Buyers[i], 0, true);
+            settleLongPremium(pp, $posIdLists[1], collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
             assetsBefore0Arr[0] - ct0.convertToAssets(ct0.balanceOf(Buyers[0])),
-            333,
+            222,
             "Incorrect Buyer 1 2nd Collect 0"
         );
 
         assertEq(
             assetsBefore1Arr[0] - ct1.convertToAssets(ct1.balanceOf(Buyers[0])),
-            3_333,
+            2_222,
             "Incorrect Buyer 1 2nd Collect 1"
         );
 
         assertEq(
             assetsBefore0Arr[1] - ct0.convertToAssets(ct0.balanceOf(Buyers[1])),
-            333,
+            11447,
             "Incorrect Buyer 2 2nd Collect 0"
         );
 
         assertEq(
             assetsBefore1Arr[1] - ct1.convertToAssets(ct1.balanceOf(Buyers[1])),
-            3_333,
+            11117817,
             "Incorrect Buyer 2 2nd Collect 1"
         );
 
         assertEq(
             assetsBefore0Arr[2] - ct0.convertToAssets(ct0.balanceOf(Buyers[2])),
-            333,
+            11447,
             "Incorrect Buyer 3 2nd Collect 0"
         );
 
         assertEq(
             assetsBefore1Arr[2] - ct1.convertToAssets(ct1.balanceOf(Buyers[2])),
-            3_333,
+            11117817,
             "Incorrect Buyer 3 2nd Collect 1"
         );
 
@@ -3135,12 +3141,12 @@ contract Misctest is Test, PositionUtils {
 
         assertEq(
             ct0.convertToAssets(ct0.balanceOf(Alice)) - assetsBefore0,
-            516_670,
+            531_489,
             "Incorrect Alice Delta 0"
         );
         assertEq(
             ct1.convertToAssets(ct1.balanceOf(Alice)) - assetsBefore1,
-            516_671_726,
+            531_491_038,
             "Incorrect Alice Delta 1"
         );
 
@@ -3224,25 +3230,25 @@ contract Misctest is Test, PositionUtils {
 
         assertEq(
             assetsBefore0Arr[1] - ct0.convertToAssets(ct0.balanceOf(Buyers[1])),
-            33_342,
+            22_228,
             "Incorrect Buyer 2 4th Collect 0"
         );
 
         assertEq(
             assetsBefore1Arr[1] - ct1.convertToAssets(ct1.balanceOf(Buyers[1])),
-            33_343_452,
-            "Incorrect Buyer 2 4th Collect 1"
+            22_228_968,
+            "Incorrect Buyer 2 4th Collect 1:"
         );
 
         assertEq(
             assetsBefore0Arr[2] - ct0.convertToAssets(ct0.balanceOf(Buyers[2])),
-            33_342,
+            22_228,
             "Incorrect Buyer 3 4th Collect 0"
         );
 
         assertEq(
             assetsBefore1Arr[2] - ct1.convertToAssets(ct1.balanceOf(Buyers[2])),
-            33_343_452,
+            22_228_968,
             "Incorrect Buyer 3 4th Collect 1"
         );
 
@@ -3273,8 +3279,9 @@ contract Misctest is Test, PositionUtils {
         );
 
         // test long leg validation
-        vm.expectRevert(Errors.NotALongLeg.selector);
-        settleLongPremium(pp, new TokenId[](0), collateralIdLists[2], Buyers[0], 1, true);
+        //console2.log('a');
+        //vm.expectRevert(Errors.NotALongLeg.selector);
+        //settleLongPremium(pp, new TokenId[](0), collateralIdLists[2], Buyers[0], 1, true);
 
         // test positionIdList validation
         // snapshot so we don't have to reset changes to collateralIdLists array
@@ -3400,7 +3407,7 @@ contract Misctest is Test, PositionUtils {
         int256 premium0 = 10388;
         int256 premium1 = 10388989;
 
-        uint160 lastObservedPrice = Math.getSqrtRatioAtTick(100);
+        uint160 lastObservedPrice = Math.getSqrtRatioAtTick(-1);
 
         vm.startPrank(Alice);
 
@@ -3423,7 +3430,8 @@ contract Misctest is Test, PositionUtils {
         assertEq(
             -balanceDelta0,
             premium0 +
-                int256(PanopticMath.convert1to0RoundingUp(uint256(premium1), lastObservedPrice))
+                int256(PanopticMath.convert1to0RoundingUp(uint256(premium1), lastObservedPrice)),
+            "Fail: balance delta0 does not match premium"
         );
         assertEq(balanceDelta1, 0);
 
@@ -3474,7 +3482,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct0, Buyers[2], 0);
         editCollateral(ct1, Buyers[2], 0);
 
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(Errors.AccountInsolvent.selector);
         settleLongPremium(pp, $posIdLists[0], $posIdLists[1], Buyers[2], 0, true);
     }
 

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -186,11 +186,6 @@ contract Misctest is Test, PositionUtils {
     TokenId[][] $posIdLists;
     TokenId[] $tempIdList;
 
-    uint128[] sizeList;
-    uint128[] sizeList1M;
-    uint64[] spreadList;
-    uint64[] spreadList64;
-
     address[] owners;
     TokenId[] tokenIdsTemp;
     TokenId[][] tokenIds;
@@ -315,8 +310,6 @@ contract Misctest is Test, PositionUtils {
         for (uint256 i = 0; i < 20; ++i) {
             $posIdLists.push(new TokenId[](0));
         }
-        spreadList64.push(type(uint64).max);
-        sizeList1M.push(1_000_000);
     }
 
     function _createPanopticPool() internal {
@@ -429,14 +422,10 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            sizeList.push(2_000_000);
-            spreadList.push(0);
-            //mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList,
-                spreadList,
+                2_000_000,
+                0,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -491,13 +480,10 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            sizeList.push(1000000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList,
-                spreadList64,
+                1_000_000,
+                type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -517,15 +503,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Alice,
-            $posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0)
-        );
-
+        pp.liquidate(new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -551,13 +529,10 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            sizeList.push(2_000_000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList,
-                spreadList,
+                2_000_000,
+                0,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -581,12 +556,10 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList1M,
-                spreadList64,
+                1_000_000,
+                type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -606,15 +579,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Alice,
-            $posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0)
-        );
-
+        pp.liquidate(new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -671,13 +636,10 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            sizeList.push(2000000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $setupIdList,
-                $setupIdList,
-                sizeList,
-                spreadList64,
+                2_000_000,
+                0,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -776,12 +738,10 @@ contract Misctest is Test, PositionUtils {
             $posIdList.push(posId);
 
             vm.startPrank(Alice);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList1M,
-                spreadList64,
+                1_000_000,
+                type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -801,15 +761,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Alice,
-            $posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0)
-        );
-
+        pp.liquidate(new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -834,14 +786,11 @@ contract Misctest is Test, PositionUtils {
             $setupIdList.push(posId);
 
             vm.startPrank(Bob);
-            sizeList.push(2000000);
 
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $setupIdList,
-                $setupIdList,
-                sizeList,
-                spreadList64,
+                2_000_000,
+                0,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -880,12 +829,10 @@ contract Misctest is Test, PositionUtils {
             $posIdList.push(posId);
 
             vm.startPrank(Alice);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList1M,
-                spreadList64,
+                1_000_000,
+                type(uint64).max,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -905,15 +852,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Alice,
-            $posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0)
-        );
-
+        pp.liquidate(new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -1420,23 +1359,18 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1462,23 +1396,18 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1496,26 +1425,19 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        sizeList.push(537);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            537,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
-        sizeList.pop();
-        sizeList.push(2_000_000);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1526,16 +1448,12 @@ contract Misctest is Test, PositionUtils {
             .wrap(0)
             .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
             .addLeg(0, 1, 0, 1, 0, 0, -224040, 3540);
-        sizeList.pop();
-        sizeList.push(537);
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            537,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1559,13 +1477,10 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 0, 0, 35, 1)
         );
 
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1580,23 +1495,18 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1620,13 +1530,10 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 1, 0, -35, 1)
         );
 
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1641,23 +1548,18 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1682,13 +1584,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Seller);
 
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1700,12 +1599,10 @@ contract Misctest is Test, PositionUtils {
             .addLeg(0, 1, 1, 1, 0, 0, 15, 1);
 
         vm.startPrank(Alice);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            type(uint64).max,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1731,11 +1628,10 @@ contract Misctest is Test, PositionUtils {
         PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        // force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Alice,
-            $posIdList,
+            $posIdList[0],
+            new TokenId[](0),
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
@@ -1803,39 +1699,30 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Seller);
-        sizeList.push(4_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            4_000_000,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         vm.startPrank(Alice);
-        sizeList.pop();
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         vm.startPrank(Bob);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1872,12 +1759,10 @@ contract Misctest is Test, PositionUtils {
             )
         );
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            type(uint64).max,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1886,101 +1771,84 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        //settleLong
-        pp.dispatchFrom(new TokenId[](0), Bob, $posIdList, $posIdList, LeftRightUnsigned.wrap(0));
+        pp.settleLongPremium($posIdList, Bob, 0, false);
 
         uint256 snap = vm.snapshotState();
-        //settleLong
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Bob,
-            $posIdList,
-            $posIdList,
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
+        pp.settleLongPremium($posIdList, Bob, 0, true);
 
         vm.revertToState(snap);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        //force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            $tempIdList,
             $tempIdList,
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        //force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            $tempIdList,
             $tempIdList,
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
 
-        //force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            $tempIdList,
             $tempIdList,
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
 
         snap = vm.snapshotState();
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        //force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            $tempIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        //force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            $tempIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
 
         uint256 snap2 = vm.snapshotState();
 
-        //force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
             $tempIdList,
+            new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
 
         vm.revertToState(snap2);
 
-        //force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
             $tempIdList,
+            new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
 
@@ -1989,12 +1857,9 @@ contract Misctest is Test, PositionUtils {
         $setupIdList.push($posIdList[1]);
 
         vm.startPrank(Bob);
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             $setupIdList,
-            sizeList1M,
-            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -2003,33 +1868,30 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        // force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
             new TokenId[](0),
+            $tempIdList,
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        // force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
             new TokenId[](0),
+            $tempIdList,
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
 
         snap2 = vm.snapshotState();
 
-        // force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
             new TokenId[](0),
+            $tempIdList,
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
 
@@ -2037,34 +1899,29 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        // force exercise
-        pp.dispatchFrom(
-            $tempIdList,
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
             new TokenId[](0),
+            $tempIdList,
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
 
         vm.revertToState(snap2);
 
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         snap2 = vm.snapshotState();
-        // force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            new TokenId[](0),
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
@@ -2073,11 +1930,10 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        // force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            new TokenId[](0),
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
@@ -2085,11 +1941,10 @@ contract Misctest is Test, PositionUtils {
         vm.revertToState(snap2);
 
         snap2 = vm.snapshotState();
-        // force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            new TokenId[](0),
             new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
@@ -2098,11 +1953,10 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        // force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Bob,
-            $posIdList,
+            $posIdList[1],
+            new TokenId[](0),
             new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
@@ -2132,13 +1986,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Seller);
 
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -2156,12 +2007,10 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            type(uint64).max,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -2187,11 +2036,10 @@ contract Misctest is Test, PositionUtils {
         twapTick = PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        // force exercise
-        pp.dispatchFrom(
-            new TokenId[](0),
+        pp.forceExercise(
             Alice,
-            $posIdList,
+            $posIdList[0],
+            new TokenId[](0),
             new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
@@ -2225,12 +2073,10 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2239,12 +2085,10 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(stdError.divisionError);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $tempIdList,
-            $tempIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2269,12 +2113,10 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2285,12 +2127,10 @@ contract Misctest is Test, PositionUtils {
         for (uint256 i; i < 257; ++i) longPositionList[i] = $posIdList[0];
 
         vm.expectRevert(stdError.arithmeticError);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             longPositionList,
-            longPositionList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2365,39 +2205,29 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         vm.startPrank(Alice);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
         vm.startPrank(Bob);
-        sizeList.push(1_000_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            1_000_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        $posIdLists[0].push($tempIdList[1]);
-        sizeList.pop();
-        sizeList.push(900_000_000);
-        // mint
-        pp.dispatch(
-            $posIdLists[0],
+        pp.mintOptions(
             $tempIdList,
-            sizeList,
-            spreadList64,
+            900_000_000,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2416,27 +2246,20 @@ contract Misctest is Test, PositionUtils {
 
         uint256 snap = vm.snapshot();
         vm.startPrank(Charlie);
-        sizeList.pop();
-        sizeList.push(250_000_000);
 
         for (uint256 i = 0; i < 10; i++) {
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList,
-                spreadList64,
+                250_000_000,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
             );
 
-            // burn
-            pp.dispatch(
-                $posIdList,
+            pp.burnOptions(
+                $posIdList[0],
                 new TokenId[](0),
-                sizeList,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2444,12 +2267,9 @@ contract Misctest is Test, PositionUtils {
         }
 
         vm.startPrank(Alice);
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2460,12 +2280,9 @@ contract Misctest is Test, PositionUtils {
         vm.revertTo(snap);
 
         vm.startPrank(Alice);
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2502,12 +2319,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2522,28 +2337,23 @@ contract Misctest is Test, PositionUtils {
 
         // the collectedAmount will always be a round number, so it's actually not possible to get a greater grossPremium than sum(collected, owed)
         // (owed and gross are both calculated from collectedAmount)
-        sizeList.push(250_000);
         for (uint256 i = 0; i < 1000; i++) {
             vm.startPrank(Alice);
             $tempIdList[0] = $posIdList[1];
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $tempIdList,
-                $tempIdList,
-                sizeList,
-                spreadList64,
+                250_000,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
             );
 
             vm.startPrank(Bob);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList,
-                spreadList64,
+                250_000,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2557,25 +2367,18 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
             $tempIdList[0] = $posIdList[0];
-            $posIdLists[0].push($posIdList[1]);
-            // burn
-            pp.dispatch(
-                $posIdLists[0],
+            pp.burnOptions(
+                $posIdList[1],
                 $tempIdList,
-                sizeList,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
             );
 
             vm.startPrank(Alice);
-            // burn
-            pp.dispatch(
-                $posIdList,
+            pp.burnOptions(
+                $posIdList[1],
                 new TokenId[](0),
-                sizeList,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2584,12 +2387,9 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // burn Bob's short option
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2616,12 +2416,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2636,14 +2434,11 @@ contract Misctest is Test, PositionUtils {
 
         // only 20 tokens actually settled, but 22 owed... 2 tokens taken from PLPs
         // we may need to redefine availablePremium as max(availablePremium, settledTokens)
-        sizeList.push(499_999);
         for (uint256 i = 0; i < 10; i++) {
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdList,
-                $posIdList,
-                sizeList,
-                spreadList64,
+                499_999,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2654,13 +2449,9 @@ contract Misctest is Test, PositionUtils {
             accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1, 1);
             swapperc.swapTo(uniPool, 2 ** 96);
             vm.startPrank(Bob);
-            // burn
-            $posIdLists[0].push($posIdList[1]);
-            pp.dispatch(
-                $posIdLists[0],
+            pp.burnOptions(
+                $posIdList[1],
                 $tempIdList,
-                sizeList,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2668,12 +2459,9 @@ contract Misctest is Test, PositionUtils {
         }
 
         // burn Bob's short option
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2703,13 +2491,10 @@ contract Misctest is Test, PositionUtils {
         // 8.896% * 1.022x vegoid = +~10% of the fee amount accumulated will be owed by sellers
         vm.startPrank(Alice);
 
-        sizeList.push(500_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdLists[0],
-            $posIdLists[0],
-            sizeList,
-            spreadList64,
+            500_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2717,14 +2502,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        sizeList.pop();
-        sizeList.push(250_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdLists[0],
-            $posIdLists[0],
-            sizeList,
-            spreadList64,
+            250_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2732,12 +2513,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Charlie);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdLists[0],
-            $posIdLists[0],
-            sizeList,
-            spreadList64,
+            250_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2753,14 +2532,10 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 1, 0, -15, 1)
         );
 
-        sizeList.pop();
-        sizeList.push(1_000_000_000 - 9_884_444 * 3);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdLists[1],
-            $posIdLists[1],
-            sizeList,
-            spreadList64,
+            1_000_000_000 - 9_884_444 * 3,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2774,16 +2549,12 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 1, 0, 0, 15, 1)
         );
 
-        sizeList.pop();
-        sizeList.push(9_884_444);
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdLists[2],
-                $posIdLists[2],
-                sizeList,
-                spreadList64,
+                9_884_444,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2801,12 +2572,10 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdLists[2],
-                $posIdLists[2],
-                sizeList,
-                spreadList64,
+                9_884_444,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2824,12 +2593,10 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdLists[2],
-                $posIdLists[2],
-                sizeList,
-                spreadList64,
+                9_884_444,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2844,17 +2611,12 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 1, 1, 0, -15, 1)
         );
 
-        sizeList.pop();
-        sizeList.push(19_768_888);
-
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdLists[2],
-                $posIdLists[2],
-                sizeList,
-                spreadList64,
+                19_768_888,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -3024,14 +2786,7 @@ contract Misctest is Test, PositionUtils {
 
         // collect buyer 1's three relevant chunks
         for (uint256 i = 0; i < 3; ++i) {
-            // settle long
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[0],
-                collateralIdLists[i],
-                collateralIdLists[i],
-                LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
-            );
+            pp.settleLongPremium(collateralIdLists[i], Buyers[0], 0, true);
         }
 
         assertEq(
@@ -3052,12 +2807,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Bob));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
-        // burn
-        pp.dispatch(
-            $posIdLists[0],
+        pp.burnOptions(
+            $posIdLists[0][0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3084,13 +2836,10 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 0, 0, 15, 1)
         );
 
-        sizeList.push(1_000_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdLists[1],
-            $posIdLists[1],
-            sizeList,
-            spreadList64,
+            1_000_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3106,21 +2855,9 @@ contract Misctest is Test, PositionUtils {
         // now, settle the dummy chunks for all the buyers/positions and see that the settled ratio for primary doesn't change
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            // settle long
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[1],
-                collateralIdLists[1],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[3],
-                collateralIdLists[3],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
+            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
+
+            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -3165,12 +2902,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
-        // burn
-        pp.dispatch(
-            $posIdLists[0],
+        pp.burnOptions(
+            $posIdLists[0][0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3196,23 +2930,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            // settle long
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[1],
-                collateralIdLists[1],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
+            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
 
-            // settle long
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[3],
-                collateralIdLists[3],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
+            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -3260,30 +2980,11 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            // settle long
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[0],
-                collateralIdLists[0],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
-            // settle long
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[1],
-                collateralIdLists[1],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
-            // settle long
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[3],
-                collateralIdLists[3],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
+            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
+
+            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 0, true);
+
+            pp.settleLongPremium(collateralIdLists[2], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -3328,12 +3029,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        // burn
-        pp.dispatch(
-            $posIdLists[0],
+        pp.burnOptions(
+            $posIdLists[0][0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3352,14 +3050,7 @@ contract Misctest is Test, PositionUtils {
 
         // test long leg validation
         vm.expectRevert(Errors.NotALongLeg.selector);
-        // settle long
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Buyers[0],
-            collateralIdLists[2],
-            collateralIdLists[2],
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
+        pp.settleLongPremium(collateralIdLists[2], Buyers[0], 1, true);
 
         // test positionIdList validation
         // snapshot so we don't have to reset changes to collateralIdLists array
@@ -3367,14 +3058,7 @@ contract Misctest is Test, PositionUtils {
 
         collateralIdLists[0].pop();
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Buyers[0],
-            collateralIdLists[0],
-            collateralIdLists[0],
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
-
+        pp.settleLongPremium(collateralIdLists[0], Buyers[0], 0, true);
         vm.revertTo(snap);
 
         // test collateral checking (basic)
@@ -3385,14 +3069,7 @@ contract Misctest is Test, PositionUtils {
             deal(address(ct0), Buyers[i], i ** 15);
             deal(address(ct1), Buyers[i], i ** 15);
             vm.expectRevert(Errors.AccountInsolvent.selector);
-            // settleLong
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Buyers[i],
-                collateralIdLists[0],
-                collateralIdLists[0],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
-            );
+            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
             vm.revertTo(snap);
         }
 
@@ -3401,12 +3078,9 @@ contract Misctest is Test, PositionUtils {
             assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[i]));
             assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[i]));
             vm.startPrank(Buyers[i]);
-            // burn
-            pp.dispatch(
-                $posIdLists[0],
+            pp.burnOptions(
+                $posIdLists[2],
                 new TokenId[](0),
-                sizeList1M,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -3455,13 +3129,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        sizeList.push(100_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdLists[0],
-            $posIdLists[0],
-            sizeList,
-            spreadList64,
+            100_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3482,12 +3153,10 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < 3; ++i) {
             vm.startPrank(Buyers[i]);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 $posIdLists[1],
-                $posIdLists[1],
-                sizeList1M,
-                spreadList64,
+                1_000_000,
+                type(uint64).max,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -3517,14 +3186,7 @@ contract Misctest is Test, PositionUtils {
         uint256 settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[0]));
         uint256 settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[0]));
 
-        // settle long
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Buyers[0],
-            $posIdLists[1],
-            $posIdLists[1],
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
+        pp.settleLongPremium($posIdLists[1], Buyers[0], 0, true);
 
         int256 balanceDelta0 = int256(ct0.convertToAssets(ct0.balanceOf(Buyers[0]))) -
             int256(settleeBalanceBefore0);
@@ -3556,14 +3218,7 @@ contract Misctest is Test, PositionUtils {
         settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[1]));
         settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[1]));
 
-        // settle long
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Buyers[1],
-            $posIdLists[1],
-            $posIdLists[1],
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
+        pp.settleLongPremium($posIdLists[1], Buyers[1], 0, true);
 
         balanceDelta0 =
             int256(ct0.convertToAssets(ct0.balanceOf(Buyers[1]))) -
@@ -3593,14 +3248,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Buyers[2], 0);
 
         vm.expectRevert(stdError.arithmeticError);
-        // settle long
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Buyers[2],
-            $posIdLists[1],
-            $posIdLists[1],
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
+        pp.settleLongPremium($posIdLists[1], Buyers[2], 0, true);
     }
 
     function test_success_settledPremiumDistribution() public {
@@ -3631,13 +3279,10 @@ contract Misctest is Test, PositionUtils {
         // Finally, close Charlie's position, they should receive ~27.5% (25% + 10% * 25%)
         vm.startPrank(Alice);
 
-        sizeList.push(500_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            500_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3645,14 +3290,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        sizeList.pop();
-        sizeList.push(250_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            250_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3660,12 +3301,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Charlie);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            250_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3680,16 +3319,11 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        $posIdLists[0].push($posIdList[1]);
-        sizeList.pop();
-        sizeList.push(44_468);
         // mint finely tuned amount of long options for Alice so premium paid = 1.1x
-        // mint
-        pp.dispatch(
-            $posIdLists[0],
+        pp.mintOptions(
             $posIdList,
-            sizeList,
-            spreadList64,
+            44_468,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3698,12 +3332,10 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         // mint finely tuned amount of long options for Bob so premium paid = 1.1x
-        // mint
-        pp.dispatch(
-            $posIdLists[0],
+        pp.mintOptions(
             $posIdList,
-            sizeList,
-            spreadList64,
+            44_468,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3727,12 +3359,9 @@ contract Misctest is Test, PositionUtils {
         $tempIdList.push($posIdList[1]);
 
         // burn Bob's short option
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             $tempIdList,
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3752,12 +3381,10 @@ contract Misctest is Test, PositionUtils {
         // re-mint the short option
         $posIdList[1] = $posIdList[0];
         $posIdList[0] = $tempIdList[0];
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3767,13 +3394,9 @@ contract Misctest is Test, PositionUtils {
 
         // Burn the long options, adds 1/2 of the removed liq
         // amount of premia paid = 50_000
-        $posIdLists[0].push($posIdList[0]);
-        // burn
-        pp.dispatch(
-            $posIdLists[0],
+        pp.burnOptions(
+            $posIdList[0],
             $tempIdList,
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3786,13 +3409,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         $tempIdList[0] = $posIdList[0];
-        $posIdLists[1].push($posIdList[1]);
-        // burn
-        pp.dispatch(
-            $posIdLists[1],
+        pp.burnOptions(
+            $posIdList[1],
             $tempIdList,
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3810,12 +3429,9 @@ contract Misctest is Test, PositionUtils {
         );
 
         // Burn other half of the removed liq
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3827,12 +3443,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[1],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3868,12 +3481,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3903,12 +3514,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3938,12 +3547,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3974,12 +3581,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4038,13 +3643,10 @@ contract Misctest is Test, PositionUtils {
         // mint fails
         vm.expectRevert(Errors.AccountInsolvent.selector);
         //vm.expectRevert();
-        // mint
-        sizeList.push(100_000);
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4096,13 +3698,10 @@ contract Misctest is Test, PositionUtils {
 
         // mint fails
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        // mint
-        sizeList.push(100_000);
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4156,14 +3755,11 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(17_818, Bob);
 
-        sizeList.push(100_000);
         // mint succeeds
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4212,14 +3808,7 @@ contract Misctest is Test, PositionUtils {
         IERC20Partial(ct0.asset()).approve(address(ct0), 1_000_000);
         IERC20Partial(ct1.asset()).approve(address(ct1), 1_000_000);
 
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Bob,
-            $posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
+        pp.liquidate(new TokenId[](0), Bob, $posIdList);
 
         (uint256 after0, uint256 after1) = (
             ct0.convertToAssets(ct0.balanceOf(Bob)),
@@ -4249,13 +3838,10 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(150504, Bob);
         ct1.deposit(0, Bob);
 
-        sizeList.push(100_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4334,14 +3920,11 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(17_820, Bob);
 
-        sizeList.push(100_000);
         // mint succeeds
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4388,14 +3971,7 @@ contract Misctest is Test, PositionUtils {
         IERC20Partial(ct0.asset()).approve(address(ct0), 1_000_000);
         IERC20Partial(ct1.asset()).approve(address(ct1), 1_000_000);
 
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Bob,
-            $posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
-        );
+        pp.liquidate(new TokenId[](0), Bob, $posIdList);
 
         (uint256 after0, uint256 after1) = (
             ct0.convertToAssets(ct0.balanceOf(Bob)),
@@ -4425,13 +4001,10 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(150466, Bob);
 
-        sizeList.push(100_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4481,12 +4054,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4643,14 +4214,11 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(0, Bob);
 
-        sizeList.push(100_000);
         // not in safeMode, mint with minimum
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4675,14 +4243,11 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(0, Bob);
 
-        sizeList.push(100_000);
         // can mint covered positions
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4747,14 +4312,11 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(0, Bob);
 
         // in safeMode, enforce covered mints, reverts
-        sizeList.push(100_000);
         vm.expectRevert();
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4768,12 +4330,10 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(181_183, Bob); //
 
         // can mint covered positions
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4829,13 +4389,10 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(2_000, Bob);
 
-        sizeList.push(100_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            100_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4853,12 +4410,9 @@ contract Misctest is Test, PositionUtils {
 
         console2.log("00");
         vm.expectRevert();
-        // burn
-        pp.dispatch(
+        pp.burnOptions(
             $posIdList,
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4870,12 +4424,9 @@ contract Misctest is Test, PositionUtils {
         // Add just enough to cover the covered exercise:
         ct1.deposit(98_300, Bob);
 
-        // burn
-        pp.dispatch(
+        pp.burnOptions(
             $posIdList,
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4922,23 +4473,17 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        sizeList.push(500_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            500_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4952,12 +4497,10 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            500_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5031,13 +4574,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        sizeList.push(500_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            500_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5051,12 +4591,9 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
-        // burn
-        pp.dispatch(
-            $posIdList,
+        pp.burnOptions(
+            $posIdList[0],
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5112,17 +4649,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        sizeList.push(2 ** 95);
-        // mint
-        pp.dispatch(
-            $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
-            int24(887272),
-            int24(-887272),
-            true
-        );
+        pp.mintOptions($posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
 
         (, , uint256[2][] memory positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Bob,
@@ -5156,16 +4683,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(requiredCross > 0, "zero collateral requirement");
         assertTrue(requiredCross <= balanceCross, "account is solvent");
 
-        // burn
-        pp.dispatch(
-            $posIdList,
-            new TokenId[](0),
-            sizeList1M,
-            spreadList64,
-            int24(887272),
-            int24(-887272),
-            true
-        );
+        pp.burnOptions($posIdList[0], new TokenId[](0), int24(887272), int24(-887272), true);
     }
 
     function test_success_PremiumRollover() public {
@@ -5185,18 +4703,8 @@ contract Misctest is Test, PositionUtils {
         posIdList[0] = tokenId;
 
         vm.startPrank(Bob);
-        sizeList.push(3);
         // mint 1 liquidity unit of wideish centered position
-        // mint
-        pp.dispatch(
-            posIdList,
-            posIdList,
-            sizeList,
-            spreadList64,
-            Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            true
-        );
+        pp.mintOptions(posIdList, 3, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK, true);
 
         vm.startPrank(Swapper);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
@@ -5212,12 +4720,9 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // works fine
-        // burn
-        pp.dispatch(
-            posIdList,
+        pp.burnOptions(
+            tokenId,
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5229,13 +4734,10 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         // lock in almost-overflowed fees per liquidity
-        sizeList.push(1_000_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             posIdList,
-            posIdList,
-            sizeList,
-            spreadList64,
+            1_000_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5269,12 +4771,9 @@ contract Misctest is Test, PositionUtils {
         // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!)
         // + fee to move price initially (if applicable)
         // The solution is to freeze fee accumulation if one of the token accumulators overflow
-        // burn
-        pp.dispatch(
-            posIdList,
+        pp.burnOptions(
+            tokenId,
             new TokenId[](0),
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5333,13 +4832,10 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5359,12 +4855,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5379,12 +4873,9 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
 
             vm.startPrank(Alice);
-            // burn
-            pp.dispatch(
-                $posIdList,
+            pp.burnOptions(
+                $posIdList[0],
                 new TokenId[](0),
-                sizeList1M,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5448,13 +4939,10 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList,
+            2_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5474,12 +4962,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5494,12 +4980,9 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(int16(ticks[i])));
 
             vm.startPrank(Alice);
-            // burn
-            pp.dispatch(
-                $posIdList,
+            pp.burnOptions(
+                $posIdList[0],
                 new TokenId[](0),
-                sizeList1M,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5545,13 +5028,10 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        sizeList.push(2_000_000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            2_000_000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5571,12 +5051,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList1M,
-            spreadList64,
+            1_000_000,
+            type(uint64).max,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5591,12 +5069,9 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
 
             vm.startPrank(Alice);
-            // burn
-            pp.dispatch(
-                $posIdList,
+            pp.burnOptions(
+                $posIdList[0],
                 new TokenId[](0),
-                sizeList1M,
-                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5653,13 +5128,10 @@ contract Misctest is Test, PositionUtils {
 
         uint256 totalSupplyBefore = ct1.totalSupply() - ct1.convertToShares(1_003_003);
 
-        sizeList.push(1_003_003);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             $posIdList,
-            $posIdList,
-            sizeList,
-            spreadList64,
+            1_003_003,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5676,14 +5148,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         vm.startPrank(Charlie);
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Bob,
-            $posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0)
-        );
+        pp.liquidate(new TokenId[](0), Bob, $posIdList);
 
         assertLe(ct1.totalSupply() / totalSupplyBefore, 10_000, "protocol loss failed to cap");
     }
@@ -5725,13 +5190,10 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5818,14 +5280,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquudate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -5889,14 +5344,11 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        sizeList.push(3000);
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             posIdList,
-            posIdList,
-            sizeList,
-            spreadList64,
+            3000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5937,13 +5389,10 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        sizeList.push(3000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             posIdList,
-            posIdList,
-            sizeList,
-            spreadList64,
+            3000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5960,16 +5409,11 @@ contract Misctest is Test, PositionUtils {
 
         posIdList2[1] = tokenId2;
 
-        sizeList.pop();
-        sizeList.push(10);
-        $posIdLists[0].push(posIdList2[1]);
         // mint second option
-        // mint
-        pp.dispatch(
-            $posIdLists[0],
+        pp.mintOptions(
             posIdList2,
-            sizeList,
-            spreadList64,
+            10,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -6006,13 +5450,9 @@ contract Misctest is Test, PositionUtils {
 
         // burn second option
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        $posIdLists[0].push(posIdList2[1]);
-        // burn
-        pp.dispatch(
-            $posIdLists[0],
+        pp.burnOptions(
+            posIdList2[1],
             posIdList,
-            sizeList1M,
-            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -6053,13 +5493,10 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        sizeList.push(3000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             posIdList,
-            posIdList,
-            sizeList,
-            spreadList,
+            3000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -6153,14 +5590,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.NotMarginCalled.selector);
-        // liquidate
-        pp.dispatchFrom(
-            new TokenId[](0),
-            Bob,
-            posIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0)
-        );
+        pp.liquidate(new TokenId[](0), Bob, posIdList);
     }
 
     function test_success_liquidation_currentTick_bonusOptimization_scenarios() public {
@@ -6197,13 +5627,10 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        sizeList.push(3000);
-        // mint
-        pp.dispatch(
+        pp.mintOptions(
             posIdList,
-            posIdList,
-            sizeList,
-            spreadList64,
+            3000,
+            0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -6274,14 +5701,7 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(int24(twapTick) + t));
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             unchecked {
                 if (
@@ -6341,13 +5761,10 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6391,14 +5808,7 @@ contract Misctest is Test, PositionUtils {
             vm.startPrank(Alice);
             console2.log("");
             console2.log("no-cross collateral", i);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6435,13 +5845,10 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6483,14 +5890,7 @@ contract Misctest is Test, PositionUtils {
             vm.startPrank(Alice);
             console2.log("");
             console2.log("cross collateral", i);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6545,13 +5945,10 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6592,14 +5989,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquidat
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6651,14 +6041,10 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 5);
             ct1.deposit(5, Bob);
 
-            sizeList.push(3000);
-
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6699,14 +6085,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            //liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6758,13 +6137,10 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6806,14 +6182,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Alice);
 
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6858,13 +6227,10 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6904,14 +6270,7 @@ contract Misctest is Test, PositionUtils {
             console2.log("no cross collateral", i);
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6949,13 +6308,10 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6998,14 +6354,7 @@ contract Misctest is Test, PositionUtils {
             console2.log("");
             console2.log("cross collateral", i);
 
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -7060,13 +6409,10 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(3000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -7104,14 +6450,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -7162,14 +6501,11 @@ contract Misctest is Test, PositionUtils {
             ct0.deposit(1000, Bob);
             token1.approve(address(ct1), 15);
             ct1.deposit(15, Bob);
-            sizeList.push(3000);
 
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -7206,14 +6542,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -7264,14 +6593,11 @@ contract Misctest is Test, PositionUtils {
             ct0.deposit(15, Bob);
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
-            sizeList.push(3000);
 
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                3000,
+                0,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -7308,14 +6634,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
             vm.revertTo(snapshot);
         }
 
@@ -7347,12 +6666,10 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                // mint
-                pp.dispatch(
+                pp.mintOptions(
                     posIdList,
-                    posIdList,
-                    sizeList1M,
-                    spreadList64,
+                    1_000_000,
+                    0,
                     Constants.MAX_V3POOL_TICK,
                     Constants.MIN_V3POOL_TICK,
                     true
@@ -7399,14 +6716,10 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(10_000);
-            spreadList.push(2 ** 30);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList,
+                10_000,
+                2 ** 30,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -7444,14 +6757,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -7484,12 +6790,10 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                // mint
-                pp.dispatch(
+                pp.mintOptions(
                     posIdList,
-                    posIdList,
-                    sizeList1M,
-                    spreadList64,
+                    1_000_000,
+                    0,
                     Constants.MAX_V3POOL_TICK,
                     Constants.MIN_V3POOL_TICK,
                     true
@@ -7536,14 +6840,10 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(150, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(10000);
-            spreadList.push(2 ** 30);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList,
+                10_000,
+                2 ** 30,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -7580,14 +6880,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -7620,12 +6913,10 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                // mint
-                pp.dispatch(
+                pp.mintOptions(
                     posIdList,
-                    posIdList,
-                    sizeList1M,
-                    spreadList64,
+                    1_000_000,
+                    0,
                     Constants.MAX_V3POOL_TICK,
                     Constants.MIN_V3POOL_TICK,
                     true
@@ -7672,13 +6963,10 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(2500, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            sizeList.push(10_000);
-            // mint
-            pp.dispatch(
+            pp.mintOptions(
                 posIdList,
-                posIdList,
-                sizeList,
-                spreadList64,
+                10_000,
+                2 ** 30,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -7715,14 +7003,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            // liquidate
-            pp.dispatchFrom(
-                new TokenId[](0),
-                Bob,
-                posIdList,
-                new TokenId[](0),
-                LeftRightUnsigned.wrap(0)
-            );
+            pp.liquidate(new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1831,20 +1831,14 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(address(pp));
-        CollateralTracker(collateralReference).takeCommissionAddData(
-            Alice,
-            0,
-            0,
-            1_000_000_000,
-            false
-        );
+        CollateralTracker(collateralReference).settleMint(Alice, 0, 0, 1_000_000_000);
         assertEq(
             1_000_000_000_000_000 -
                 1 -
                 CollateralTracker(collateralReference).convertToAssets(
                     CollateralTracker(collateralReference).balanceOf(Alice)
                 ),
-            1_000_000_000 + 2000
+            1_000_000_000 + 2000 * 0
         );
     }
 
@@ -5062,9 +5056,10 @@ contract Misctest is Test, PositionUtils {
         // make sure Alice earns no fees on token 0 (her delta is slightly negative due to commission fees/precision etc)
         // the accumulator overflowed, so the accumulation was frozen. If she had poked before the accumulator overflowed,
         // she could have still earned some fees, but now the accumulation is frozen forever.
+        // old with itmSpreadFee = -1244790
         assertEq(
             int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore0),
-            -1244790
+            -930817
         );
 
         // but she earns all of fees on token 1 since the premium accumulator did not overflow (!)

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -202,7 +202,7 @@ contract Misctest is Test, PositionUtils {
         // deploy reference pool and collateral token
         poolReference = address(new PanopticPool(sfpm));
         collateralReference = address(
-            new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000, 20_000)
+            new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000)
         );
         token0 = new ERC20S("token0", "T0", 18);
         token1 = new ERC20S("token1", "T1", 18);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -121,6 +121,146 @@ contract SwapperC {
     }
 }
 
+// Inherits all of PanopticPool's functionality and adds legacy mint/burn/liquidate/forceExercise/settle access
+contract PanopticPoolHarness is PanopticPool {
+    constructor(SemiFungiblePositionManager _SFPM) PanopticPool(_SFPM) {}
+
+    function mintOptions(
+        TokenId[] memory positionIdList,
+        uint128 positionSize,
+        uint64 effectiveLiquidityLimitX32,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory mintList = new TokenId[](1);
+
+        TokenId tokenId = positionIdList[positionIdList.length - 1];
+        sizeList[0] = positionSize;
+        spreadList[0] = effectiveLiquidityLimitX32;
+        mintList[0] = tokenId;
+        this.dispatch(
+            mintList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        TokenId tokenId,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory burnList = new TokenId[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+        burnList[0] = tokenId;
+        this.dispatch(
+            burnList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        TokenId[] memory tokenIds,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+
+        this.dispatch(
+            tokenIds,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function liquidate(
+        TokenId[] memory liquidatorList,
+        address liquidatee,
+        TokenId[] memory positionIdList
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        this.dispatchFrom(
+            liquidatorList,
+            liquidatee,
+            positionIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function forceExercise(
+        address exercisee,
+        TokenId tokenId,
+        TokenId[] memory exerciseeList,
+        TokenId[] memory exercisorList,
+        LeftRightUnsigned premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        this.dispatchFrom(
+            exercisorList,
+            exercisee,
+            targetList,
+            exerciseeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function settleLongPremium(
+        TokenId[] memory settlerList,
+        TokenId[] memory settleeList,
+        address exercisee,
+        uint256 legIndex,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        this.dispatchFrom(
+            settlerList,
+            exercisee,
+            targetList,
+            settleeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+}
+
 // mostly just fixed one-off tests/PoC
 contract Misctest is Test, PositionUtils {
     // the instance of SFPM we are testing
@@ -138,7 +278,7 @@ contract Misctest is Test, PositionUtils {
     ISwapRouter router = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
 
     PanopticFactory factory;
-    PanopticPool pp;
+    PanopticPoolHarness pp;
     CollateralTracker ct0;
     CollateralTracker ct1;
     PanopticHelper ph;
@@ -200,7 +340,7 @@ contract Misctest is Test, PositionUtils {
         ph = new PanopticHelper(sfpm);
 
         // deploy reference pool and collateral token
-        poolReference = address(new PanopticPool(sfpm));
+        poolReference = address(new PanopticPoolHarness(sfpm));
         collateralReference = address(
             new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000, 20_000)
         );
@@ -330,7 +470,7 @@ contract Misctest is Test, PositionUtils {
         token0.approve(address(factory), type(uint104).max);
         token1.approve(address(factory), type(uint104).max);
 
-        pp = PanopticPool(
+        pp = PanopticPoolHarness(
             address(
                 factory.deployNewPool(
                     address(token0),
@@ -1708,9 +1848,10 @@ contract Misctest is Test, PositionUtils {
             true
         );
 
+        $posIdLists[0].push($posIdList[0]);
         vm.startPrank(Alice);
         pp.mintOptions(
-            $posIdList,
+            $posIdLists[0],
             2_000_000,
             0,
             Constants.MIN_V3POOL_TICK,
@@ -1771,10 +1912,10 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.settleLongPremium($posIdList, Bob, 0, false);
+        pp.settleLongPremium($posIdLists[0], $posIdList, Bob, 0, false);
 
         uint256 snap = vm.snapshotState();
-        pp.settleLongPremium($posIdList, Bob, 0, true);
+        pp.settleLongPremium($posIdLists[0], $posIdList, Bob, 0, true);
 
         vm.revertToState(snap);
 
@@ -2786,7 +2927,7 @@ contract Misctest is Test, PositionUtils {
 
         // collect buyer 1's three relevant chunks
         for (uint256 i = 0; i < 3; ++i) {
-            pp.settleLongPremium(collateralIdLists[i], Buyers[0], 0, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[i], Buyers[0], 0, true);
         }
 
         assertEq(
@@ -2855,9 +2996,9 @@ contract Misctest is Test, PositionUtils {
         // now, settle the dummy chunks for all the buyers/positions and see that the settled ratio for primary doesn't change
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[1], Buyers[i], 1, true);
 
-            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -2930,9 +3071,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[1], Buyers[i], 1, true);
 
-            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -2980,11 +3121,11 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[0], Buyers[i], 0, true);
 
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 0, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[1], Buyers[i], 0, true);
 
-            pp.settleLongPremium(collateralIdLists[2], Buyers[i], 0, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[2], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -3050,7 +3191,7 @@ contract Misctest is Test, PositionUtils {
 
         // test long leg validation
         vm.expectRevert(Errors.NotALongLeg.selector);
-        pp.settleLongPremium(collateralIdLists[2], Buyers[0], 1, true);
+        pp.settleLongPremium(new TokenId[](0), collateralIdLists[2], Buyers[0], 1, true);
 
         // test positionIdList validation
         // snapshot so we don't have to reset changes to collateralIdLists array
@@ -3058,7 +3199,7 @@ contract Misctest is Test, PositionUtils {
 
         collateralIdLists[0].pop();
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.settleLongPremium(collateralIdLists[0], Buyers[0], 0, true);
+        pp.settleLongPremium(new TokenId[](0), collateralIdLists[0], Buyers[0], 0, true);
         vm.revertTo(snap);
 
         // test collateral checking (basic)
@@ -3069,7 +3210,7 @@ contract Misctest is Test, PositionUtils {
             deal(address(ct0), Buyers[i], i ** 15);
             deal(address(ct1), Buyers[i], i ** 15);
             vm.expectRevert(Errors.AccountInsolvent.selector);
-            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
+            pp.settleLongPremium(new TokenId[](0), collateralIdLists[0], Buyers[i], 0, true);
             vm.revertTo(snap);
         }
 
@@ -3186,7 +3327,7 @@ contract Misctest is Test, PositionUtils {
         uint256 settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[0]));
         uint256 settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[0]));
 
-        pp.settleLongPremium($posIdLists[1], Buyers[0], 0, true);
+        pp.settleLongPremium($posIdLists[0], $posIdLists[1], Buyers[0], 0, true);
 
         int256 balanceDelta0 = int256(ct0.convertToAssets(ct0.balanceOf(Buyers[0]))) -
             int256(settleeBalanceBefore0);
@@ -3218,7 +3359,7 @@ contract Misctest is Test, PositionUtils {
         settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[1]));
         settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[1]));
 
-        pp.settleLongPremium($posIdLists[1], Buyers[1], 0, true);
+        pp.settleLongPremium($posIdLists[0], $posIdLists[1], Buyers[1], 0, true);
 
         balanceDelta0 =
             int256(ct0.convertToAssets(ct0.balanceOf(Buyers[1]))) -
@@ -3248,7 +3389,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Buyers[2], 0);
 
         vm.expectRevert(stdError.arithmeticError);
-        pp.settleLongPremium($posIdLists[1], Buyers[2], 0, true);
+        pp.settleLongPremium($posIdLists[0], $posIdLists[1], Buyers[2], 0, true);
     }
 
     function test_success_settledPremiumDistribution() public {
@@ -4572,6 +4713,7 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 59);
         vm.roll(block.number + 1);
 
+        console2.log("safe", pp.isSafeMode());
         vm.startPrank(Alice);
 
         pp.mintOptions(

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -186,6 +186,11 @@ contract Misctest is Test, PositionUtils {
     TokenId[][] $posIdLists;
     TokenId[] $tempIdList;
 
+    uint128[] sizeList;
+    uint128[] sizeList1M;
+    uint64[] spreadList;
+    uint64[] spreadList64;
+
     address[] owners;
     TokenId[] tokenIdsTemp;
     TokenId[][] tokenIds;
@@ -310,6 +315,8 @@ contract Misctest is Test, PositionUtils {
         for (uint256 i = 0; i < 20; ++i) {
             $posIdLists.push(new TokenId[](0));
         }
+        spreadList64.push(type(uint64).max);
+        sizeList1M.push(1_000_000);
     }
 
     function _createPanopticPool() internal {
@@ -422,10 +429,14 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            pp.mintOptions(
+            sizeList.push(2_000_000);
+            spreadList.push(0);
+            //mint
+            pp.dispatch(
                 $posIdList,
-                2_000_000,
-                0,
+                $posIdList,
+                sizeList,
+                spreadList,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -480,10 +491,13 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            sizeList.push(1000000);
+            // mint
+            pp.dispatch(
                 $posIdList,
-                1_000_000,
-                type(uint64).max,
+                $posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -503,7 +517,15 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Alice,
+            $posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0)
+        );
+
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -529,10 +551,13 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            pp.mintOptions(
+            sizeList.push(2_000_000);
+            // mint
+            pp.dispatch(
                 $posIdList,
-                2_000_000,
-                0,
+                $posIdList,
+                sizeList,
+                spreadList,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -556,10 +581,12 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdList,
-                1_000_000,
-                type(uint64).max,
+                $posIdList,
+                sizeList1M,
+                spreadList64,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -579,7 +606,15 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Alice,
+            $posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0)
+        );
+
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -636,10 +671,13 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            pp.mintOptions(
+            sizeList.push(2000000);
+            // mint
+            pp.dispatch(
                 $setupIdList,
-                2_000_000,
-                0,
+                $setupIdList,
+                sizeList,
+                spreadList64,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -738,10 +776,12 @@ contract Misctest is Test, PositionUtils {
             $posIdList.push(posId);
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdList,
-                1_000_000,
-                type(uint64).max,
+                $posIdList,
+                sizeList1M,
+                spreadList64,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -761,7 +801,15 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Alice,
+            $posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0)
+        );
+
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -786,11 +834,14 @@ contract Misctest is Test, PositionUtils {
             $setupIdList.push(posId);
 
             vm.startPrank(Bob);
+            sizeList.push(2000000);
 
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $setupIdList,
-                2_000_000,
-                0,
+                $setupIdList,
+                sizeList,
+                spreadList64,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -829,10 +880,12 @@ contract Misctest is Test, PositionUtils {
             $posIdList.push(posId);
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdList,
-                1_000_000,
-                type(uint64).max,
+                $posIdList,
+                sizeList1M,
+                spreadList64,
                 Constants.MIN_V3POOL_TICK,
                 Constants.MAX_V3POOL_TICK,
                 true
@@ -852,7 +905,15 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Alice,
+            $posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0)
+        );
+
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -1359,18 +1420,23 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1396,18 +1462,23 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1425,19 +1496,26 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        pp.mintOptions(
+        sizeList.push(537);
+        // mint
+        pp.dispatch(
             $posIdList,
-            537,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
+        sizeList.pop();
+        sizeList.push(2_000_000);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1448,12 +1526,16 @@ contract Misctest is Test, PositionUtils {
             .wrap(0)
             .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
             .addLeg(0, 1, 0, 1, 0, 0, -224040, 3540);
+        sizeList.pop();
+        sizeList.push(537);
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            537,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1477,10 +1559,13 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 0, 0, 35, 1)
         );
 
-        pp.mintOptions(
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1495,18 +1580,23 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1530,10 +1620,13 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 1, 0, -35, 1)
         );
 
-        pp.mintOptions(
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1548,18 +1641,23 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -1584,10 +1682,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Seller);
 
-        pp.mintOptions(
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1599,10 +1700,12 @@ contract Misctest is Test, PositionUtils {
             .addLeg(0, 1, 1, 1, 0, 0, 15, 1);
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1628,10 +1731,11 @@ contract Misctest is Test, PositionUtils {
         PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        pp.forceExercise(
-            Alice,
-            $posIdList[0],
+        // force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Alice,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
@@ -1699,30 +1803,39 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Seller);
-        pp.mintOptions(
+        sizeList.push(4_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            4_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        sizeList.pop();
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         vm.startPrank(Bob);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1759,10 +1872,12 @@ contract Misctest is Test, PositionUtils {
             )
         );
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1771,84 +1886,101 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.settleLongPremium($posIdList, Bob, 0, false);
+        //settleLong
+        pp.dispatchFrom(new TokenId[](0), Bob, $posIdList, $posIdList, LeftRightUnsigned.wrap(0));
 
         uint256 snap = vm.snapshotState();
-        pp.settleLongPremium($posIdList, Bob, 0, true);
+        //settleLong
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Bob,
+            $posIdList,
+            $posIdList,
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
 
         vm.revertToState(snap);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        //force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
             $tempIdList,
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        //force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
             $tempIdList,
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
 
-        vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        //force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
             $tempIdList,
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
 
         snap = vm.snapshotState();
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        //force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        //force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
 
         uint256 snap2 = vm.snapshotState();
 
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
-            $tempIdList,
+        //force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Bob,
+            $posIdList,
+            $tempIdList,
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
 
         vm.revertToState(snap2);
 
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
-            $tempIdList,
+        //force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Bob,
+            $posIdList,
+            $tempIdList,
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
 
@@ -1857,9 +1989,12 @@ contract Misctest is Test, PositionUtils {
         $setupIdList.push($posIdList[1]);
 
         vm.startPrank(Bob);
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             $setupIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -1868,30 +2003,33 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
-            new TokenId[](0),
+        // force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
+            new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
-            new TokenId[](0),
+        // force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
+            new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
-            new TokenId[](0),
+        // force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
+            new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
 
@@ -1899,29 +2037,34 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
-            new TokenId[](0),
+        // force exercise
+        pp.dispatchFrom(
             $tempIdList,
+            Bob,
+            $posIdList,
+            new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
 
         vm.revertToState(snap2);
 
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
         );
 
         snap2 = vm.snapshotState();
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        // force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Bob,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(0)
         );
@@ -1930,10 +2073,11 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        // force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Bob,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(0).toLeftSlot(1)
         );
@@ -1941,10 +2085,11 @@ contract Misctest is Test, PositionUtils {
         vm.revertToState(snap2);
 
         snap2 = vm.snapshotState();
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        // force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Bob,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(0)
         );
@@ -1953,10 +2098,11 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
-            Bob,
-            $posIdList[1],
+        // force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Bob,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
@@ -1986,10 +2132,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Seller);
 
-        pp.mintOptions(
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -2007,10 +2156,12 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MIN_V3POOL_TICK,
             Constants.MAX_V3POOL_TICK,
             true
@@ -2036,10 +2187,11 @@ contract Misctest is Test, PositionUtils {
         twapTick = PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        pp.forceExercise(
-            Alice,
-            $posIdList[0],
+        // force exercise
+        pp.dispatchFrom(
             new TokenId[](0),
+            Alice,
+            $posIdList,
             new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
@@ -2073,10 +2225,12 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2085,10 +2239,12 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(stdError.divisionError);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $tempIdList,
-            1_000_000,
-            0,
+            $tempIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2113,10 +2269,12 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2127,10 +2285,12 @@ contract Misctest is Test, PositionUtils {
         for (uint256 i; i < 257; ++i) longPositionList[i] = $posIdList[0];
 
         vm.expectRevert(stdError.arithmeticError);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             longPositionList,
-            1_000_000,
-            0,
+            longPositionList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2205,29 +2365,39 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
         vm.startPrank(Bob);
-        pp.mintOptions(
+        sizeList.push(1_000_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
 
-        pp.mintOptions(
+        $posIdLists[0].push($tempIdList[1]);
+        sizeList.pop();
+        sizeList.push(900_000_000);
+        // mint
+        pp.dispatch(
+            $posIdLists[0],
             $tempIdList,
-            900_000_000,
-            type(uint64).max,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2246,20 +2416,27 @@ contract Misctest is Test, PositionUtils {
 
         uint256 snap = vm.snapshot();
         vm.startPrank(Charlie);
+        sizeList.pop();
+        sizeList.push(250_000_000);
 
         for (uint256 i = 0; i < 10; i++) {
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdList,
-                250_000_000,
-                type(uint64).max,
+                $posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
             );
 
-            pp.burnOptions(
-                $posIdList[0],
+            // burn
+            pp.dispatch(
+                $posIdList,
                 new TokenId[](0),
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2267,9 +2444,12 @@ contract Misctest is Test, PositionUtils {
         }
 
         vm.startPrank(Alice);
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2280,9 +2460,12 @@ contract Misctest is Test, PositionUtils {
         vm.revertTo(snap);
 
         vm.startPrank(Alice);
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2319,10 +2502,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2337,23 +2522,28 @@ contract Misctest is Test, PositionUtils {
 
         // the collectedAmount will always be a round number, so it's actually not possible to get a greater grossPremium than sum(collected, owed)
         // (owed and gross are both calculated from collectedAmount)
+        sizeList.push(250_000);
         for (uint256 i = 0; i < 1000; i++) {
             vm.startPrank(Alice);
             $tempIdList[0] = $posIdList[1];
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $tempIdList,
-                250_000,
-                type(uint64).max,
+                $tempIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
             );
 
             vm.startPrank(Bob);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdList,
-                250_000,
-                type(uint64).max,
+                $posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2367,18 +2557,25 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
             $tempIdList[0] = $posIdList[0];
-            pp.burnOptions(
-                $posIdList[1],
+            $posIdLists[0].push($posIdList[1]);
+            // burn
+            pp.dispatch(
+                $posIdLists[0],
                 $tempIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
             );
 
             vm.startPrank(Alice);
-            pp.burnOptions(
-                $posIdList[1],
+            // burn
+            pp.dispatch(
+                $posIdList,
                 new TokenId[](0),
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2387,9 +2584,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // burn Bob's short option
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2416,10 +2616,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2434,11 +2636,14 @@ contract Misctest is Test, PositionUtils {
 
         // only 20 tokens actually settled, but 22 owed... 2 tokens taken from PLPs
         // we may need to redefine availablePremium as max(availablePremium, settledTokens)
+        sizeList.push(499_999);
         for (uint256 i = 0; i < 10; i++) {
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdList,
-                499_999,
-                type(uint64).max,
+                $posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2449,9 +2654,13 @@ contract Misctest is Test, PositionUtils {
             accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1, 1);
             swapperc.swapTo(uniPool, 2 ** 96);
             vm.startPrank(Bob);
-            pp.burnOptions(
-                $posIdList[1],
+            // burn
+            $posIdLists[0].push($posIdList[1]);
+            pp.dispatch(
+                $posIdLists[0],
                 $tempIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2459,9 +2668,12 @@ contract Misctest is Test, PositionUtils {
         }
 
         // burn Bob's short option
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2491,10 +2703,13 @@ contract Misctest is Test, PositionUtils {
         // 8.896% * 1.022x vegoid = +~10% of the fee amount accumulated will be owed by sellers
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        sizeList.push(500_000_000);
+        // mint
+        pp.dispatch(
             $posIdLists[0],
-            500_000_000,
-            0,
+            $posIdLists[0],
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2502,10 +2717,14 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        sizeList.pop();
+        sizeList.push(250_000_000);
+        // mint
+        pp.dispatch(
             $posIdLists[0],
-            250_000_000,
-            0,
+            $posIdLists[0],
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2513,10 +2732,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Charlie);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdLists[0],
-            250_000_000,
-            0,
+            $posIdLists[0],
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2532,10 +2753,14 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 1, 0, -15, 1)
         );
 
-        pp.mintOptions(
+        sizeList.pop();
+        sizeList.push(1_000_000_000 - 9_884_444 * 3);
+        // mint
+        pp.dispatch(
             $posIdLists[1],
-            1_000_000_000 - 9_884_444 * 3,
-            0,
+            $posIdLists[1],
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2549,12 +2774,16 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 1, 0, 0, 15, 1)
         );
 
+        sizeList.pop();
+        sizeList.push(9_884_444);
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdLists[2],
-                9_884_444,
-                type(uint64).max,
+                $posIdLists[2],
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2572,10 +2801,12 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdLists[2],
-                9_884_444,
-                type(uint64).max,
+                $posIdLists[2],
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2593,10 +2824,12 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdLists[2],
-                9_884_444,
-                type(uint64).max,
+                $posIdLists[2],
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2611,12 +2844,17 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 1, 1, 0, -15, 1)
         );
 
+        sizeList.pop();
+        sizeList.push(19_768_888);
+
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdLists[2],
-                19_768_888,
-                type(uint64).max,
+                $posIdLists[2],
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -2786,7 +3024,14 @@ contract Misctest is Test, PositionUtils {
 
         // collect buyer 1's three relevant chunks
         for (uint256 i = 0; i < 3; ++i) {
-            pp.settleLongPremium(collateralIdLists[i], Buyers[0], 0, true);
+            // settle long
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[0],
+                collateralIdLists[i],
+                collateralIdLists[i],
+                LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            );
         }
 
         assertEq(
@@ -2807,9 +3052,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Bob));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
-        pp.burnOptions(
-            $posIdLists[0][0],
+        // burn
+        pp.dispatch(
+            $posIdLists[0],
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2836,10 +3084,13 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 0, 0, 15, 1)
         );
 
-        pp.mintOptions(
+        sizeList.push(1_000_000_000);
+        // mint
+        pp.dispatch(
             $posIdLists[1],
-            1_000_000_000,
-            0,
+            $posIdLists[1],
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2855,9 +3106,21 @@ contract Misctest is Test, PositionUtils {
         // now, settle the dummy chunks for all the buyers/positions and see that the settled ratio for primary doesn't change
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
-
-            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
+            // settle long
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[1],
+                collateralIdLists[1],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[3],
+                collateralIdLists[3],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
         }
 
         assertEq(
@@ -2902,9 +3165,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
-        pp.burnOptions(
-            $posIdLists[0][0],
+        // burn
+        pp.dispatch(
+            $posIdLists[0],
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -2930,9 +3196,23 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 1, true);
+            // settle long
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[1],
+                collateralIdLists[1],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
 
-            pp.settleLongPremium(collateralIdLists[3], Buyers[i], 0, true);
+            // settle long
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[3],
+                collateralIdLists[3],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
         }
 
         assertEq(
@@ -2980,11 +3260,30 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
-
-            pp.settleLongPremium(collateralIdLists[1], Buyers[i], 0, true);
-
-            pp.settleLongPremium(collateralIdLists[2], Buyers[i], 0, true);
+            // settle long
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[0],
+                collateralIdLists[0],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
+            // settle long
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[1],
+                collateralIdLists[1],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
+            // settle long
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[3],
+                collateralIdLists[3],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
         }
 
         assertEq(
@@ -3029,9 +3328,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        pp.burnOptions(
-            $posIdLists[0][0],
+        // burn
+        pp.dispatch(
+            $posIdLists[0],
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3050,7 +3352,14 @@ contract Misctest is Test, PositionUtils {
 
         // test long leg validation
         vm.expectRevert(Errors.NotALongLeg.selector);
-        pp.settleLongPremium(collateralIdLists[2], Buyers[0], 1, true);
+        // settle long
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Buyers[0],
+            collateralIdLists[2],
+            collateralIdLists[2],
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
 
         // test positionIdList validation
         // snapshot so we don't have to reset changes to collateralIdLists array
@@ -3058,7 +3367,14 @@ contract Misctest is Test, PositionUtils {
 
         collateralIdLists[0].pop();
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.settleLongPremium(collateralIdLists[0], Buyers[0], 0, true);
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Buyers[0],
+            collateralIdLists[0],
+            collateralIdLists[0],
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
+
         vm.revertTo(snap);
 
         // test collateral checking (basic)
@@ -3069,7 +3385,14 @@ contract Misctest is Test, PositionUtils {
             deal(address(ct0), Buyers[i], i ** 15);
             deal(address(ct1), Buyers[i], i ** 15);
             vm.expectRevert(Errors.AccountInsolvent.selector);
-            pp.settleLongPremium(collateralIdLists[0], Buyers[i], 0, true);
+            // settleLong
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Buyers[i],
+                collateralIdLists[0],
+                collateralIdLists[0],
+                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            );
             vm.revertTo(snap);
         }
 
@@ -3078,9 +3401,12 @@ contract Misctest is Test, PositionUtils {
             assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[i]));
             assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[i]));
             vm.startPrank(Buyers[i]);
-            pp.burnOptions(
-                $posIdLists[2],
+            // burn
+            pp.dispatch(
+                $posIdLists[0],
                 new TokenId[](0),
+                sizeList1M,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -3129,10 +3455,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        sizeList.push(100_000_000);
+        // mint
+        pp.dispatch(
             $posIdLists[0],
-            100_000_000,
-            0,
+            $posIdLists[0],
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3153,10 +3482,12 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < 3; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 $posIdLists[1],
-                1_000_000,
-                type(uint64).max,
+                $posIdLists[1],
+                sizeList1M,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -3186,7 +3517,14 @@ contract Misctest is Test, PositionUtils {
         uint256 settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[0]));
         uint256 settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[0]));
 
-        pp.settleLongPremium($posIdLists[1], Buyers[0], 0, true);
+        // settle long
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Buyers[0],
+            $posIdLists[1],
+            $posIdLists[1],
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
 
         int256 balanceDelta0 = int256(ct0.convertToAssets(ct0.balanceOf(Buyers[0]))) -
             int256(settleeBalanceBefore0);
@@ -3218,7 +3556,14 @@ contract Misctest is Test, PositionUtils {
         settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[1]));
         settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[1]));
 
-        pp.settleLongPremium($posIdLists[1], Buyers[1], 0, true);
+        // settle long
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Buyers[1],
+            $posIdLists[1],
+            $posIdLists[1],
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
 
         balanceDelta0 =
             int256(ct0.convertToAssets(ct0.balanceOf(Buyers[1]))) -
@@ -3248,7 +3593,14 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Buyers[2], 0);
 
         vm.expectRevert(stdError.arithmeticError);
-        pp.settleLongPremium($posIdLists[1], Buyers[2], 0, true);
+        // settle long
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Buyers[2],
+            $posIdLists[1],
+            $posIdLists[1],
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
     }
 
     function test_success_settledPremiumDistribution() public {
@@ -3279,10 +3631,13 @@ contract Misctest is Test, PositionUtils {
         // Finally, close Charlie's position, they should receive ~27.5% (25% + 10% * 25%)
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        sizeList.push(500_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            500_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3290,10 +3645,14 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        sizeList.pop();
+        sizeList.push(250_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            250_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3301,10 +3660,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Charlie);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            250_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3319,11 +3680,16 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
+        $posIdLists[0].push($posIdList[1]);
+        sizeList.pop();
+        sizeList.push(44_468);
         // mint finely tuned amount of long options for Alice so premium paid = 1.1x
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
+            $posIdLists[0],
             $posIdList,
-            44_468,
-            type(uint64).max,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3332,10 +3698,12 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         // mint finely tuned amount of long options for Bob so premium paid = 1.1x
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
+            $posIdLists[0],
             $posIdList,
-            44_468,
-            type(uint64).max,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3359,9 +3727,12 @@ contract Misctest is Test, PositionUtils {
         $tempIdList.push($posIdList[1]);
 
         // burn Bob's short option
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             $tempIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3381,10 +3752,12 @@ contract Misctest is Test, PositionUtils {
         // re-mint the short option
         $posIdList[1] = $posIdList[0];
         $posIdList[0] = $tempIdList[0];
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3394,9 +3767,13 @@ contract Misctest is Test, PositionUtils {
 
         // Burn the long options, adds 1/2 of the removed liq
         // amount of premia paid = 50_000
-        pp.burnOptions(
-            $posIdList[0],
+        $posIdLists[0].push($posIdList[0]);
+        // burn
+        pp.dispatch(
+            $posIdLists[0],
             $tempIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3409,9 +3786,13 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         $tempIdList[0] = $posIdList[0];
-        pp.burnOptions(
-            $posIdList[1],
+        $posIdLists[1].push($posIdList[1]);
+        // burn
+        pp.dispatch(
+            $posIdLists[1],
             $tempIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3429,9 +3810,12 @@ contract Misctest is Test, PositionUtils {
         );
 
         // Burn other half of the removed liq
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3443,9 +3827,12 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        pp.burnOptions(
-            $posIdList[1],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3481,10 +3868,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3514,10 +3903,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3547,10 +3938,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3581,10 +3974,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3643,10 +4038,13 @@ contract Misctest is Test, PositionUtils {
         // mint fails
         vm.expectRevert(Errors.AccountInsolvent.selector);
         //vm.expectRevert();
-        pp.mintOptions(
+        // mint
+        sizeList.push(100_000);
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3698,10 +4096,13 @@ contract Misctest is Test, PositionUtils {
 
         // mint fails
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.mintOptions(
+        // mint
+        sizeList.push(100_000);
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3755,11 +4156,14 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(17_818, Bob);
 
+        sizeList.push(100_000);
         // mint succeeds
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3808,7 +4212,14 @@ contract Misctest is Test, PositionUtils {
         IERC20Partial(ct0.asset()).approve(address(ct0), 1_000_000);
         IERC20Partial(ct1.asset()).approve(address(ct1), 1_000_000);
 
-        pp.liquidate(new TokenId[](0), Bob, $posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Bob,
+            $posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
 
         (uint256 after0, uint256 after1) = (
             ct0.convertToAssets(ct0.balanceOf(Bob)),
@@ -3838,10 +4249,13 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(150504, Bob);
         ct1.deposit(0, Bob);
 
-        pp.mintOptions(
+        sizeList.push(100_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3920,11 +4334,14 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(17_820, Bob);
 
+        sizeList.push(100_000);
         // mint succeeds
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -3971,7 +4388,14 @@ contract Misctest is Test, PositionUtils {
         IERC20Partial(ct0.asset()).approve(address(ct0), 1_000_000);
         IERC20Partial(ct1.asset()).approve(address(ct1), 1_000_000);
 
-        pp.liquidate(new TokenId[](0), Bob, $posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Bob,
+            $posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
 
         (uint256 after0, uint256 after1) = (
             ct0.convertToAssets(ct0.balanceOf(Bob)),
@@ -4001,10 +4425,13 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(150466, Bob);
 
-        pp.mintOptions(
+        sizeList.push(100_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4054,10 +4481,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            0,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4214,11 +4643,14 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(0, Bob);
 
+        sizeList.push(100_000);
         // not in safeMode, mint with minimum
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4243,11 +4675,14 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(0, Bob);
 
+        sizeList.push(100_000);
         // can mint covered positions
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4312,11 +4747,14 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(0, Bob);
 
         // in safeMode, enforce covered mints, reverts
+        sizeList.push(100_000);
         vm.expectRevert();
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4330,10 +4768,12 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(181_183, Bob); //
 
         // can mint covered positions
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4389,10 +4829,13 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(2_000, Bob);
 
-        pp.mintOptions(
+        sizeList.push(100_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            100_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4410,9 +4853,12 @@ contract Misctest is Test, PositionUtils {
 
         console2.log("00");
         vm.expectRevert();
-        pp.burnOptions(
+        // burn
+        pp.dispatch(
             $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4424,9 +4870,12 @@ contract Misctest is Test, PositionUtils {
         // Add just enough to cover the covered exercise:
         ct1.deposit(98_300, Bob);
 
-        pp.burnOptions(
+        // burn
+        pp.dispatch(
             $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4473,17 +4922,23 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        sizeList.push(500_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            500_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4497,10 +4952,12 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            500_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4574,10 +5031,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        sizeList.push(500_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            500_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4591,9 +5051,12 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
-        pp.burnOptions(
-            $posIdList[0],
+        // burn
+        pp.dispatch(
+            $posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4649,7 +5112,17 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
+        sizeList.push(2 ** 95);
+        // mint
+        pp.dispatch(
+            $posIdList,
+            $posIdList,
+            sizeList,
+            spreadList64,
+            int24(887272),
+            int24(-887272),
+            true
+        );
 
         (, , uint256[2][] memory positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Bob,
@@ -4683,7 +5156,16 @@ contract Misctest is Test, PositionUtils {
         assertTrue(requiredCross > 0, "zero collateral requirement");
         assertTrue(requiredCross <= balanceCross, "account is solvent");
 
-        pp.burnOptions($posIdList[0], new TokenId[](0), int24(887272), int24(-887272), true);
+        // burn
+        pp.dispatch(
+            $posIdList,
+            new TokenId[](0),
+            sizeList1M,
+            spreadList64,
+            int24(887272),
+            int24(-887272),
+            true
+        );
     }
 
     function test_success_PremiumRollover() public {
@@ -4703,8 +5185,18 @@ contract Misctest is Test, PositionUtils {
         posIdList[0] = tokenId;
 
         vm.startPrank(Bob);
+        sizeList.push(3);
         // mint 1 liquidity unit of wideish centered position
-        pp.mintOptions(posIdList, 3, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK, true);
+        // mint
+        pp.dispatch(
+            posIdList,
+            posIdList,
+            sizeList,
+            spreadList64,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
 
         vm.startPrank(Swapper);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
@@ -4720,9 +5212,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // works fine
-        pp.burnOptions(
-            tokenId,
+        // burn
+        pp.dispatch(
+            posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4734,10 +5229,13 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         // lock in almost-overflowed fees per liquidity
-        pp.mintOptions(
+        sizeList.push(1_000_000_000);
+        // mint
+        pp.dispatch(
             posIdList,
-            1_000_000_000,
-            0,
+            posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4771,9 +5269,12 @@ contract Misctest is Test, PositionUtils {
         // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!)
         // + fee to move price initially (if applicable)
         // The solution is to freeze fee accumulation if one of the token accumulators overflow
-        pp.burnOptions(
-            tokenId,
+        // burn
+        pp.dispatch(
+            posIdList,
             new TokenId[](0),
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4832,10 +5333,13 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        pp.mintOptions(
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4855,10 +5359,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4873,9 +5379,12 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
 
             vm.startPrank(Alice);
-            pp.burnOptions(
-                $posIdList[0],
+            // burn
+            pp.dispatch(
+                $posIdList,
                 new TokenId[](0),
+                sizeList1M,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -4939,10 +5448,13 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        pp.mintOptions(
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4962,10 +5474,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -4980,9 +5494,12 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(int16(ticks[i])));
 
             vm.startPrank(Alice);
-            pp.burnOptions(
-                $posIdList[0],
+            // burn
+            pp.dispatch(
+                $posIdList,
                 new TokenId[](0),
+                sizeList1M,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5028,10 +5545,13 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        pp.mintOptions(
+        sizeList.push(2_000_000);
+        // mint
+        pp.dispatch(
             $posIdList,
-            2_000_000,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5051,10 +5571,12 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_000_000,
-            type(uint64).max,
+            $posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5069,9 +5591,12 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
 
             vm.startPrank(Alice);
-            pp.burnOptions(
-                $posIdList[0],
+            // burn
+            pp.dispatch(
+                $posIdList,
                 new TokenId[](0),
+                sizeList1M,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5128,10 +5653,13 @@ contract Misctest is Test, PositionUtils {
 
         uint256 totalSupplyBefore = ct1.totalSupply() - ct1.convertToShares(1_003_003);
 
-        pp.mintOptions(
+        sizeList.push(1_003_003);
+        // mint
+        pp.dispatch(
             $posIdList,
-            1_003_003,
-            0,
+            $posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5148,7 +5676,14 @@ contract Misctest is Test, PositionUtils {
         }
 
         vm.startPrank(Charlie);
-        pp.liquidate(new TokenId[](0), Bob, $posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Bob,
+            $posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0)
+        );
 
         assertLe(ct1.totalSupply() / totalSupplyBefore, 10_000, "protocol loss failed to cap");
     }
@@ -5190,10 +5725,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5280,7 +5818,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquudate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -5344,11 +5889,14 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
+        sizeList.push(3000);
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
             posIdList,
-            3000,
-            0,
+            posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5389,10 +5937,13 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        sizeList.push(3000);
+        // mint
+        pp.dispatch(
             posIdList,
-            3000,
-            0,
+            posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5409,11 +5960,16 @@ contract Misctest is Test, PositionUtils {
 
         posIdList2[1] = tokenId2;
 
+        sizeList.pop();
+        sizeList.push(10);
+        $posIdLists[0].push(posIdList2[1]);
         // mint second option
-        pp.mintOptions(
+        // mint
+        pp.dispatch(
+            $posIdLists[0],
             posIdList2,
-            10,
-            0,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5450,9 +6006,13 @@ contract Misctest is Test, PositionUtils {
 
         // burn second option
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.burnOptions(
-            posIdList2[1],
+        $posIdLists[0].push(posIdList2[1]);
+        // burn
+        pp.dispatch(
+            $posIdLists[0],
             posIdList,
+            sizeList1M,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5493,10 +6053,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        pp.mintOptions(
+        sizeList.push(3000);
+        // mint
+        pp.dispatch(
             posIdList,
-            3000,
-            0,
+            posIdList,
+            sizeList,
+            spreadList,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5590,7 +6153,14 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.NotMarginCalled.selector);
-        pp.liquidate(new TokenId[](0), Bob, posIdList);
+        // liquidate
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Bob,
+            posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0)
+        );
     }
 
     function test_success_liquidation_currentTick_bonusOptimization_scenarios() public {
@@ -5627,10 +6197,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        pp.mintOptions(
+        sizeList.push(3000);
+        // mint
+        pp.dispatch(
             posIdList,
-            3000,
-            0,
+            posIdList,
+            sizeList,
+            spreadList64,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
@@ -5701,7 +6274,14 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(int24(twapTick) + t));
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             unchecked {
                 if (
@@ -5761,10 +6341,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5808,7 +6391,14 @@ contract Misctest is Test, PositionUtils {
             vm.startPrank(Alice);
             console2.log("");
             console2.log("no-cross collateral", i);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -5845,10 +6435,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5890,7 +6483,14 @@ contract Misctest is Test, PositionUtils {
             vm.startPrank(Alice);
             console2.log("");
             console2.log("cross collateral", i);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -5945,10 +6545,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5989,7 +6592,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidat
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6041,10 +6651,14 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 5);
             ct1.deposit(5, Bob);
 
-            pp.mintOptions(
+            sizeList.push(3000);
+
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6085,7 +6699,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            //liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6137,10 +6758,13 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6182,7 +6806,14 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Alice);
 
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6227,10 +6858,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6270,7 +6904,14 @@ contract Misctest is Test, PositionUtils {
             console2.log("no cross collateral", i);
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6308,10 +6949,13 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6354,7 +6998,14 @@ contract Misctest is Test, PositionUtils {
             console2.log("");
             console2.log("cross collateral", i);
 
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6409,10 +7060,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(3000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6450,7 +7104,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6501,11 +7162,14 @@ contract Misctest is Test, PositionUtils {
             ct0.deposit(1000, Bob);
             token1.approve(address(ct1), 15);
             ct1.deposit(15, Bob);
+            sizeList.push(3000);
 
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6542,7 +7206,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6593,11 +7264,14 @@ contract Misctest is Test, PositionUtils {
             ct0.deposit(15, Bob);
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
+            sizeList.push(3000);
 
-            pp.mintOptions(
+            // mint
+            pp.dispatch(
                 posIdList,
-                3000,
-                0,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6634,7 +7308,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
             vm.revertTo(snapshot);
         }
 
@@ -6666,10 +7347,12 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                // mint
+                pp.dispatch(
                     posIdList,
-                    1_000_000,
-                    0,
+                    posIdList,
+                    sizeList1M,
+                    spreadList64,
                     Constants.MAX_V3POOL_TICK,
                     Constants.MIN_V3POOL_TICK,
                     true
@@ -6716,10 +7399,14 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(10_000);
+            spreadList.push(2 ** 30);
+            // mint
+            pp.dispatch(
                 posIdList,
-                10_000,
-                2 ** 30,
+                posIdList,
+                sizeList,
+                spreadList,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6757,7 +7444,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6790,10 +7484,12 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                // mint
+                pp.dispatch(
                     posIdList,
-                    1_000_000,
-                    0,
+                    posIdList,
+                    sizeList1M,
+                    spreadList64,
                     Constants.MAX_V3POOL_TICK,
                     Constants.MIN_V3POOL_TICK,
                     true
@@ -6840,10 +7536,14 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(150, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(10000);
+            spreadList.push(2 ** 30);
+            // mint
+            pp.dispatch(
                 posIdList,
-                10_000,
-                2 ** 30,
+                posIdList,
+                sizeList,
+                spreadList,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -6880,7 +7580,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }
@@ -6913,10 +7620,12 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                // mint
+                pp.dispatch(
                     posIdList,
-                    1_000_000,
-                    0,
+                    posIdList,
+                    sizeList1M,
+                    spreadList64,
                     Constants.MAX_V3POOL_TICK,
                     Constants.MIN_V3POOL_TICK,
                     true
@@ -6963,10 +7672,13 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(2500, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            sizeList.push(10_000);
+            // mint
+            pp.dispatch(
                 posIdList,
-                10_000,
-                2 ** 30,
+                posIdList,
+                sizeList,
+                spreadList64,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -7003,7 +7715,14 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            // liquidate
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Bob,
+                posIdList,
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            );
 
             vm.revertTo(snapshot);
         }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -121,146 +121,6 @@ contract SwapperC {
     }
 }
 
-// Inherits all of PanopticPool's functionality and adds legacy mint/burn/liquidate/forceExercise/settle access
-contract PanopticPoolHarness is PanopticPool {
-    constructor(SemiFungiblePositionManager _SFPM) PanopticPool(_SFPM) {}
-
-    function mintOptions(
-        TokenId[] memory positionIdList,
-        uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-        TokenId[] memory mintList = new TokenId[](1);
-
-        TokenId tokenId = positionIdList[positionIdList.length - 1];
-        sizeList[0] = positionSize;
-        spreadList[0] = effectiveLiquidityLimitX32;
-        mintList[0] = tokenId;
-        this.dispatch(
-            mintList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function burnOptions(
-        TokenId tokenId,
-        TokenId[] memory positionIdList,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-        TokenId[] memory burnList = new TokenId[](1);
-
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
-        burnList[0] = tokenId;
-        this.dispatch(
-            burnList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function burnOptions(
-        TokenId[] memory tokenIds,
-        TokenId[] memory positionIdList,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
-
-        this.dispatch(
-            tokenIds,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function liquidate(
-        TokenId[] memory liquidatorList,
-        address liquidatee,
-        TokenId[] memory positionIdList
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        this.dispatchFrom(
-            liquidatorList,
-            liquidatee,
-            positionIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
-        );
-    }
-
-    function forceExercise(
-        address exercisee,
-        TokenId tokenId,
-        TokenId[] memory exerciseeList,
-        TokenId[] memory exercisorList,
-        LeftRightUnsigned premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        TokenId[] memory targetList = new TokenId[](1);
-
-        this.dispatchFrom(
-            exercisorList,
-            exercisee,
-            targetList,
-            exerciseeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
-        );
-    }
-
-    function settleLongPremium(
-        TokenId[] memory settlerList,
-        TokenId[] memory settleeList,
-        address exercisee,
-        uint256 legIndex,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        TokenId[] memory targetList = new TokenId[](1);
-
-        this.dispatchFrom(
-            settlerList,
-            exercisee,
-            targetList,
-            settleeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
-        );
-    }
-}
-
 // mostly just fixed one-off tests/PoC
 contract Misctest is Test, PositionUtils {
     // the instance of SFPM we are testing
@@ -278,7 +138,7 @@ contract Misctest is Test, PositionUtils {
     ISwapRouter router = ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
 
     PanopticFactory factory;
-    PanopticPoolHarness pp;
+    PanopticPool pp;
     CollateralTracker ct0;
     CollateralTracker ct1;
     PanopticHelper ph;
@@ -340,7 +200,7 @@ contract Misctest is Test, PositionUtils {
         ph = new PanopticHelper(sfpm);
 
         // deploy reference pool and collateral token
-        poolReference = address(new PanopticPoolHarness(sfpm));
+        poolReference = address(new PanopticPool(sfpm));
         collateralReference = address(
             new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000, 20_000)
         );
@@ -470,7 +330,7 @@ contract Misctest is Test, PositionUtils {
         token0.approve(address(factory), type(uint104).max);
         token1.approve(address(factory), type(uint104).max);
 
-        pp = PanopticPoolHarness(
+        pp = PanopticPool(
             address(
                 factory.deployNewPool(
                     address(token0),
@@ -507,6 +367,147 @@ contract Misctest is Test, PositionUtils {
 
         ct0 = pp.collateralToken0();
         ct1 = pp.collateralToken1();
+    }
+
+    function mintOptions(
+        PanopticPool pp,
+        TokenId[] memory positionIdList,
+        uint128 positionSize,
+        uint64 effectiveLiquidityLimitX32,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) public {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory mintList = new TokenId[](1);
+
+        TokenId tokenId = positionIdList[positionIdList.length - 1];
+        sizeList[0] = positionSize;
+        spreadList[0] = effectiveLiquidityLimitX32;
+        mintList[0] = tokenId;
+        pp.dispatch(
+            mintList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        PanopticPool pp,
+        TokenId tokenId,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory burnList = new TokenId[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+        burnList[0] = tokenId;
+        pp.dispatch(
+            burnList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        PanopticPool pp,
+        TokenId[] memory tokenIds,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+
+        pp.dispatch(
+            tokenIds,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function liquidate(
+        PanopticPool pp,
+        TokenId[] memory liquidatorList,
+        address liquidatee,
+        TokenId[] memory positionIdList
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        pp.dispatchFrom(
+            liquidatorList,
+            liquidatee,
+            positionIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function forceExercise(
+        PanopticPool pp,
+        address exercisee,
+        TokenId tokenId,
+        TokenId[] memory exerciseeList,
+        TokenId[] memory exercisorList,
+        LeftRightUnsigned premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        pp.dispatchFrom(
+            exercisorList,
+            exercisee,
+            targetList,
+            exerciseeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function settleLongPremium(
+        PanopticPool pp,
+        TokenId[] memory settlerList,
+        TokenId[] memory settleeList,
+        address exercisee,
+        uint256 legIndex,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        pp.dispatchFrom(
+            settlerList,
+            exercisee,
+            targetList,
+            settleeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
     }
 
     function test_gas_MaxPositions_short_packed() public {
@@ -562,7 +563,8 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 2_000_000,
                 0,
@@ -620,7 +622,8 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 1_000_000,
                 type(uint64).max,
@@ -643,7 +646,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        liquidate(pp, new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -669,7 +672,8 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 2_000_000,
                 0,
@@ -696,7 +700,8 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 1_000_000,
                 type(uint64).max,
@@ -719,7 +724,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        liquidate(pp, new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -776,7 +781,8 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $setupIdList,
                 2_000_000,
                 0,
@@ -878,7 +884,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList.push(posId);
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 1_000_000,
                 type(uint64).max,
@@ -901,7 +908,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        liquidate(pp, new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -927,7 +934,8 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $setupIdList,
                 2_000_000,
                 0,
@@ -969,7 +977,8 @@ contract Misctest is Test, PositionUtils {
             $posIdList.push(posId);
 
             vm.startPrank(Alice);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 1_000_000,
                 type(uint64).max,
@@ -992,7 +1001,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Alice, 0);
 
         uint256 gasBefore = gasleft();
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        liquidate(pp, new TokenId[](0), Alice, $posIdList);
         console.log("Gas used: %d Liquidation", gasBefore - gasleft());
     }
 
@@ -1499,7 +1508,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -1508,7 +1518,8 @@ contract Misctest is Test, PositionUtils {
             true
         );
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -1536,7 +1547,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -1545,7 +1557,8 @@ contract Misctest is Test, PositionUtils {
             true
         );
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -1565,7 +1578,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             537,
             0,
@@ -1574,7 +1588,8 @@ contract Misctest is Test, PositionUtils {
             true
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -1590,7 +1605,8 @@ contract Misctest is Test, PositionUtils {
             .addLeg(0, 1, 0, 1, 0, 0, -224040, 3540);
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             537,
             0,
@@ -1617,7 +1633,8 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 0, 0, 35, 1)
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -1635,7 +1652,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             type(uint64).max,
@@ -1644,7 +1662,8 @@ contract Misctest is Test, PositionUtils {
             true
         );
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -1670,7 +1689,8 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 1, 0, -35, 1)
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -1688,7 +1708,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             type(uint64).max,
@@ -1697,7 +1718,8 @@ contract Misctest is Test, PositionUtils {
             true
         );
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -1724,7 +1746,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Seller);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -1739,7 +1762,8 @@ contract Misctest is Test, PositionUtils {
             .addLeg(0, 1, 1, 1, 0, 0, 15, 1);
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             type(uint64).max,
@@ -1768,7 +1792,8 @@ contract Misctest is Test, PositionUtils {
         PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             $posIdList[0],
             new TokenId[](0),
@@ -1839,7 +1864,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Seller);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             4_000_000,
             0,
@@ -1850,7 +1876,8 @@ contract Misctest is Test, PositionUtils {
 
         $posIdLists[0].push($posIdList[0]);
         vm.startPrank(Alice);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[0],
             2_000_000,
             0,
@@ -1860,7 +1887,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Bob);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -1900,7 +1928,8 @@ contract Misctest is Test, PositionUtils {
             )
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             type(uint64).max,
@@ -1912,15 +1941,16 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.settleLongPremium($posIdLists[0], $posIdList, Bob, 0, false);
+        settleLongPremium(pp, $posIdLists[0], $posIdList, Bob, 0, false);
 
         uint256 snap = vm.snapshotState();
-        pp.settleLongPremium($posIdLists[0], $posIdList, Bob, 0, true);
+        settleLongPremium(pp, $posIdLists[0], $posIdList, Bob, 0, true);
 
         vm.revertToState(snap);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             $tempIdList,
@@ -1929,7 +1959,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             $tempIdList,
@@ -1938,7 +1969,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             $tempIdList,
@@ -1947,7 +1979,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         snap = vm.snapshotState();
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MIN_V3POOL_TICK,
@@ -1956,7 +1989,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             $tempIdList,
@@ -1965,7 +1999,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             $tempIdList,
@@ -1975,7 +2010,8 @@ contract Misctest is Test, PositionUtils {
 
         uint256 snap2 = vm.snapshotState();
 
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             $tempIdList,
@@ -1985,7 +2021,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.revertToState(snap2);
 
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             $tempIdList,
@@ -1998,7 +2035,8 @@ contract Misctest is Test, PositionUtils {
         $setupIdList.push($posIdList[1]);
 
         vm.startPrank(Bob);
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             $setupIdList,
             Constants.MIN_V3POOL_TICK,
@@ -2009,7 +2047,8 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2018,7 +2057,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2028,7 +2068,8 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2040,7 +2081,8 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2050,7 +2092,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.revertToState(snap2);
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MIN_V3POOL_TICK,
@@ -2059,7 +2102,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         snap2 = vm.snapshotState();
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2071,7 +2115,8 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2082,7 +2127,8 @@ contract Misctest is Test, PositionUtils {
         vm.revertToState(snap2);
 
         snap2 = vm.snapshotState();
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2094,7 +2140,8 @@ contract Misctest is Test, PositionUtils {
 
         snap2 = vm.snapshotState();
 
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Bob,
             $posIdList[1],
             new TokenId[](0),
@@ -2127,7 +2174,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Seller);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -2148,7 +2196,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             type(uint64).max,
@@ -2177,7 +2226,8 @@ contract Misctest is Test, PositionUtils {
         twapTick = PanopticMath.twapFilter(uniPool, 600);
 
         vm.startPrank(Bob);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             $posIdList[0],
             new TokenId[](0),
@@ -2214,7 +2264,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -2226,7 +2277,8 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(stdError.divisionError);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $tempIdList,
             1_000_000,
             0,
@@ -2254,7 +2306,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -2268,7 +2321,8 @@ contract Misctest is Test, PositionUtils {
         for (uint256 i; i < 257; ++i) longPositionList[i] = $posIdList[0];
 
         vm.expectRevert(stdError.arithmeticError);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             longPositionList,
             1_000_000,
             0,
@@ -2346,7 +2400,8 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -2356,7 +2411,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(Bob);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000_000,
             0,
@@ -2365,7 +2421,8 @@ contract Misctest is Test, PositionUtils {
             true
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $tempIdList,
             900_000_000,
             type(uint64).max,
@@ -2389,7 +2446,8 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Charlie);
 
         for (uint256 i = 0; i < 10; i++) {
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 250_000_000,
                 type(uint64).max,
@@ -2398,7 +2456,8 @@ contract Misctest is Test, PositionUtils {
                 true
             );
 
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
@@ -2408,7 +2467,8 @@ contract Misctest is Test, PositionUtils {
         }
 
         vm.startPrank(Alice);
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -2421,7 +2481,8 @@ contract Misctest is Test, PositionUtils {
         vm.revertTo(snap);
 
         vm.startPrank(Alice);
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -2460,7 +2521,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -2481,7 +2543,8 @@ contract Misctest is Test, PositionUtils {
         for (uint256 i = 0; i < 1000; i++) {
             vm.startPrank(Alice);
             $tempIdList[0] = $posIdList[1];
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $tempIdList,
                 250_000,
                 type(uint64).max,
@@ -2491,7 +2554,8 @@ contract Misctest is Test, PositionUtils {
             );
 
             vm.startPrank(Bob);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 250_000,
                 type(uint64).max,
@@ -2508,7 +2572,8 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Bob);
             $tempIdList[0] = $posIdList[0];
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdList[1],
                 $tempIdList,
                 Constants.MAX_V3POOL_TICK,
@@ -2517,7 +2582,8 @@ contract Misctest is Test, PositionUtils {
             );
 
             vm.startPrank(Alice);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdList[1],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
@@ -2528,7 +2594,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // burn Bob's short option
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -2557,7 +2624,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -2576,7 +2644,8 @@ contract Misctest is Test, PositionUtils {
         // only 20 tokens actually settled, but 22 owed... 2 tokens taken from PLPs
         // we may need to redefine availablePremium as max(availablePremium, settledTokens)
         for (uint256 i = 0; i < 10; i++) {
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdList,
                 499_999,
                 type(uint64).max,
@@ -2590,7 +2659,8 @@ contract Misctest is Test, PositionUtils {
             accruePoolFeesInRange(address(uniPool), uniPool.liquidity() - 1, 1, 1);
             swapperc.swapTo(uniPool, 2 ** 96);
             vm.startPrank(Bob);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdList[1],
                 $tempIdList,
                 Constants.MAX_V3POOL_TICK,
@@ -2600,7 +2670,8 @@ contract Misctest is Test, PositionUtils {
         }
 
         // burn Bob's short option
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -2632,7 +2703,8 @@ contract Misctest is Test, PositionUtils {
         // 8.896% * 1.022x vegoid = +~10% of the fee amount accumulated will be owed by sellers
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[0],
             500_000_000,
             0,
@@ -2643,7 +2715,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[0],
             250_000_000,
             0,
@@ -2654,7 +2727,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Charlie);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[0],
             250_000_000,
             0,
@@ -2673,7 +2747,8 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 1, 0, -15, 1)
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[1],
             1_000_000_000 - 9_884_444 * 3,
             0,
@@ -2692,7 +2767,8 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[2],
                 9_884_444,
                 type(uint64).max,
@@ -2713,7 +2789,8 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[2],
                 9_884_444,
                 type(uint64).max,
@@ -2734,7 +2811,8 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[2],
                 9_884_444,
                 type(uint64).max,
@@ -2754,7 +2832,8 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[2],
                 19_768_888,
                 type(uint64).max,
@@ -2927,7 +3006,7 @@ contract Misctest is Test, PositionUtils {
 
         // collect buyer 1's three relevant chunks
         for (uint256 i = 0; i < 3; ++i) {
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[i], Buyers[0], 0, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[i], Buyers[0], 0, true);
         }
 
         assertEq(
@@ -2948,7 +3027,8 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Bob));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Bob));
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdLists[0][0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -2977,7 +3057,8 @@ contract Misctest is Test, PositionUtils {
                 .addLeg(0, 1, 1, 0, 0, 0, 15, 1)
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[1],
             1_000_000_000,
             0,
@@ -2996,9 +3077,9 @@ contract Misctest is Test, PositionUtils {
         // now, settle the dummy chunks for all the buyers/positions and see that the settled ratio for primary doesn't change
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[1], Buyers[i], 1, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[1], Buyers[i], 1, true);
 
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[3], Buyers[i], 0, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -3043,7 +3124,8 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Alice));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdLists[0][0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -3071,9 +3153,9 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[1], Buyers[i], 1, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[1], Buyers[i], 1, true);
 
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[3], Buyers[i], 0, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[3], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -3121,11 +3203,11 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1Arr[2] = ct1.convertToAssets(ct1.balanceOf(Buyers[2]));
 
         for (uint256 i = 0; i < Buyers.length; ++i) {
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[0], Buyers[i], 0, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[0], Buyers[i], 0, true);
 
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[1], Buyers[i], 0, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[1], Buyers[i], 0, true);
 
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[2], Buyers[i], 0, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[2], Buyers[i], 0, true);
         }
 
         assertEq(
@@ -3170,7 +3252,8 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdLists[0][0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -3191,7 +3274,7 @@ contract Misctest is Test, PositionUtils {
 
         // test long leg validation
         vm.expectRevert(Errors.NotALongLeg.selector);
-        pp.settleLongPremium(new TokenId[](0), collateralIdLists[2], Buyers[0], 1, true);
+        settleLongPremium(pp, new TokenId[](0), collateralIdLists[2], Buyers[0], 1, true);
 
         // test positionIdList validation
         // snapshot so we don't have to reset changes to collateralIdLists array
@@ -3199,7 +3282,7 @@ contract Misctest is Test, PositionUtils {
 
         collateralIdLists[0].pop();
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.settleLongPremium(new TokenId[](0), collateralIdLists[0], Buyers[0], 0, true);
+        settleLongPremium(pp, new TokenId[](0), collateralIdLists[0], Buyers[0], 0, true);
         vm.revertTo(snap);
 
         // test collateral checking (basic)
@@ -3210,7 +3293,7 @@ contract Misctest is Test, PositionUtils {
             deal(address(ct0), Buyers[i], i ** 15);
             deal(address(ct1), Buyers[i], i ** 15);
             vm.expectRevert(Errors.AccountInsolvent.selector);
-            pp.settleLongPremium(new TokenId[](0), collateralIdLists[0], Buyers[i], 0, true);
+            settleLongPremium(pp, new TokenId[](0), collateralIdLists[0], Buyers[i], 0, true);
             vm.revertTo(snap);
         }
 
@@ -3219,7 +3302,8 @@ contract Misctest is Test, PositionUtils {
             assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[i]));
             assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[i]));
             vm.startPrank(Buyers[i]);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdLists[2],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
@@ -3270,7 +3354,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[0],
             100_000_000,
             0,
@@ -3294,7 +3379,8 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < 3; ++i) {
             vm.startPrank(Buyers[i]);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[1],
                 1_000_000,
                 type(uint64).max,
@@ -3327,7 +3413,7 @@ contract Misctest is Test, PositionUtils {
         uint256 settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[0]));
         uint256 settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[0]));
 
-        pp.settleLongPremium($posIdLists[0], $posIdLists[1], Buyers[0], 0, true);
+        settleLongPremium(pp, $posIdLists[0], $posIdLists[1], Buyers[0], 0, true);
 
         int256 balanceDelta0 = int256(ct0.convertToAssets(ct0.balanceOf(Buyers[0]))) -
             int256(settleeBalanceBefore0);
@@ -3359,7 +3445,7 @@ contract Misctest is Test, PositionUtils {
         settleeBalanceBefore0 = ct0.convertToAssets(ct0.balanceOf(Buyers[1]));
         settleeBalanceBefore1 = ct1.convertToAssets(ct1.balanceOf(Buyers[1]));
 
-        pp.settleLongPremium($posIdLists[0], $posIdLists[1], Buyers[1], 0, true);
+        settleLongPremium(pp, $posIdLists[0], $posIdLists[1], Buyers[1], 0, true);
 
         balanceDelta0 =
             int256(ct0.convertToAssets(ct0.balanceOf(Buyers[1]))) -
@@ -3389,7 +3475,7 @@ contract Misctest is Test, PositionUtils {
         editCollateral(ct1, Buyers[2], 0);
 
         vm.expectRevert(stdError.arithmeticError);
-        pp.settleLongPremium($posIdLists[0], $posIdLists[1], Buyers[2], 0, true);
+        settleLongPremium(pp, $posIdLists[0], $posIdLists[1], Buyers[2], 0, true);
     }
 
     function test_success_settledPremiumDistribution() public {
@@ -3420,7 +3506,8 @@ contract Misctest is Test, PositionUtils {
         // Finally, close Charlie's position, they should receive ~27.5% (25% + 10% * 25%)
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             500_000,
             0,
@@ -3431,7 +3518,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             250_000,
             0,
@@ -3442,7 +3530,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Charlie);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             250_000,
             0,
@@ -3461,7 +3550,8 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         // mint finely tuned amount of long options for Alice so premium paid = 1.1x
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             44_468,
             type(uint64).max,
@@ -3473,7 +3563,8 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         // mint finely tuned amount of long options for Bob so premium paid = 1.1x
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             44_468,
             type(uint64).max,
@@ -3500,7 +3591,8 @@ contract Misctest is Test, PositionUtils {
         $tempIdList.push($posIdList[1]);
 
         // burn Bob's short option
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             $tempIdList,
             Constants.MAX_V3POOL_TICK,
@@ -3522,7 +3614,8 @@ contract Misctest is Test, PositionUtils {
         // re-mint the short option
         $posIdList[1] = $posIdList[0];
         $posIdList[0] = $tempIdList[0];
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -3535,7 +3628,8 @@ contract Misctest is Test, PositionUtils {
 
         // Burn the long options, adds 1/2 of the removed liq
         // amount of premia paid = 50_000
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             $tempIdList,
             Constants.MAX_V3POOL_TICK,
@@ -3550,7 +3644,8 @@ contract Misctest is Test, PositionUtils {
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Alice));
 
         $tempIdList[0] = $posIdList[0];
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[1],
             $tempIdList,
             Constants.MAX_V3POOL_TICK,
@@ -3570,7 +3665,8 @@ contract Misctest is Test, PositionUtils {
         );
 
         // Burn other half of the removed liq
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -3584,7 +3680,8 @@ contract Misctest is Test, PositionUtils {
         assetsBefore0 = ct0.convertToAssets(ct0.balanceOf(Charlie));
         assetsBefore1 = ct1.convertToAssets(ct1.balanceOf(Charlie));
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[1],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -3622,7 +3719,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -3655,7 +3753,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -3688,7 +3787,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -3722,7 +3822,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -3784,7 +3885,8 @@ contract Misctest is Test, PositionUtils {
         // mint fails
         vm.expectRevert(Errors.AccountInsolvent.selector);
         //vm.expectRevert();
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -3839,7 +3941,8 @@ contract Misctest is Test, PositionUtils {
 
         // mint fails
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -3897,7 +4000,8 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(17_818, Bob);
 
         // mint succeeds
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -3949,7 +4053,7 @@ contract Misctest is Test, PositionUtils {
         IERC20Partial(ct0.asset()).approve(address(ct0), 1_000_000);
         IERC20Partial(ct1.asset()).approve(address(ct1), 1_000_000);
 
-        pp.liquidate(new TokenId[](0), Bob, $posIdList);
+        liquidate(pp, new TokenId[](0), Bob, $posIdList);
 
         (uint256 after0, uint256 after1) = (
             ct0.convertToAssets(ct0.balanceOf(Bob)),
@@ -3979,7 +4083,8 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(150504, Bob);
         ct1.deposit(0, Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4062,7 +4167,8 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(17_820, Bob);
 
         // mint succeeds
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4112,7 +4218,7 @@ contract Misctest is Test, PositionUtils {
         IERC20Partial(ct0.asset()).approve(address(ct0), 1_000_000);
         IERC20Partial(ct1.asset()).approve(address(ct1), 1_000_000);
 
-        pp.liquidate(new TokenId[](0), Bob, $posIdList);
+        liquidate(pp, new TokenId[](0), Bob, $posIdList);
 
         (uint256 after0, uint256 after1) = (
             ct0.convertToAssets(ct0.balanceOf(Bob)),
@@ -4142,7 +4248,8 @@ contract Misctest is Test, PositionUtils {
         ct0.deposit(0, Bob);
         ct1.deposit(150466, Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4195,7 +4302,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             0,
@@ -4356,7 +4464,8 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(0, Bob);
 
         // not in safeMode, mint with minimum
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4385,7 +4494,8 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(0, Bob);
 
         // can mint covered positions
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4454,7 +4564,8 @@ contract Misctest is Test, PositionUtils {
 
         // in safeMode, enforce covered mints, reverts
         vm.expectRevert();
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4471,7 +4582,8 @@ contract Misctest is Test, PositionUtils {
         ct1.deposit(181_183, Bob); //
 
         // can mint covered positions
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4530,7 +4642,8 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(ct1), 1_000_000);
         ct1.deposit(2_000, Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             100_000,
             0,
@@ -4551,7 +4664,8 @@ contract Misctest is Test, PositionUtils {
 
         console2.log("00");
         vm.expectRevert();
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -4565,7 +4679,8 @@ contract Misctest is Test, PositionUtils {
         // Add just enough to cover the covered exercise:
         ct1.deposit(98_300, Bob);
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -4614,7 +4729,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             500_000,
             0,
@@ -4622,14 +4738,14 @@ contract Misctest is Test, PositionUtils {
             Constants.MIN_V3POOL_TICK,
             true
         );
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
-
         (, , int24 slowOracleTickStale, , uint256 medianDataStale) = pp.getOracleTicks();
 
         assertEq(slowOracleTick, slowOracleTickStale, "no slow oracle update");
@@ -4638,7 +4754,8 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             500_000,
             0,
@@ -4716,7 +4833,8 @@ contract Misctest is Test, PositionUtils {
         console2.log("safe", pp.isSafeMode());
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             500_000,
             0,
@@ -4733,7 +4851,8 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 1);
         vm.roll(block.number + 1);
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             $posIdList[0],
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -4791,7 +4910,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions($posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
+        mintOptions(pp, $posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
 
         (, , uint256[2][] memory positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Bob,
@@ -4825,7 +4944,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(requiredCross > 0, "zero collateral requirement");
         assertTrue(requiredCross <= balanceCross, "account is solvent");
 
-        pp.burnOptions($posIdList[0], new TokenId[](0), int24(887272), int24(-887272), true);
+        burnOptions(pp, $posIdList[0], new TokenId[](0), int24(887272), int24(-887272), true);
     }
 
     function test_success_PremiumRollover() public {
@@ -4846,7 +4965,15 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // mint 1 liquidity unit of wideish centered position
-        pp.mintOptions(posIdList, 3, 0, Constants.MAX_V3POOL_TICK, Constants.MIN_V3POOL_TICK, true);
+        mintOptions(
+            pp,
+            posIdList,
+            3,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
 
         vm.startPrank(Swapper);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
@@ -4862,7 +4989,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
         // works fine
-        pp.burnOptions(
+        burnOptions(
+            pp,
             tokenId,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -4876,7 +5004,8 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         // lock in almost-overflowed fees per liquidity
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             1_000_000_000,
             0,
@@ -4913,7 +5042,8 @@ contract Misctest is Test, PositionUtils {
         // so the cost of the attack is just ~2**64 * active liquidity (shown here to be as low as 1 even with initial full-range!)
         // + fee to move price initially (if applicable)
         // The solution is to freeze fee accumulation if one of the token accumulators overflow
-        pp.burnOptions(
+        burnOptions(
+            pp,
             tokenId,
             new TokenId[](0),
             Constants.MAX_V3POOL_TICK,
@@ -4974,7 +5104,8 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -4997,7 +5128,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             type(uint64).max,
@@ -5015,7 +5147,8 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
 
             vm.startPrank(Alice);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
@@ -5081,7 +5214,8 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -5104,7 +5238,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             type(uint64).max,
@@ -5122,7 +5257,8 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(int16(ticks[i])));
 
             vm.startPrank(Alice);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
@@ -5170,7 +5306,8 @@ contract Misctest is Test, PositionUtils {
                 )
         );
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             2_000_000,
             0,
@@ -5193,7 +5330,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Alice);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_000_000,
             type(uint64).max,
@@ -5211,7 +5349,8 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(ticks[i]));
 
             vm.startPrank(Alice);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdList[0],
                 new TokenId[](0),
                 Constants.MAX_V3POOL_TICK,
@@ -5270,7 +5409,8 @@ contract Misctest is Test, PositionUtils {
 
         uint256 totalSupplyBefore = ct1.totalSupply() - ct1.convertToShares(1_003_003);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdList,
             1_003_003,
             0,
@@ -5290,7 +5430,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         vm.startPrank(Charlie);
-        pp.liquidate(new TokenId[](0), Bob, $posIdList);
+        liquidate(pp, new TokenId[](0), Bob, $posIdList);
 
         assertLe(ct1.totalSupply() / totalSupplyBefore, 10_000, "protocol loss failed to cap");
     }
@@ -5332,7 +5472,8 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -5422,7 +5563,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -5487,7 +5628,8 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             3000,
             0,
@@ -5531,7 +5673,8 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             3000,
             0,
@@ -5552,7 +5695,8 @@ contract Misctest is Test, PositionUtils {
         posIdList2[1] = tokenId2;
 
         // mint second option
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList2,
             10,
             0,
@@ -5592,7 +5736,8 @@ contract Misctest is Test, PositionUtils {
 
         // burn second option
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.burnOptions(
+        burnOptions(
+            pp,
             posIdList2[1],
             posIdList,
             Constants.MAX_V3POOL_TICK,
@@ -5635,7 +5780,8 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             3000,
             0,
@@ -5732,7 +5878,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         vm.expectRevert(Errors.NotMarginCalled.selector);
-        pp.liquidate(new TokenId[](0), Bob, posIdList);
+        liquidate(pp, new TokenId[](0), Bob, posIdList);
     }
 
     function test_success_liquidation_currentTick_bonusOptimization_scenarios() public {
@@ -5769,7 +5915,8 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
         }
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             3000,
             0,
@@ -5843,7 +5990,7 @@ contract Misctest is Test, PositionUtils {
             swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(int24(twapTick) + t));
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             unchecked {
                 if (
@@ -5903,7 +6050,8 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -5950,7 +6098,7 @@ contract Misctest is Test, PositionUtils {
             vm.startPrank(Alice);
             console2.log("");
             console2.log("no-cross collateral", i);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -5987,7 +6135,8 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6032,7 +6181,7 @@ contract Misctest is Test, PositionUtils {
             vm.startPrank(Alice);
             console2.log("");
             console2.log("cross collateral", i);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6087,7 +6236,8 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6131,7 +6281,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6183,7 +6333,8 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 5);
             ct1.deposit(5, Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6227,7 +6378,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6279,7 +6430,8 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6324,7 +6476,7 @@ contract Misctest is Test, PositionUtils {
 
             vm.startPrank(Alice);
 
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6369,7 +6521,8 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6412,7 +6565,7 @@ contract Misctest is Test, PositionUtils {
             console2.log("no cross collateral", i);
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6450,7 +6603,8 @@ contract Misctest is Test, PositionUtils {
             }
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6496,7 +6650,7 @@ contract Misctest is Test, PositionUtils {
             console2.log("");
             console2.log("cross collateral", i);
 
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6551,7 +6705,8 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6592,7 +6747,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6644,7 +6799,8 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 15);
             ct1.deposit(15, Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6684,7 +6840,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6736,7 +6892,8 @@ contract Misctest is Test, PositionUtils {
             token1.approve(address(ct1), 1000);
             ct1.deposit(1000, Bob);
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 3000,
                 0,
@@ -6776,7 +6933,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
             vm.revertTo(snapshot);
         }
 
@@ -6808,7 +6965,8 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                mintOptions(
+                    pp,
                     posIdList,
                     1_000_000,
                     0,
@@ -6858,7 +7016,8 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(1000, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 10_000,
                 2 ** 30,
@@ -6899,7 +7058,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -6932,7 +7091,8 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                mintOptions(
+                    pp,
                     posIdList,
                     1_000_000,
                     0,
@@ -6982,7 +7142,8 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(150, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 10_000,
                 2 ** 30,
@@ -7022,7 +7183,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }
@@ -7055,7 +7216,8 @@ contract Misctest is Test, PositionUtils {
                 //.addLeg(legIndex, optionRatio, asset, isLong, tokenType, riskPartner, strike, width);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                mintOptions(
+                    pp,
                     posIdList,
                     1_000_000,
                     0,
@@ -7105,7 +7267,8 @@ contract Misctest is Test, PositionUtils {
             ct1.deposit(2500, Bob);
             // mint 1 liquidity unit of wideish centered position
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 10_000,
                 2 ** 30,
@@ -7145,7 +7308,7 @@ contract Misctest is Test, PositionUtils {
             }
 
             vm.startPrank(Alice);
-            pp.liquidate(new TokenId[](0), Bob, posIdList);
+            liquidate(pp, new TokenId[](0), Bob, posIdList);
 
             vm.revertTo(snapshot);
         }

--- a/test/foundry/core/PanopticFactory.t.sol
+++ b/test/foundry/core/PanopticFactory.t.sol
@@ -222,7 +222,7 @@ contract PanopticFactoryTest is Test {
             sfpm,
             V3FACTORY,
             address(new PanopticPool(sfpm)),
-            address(new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000, 20_000)),
+            address(new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000)),
             props,
             indices,
             pointers

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -311,20 +311,16 @@ contract PanopticPoolTest is PositionUtils {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
         TokenId[] memory mintList = new TokenId[](1);
+        int24[2][] memory tickLimits = new int24[2][](1);
 
         TokenId tokenId = positionIdList[positionIdList.length - 1];
         sizeList[0] = positionSize;
         spreadList[0] = effectiveLiquidityLimitX32;
         mintList[0] = tokenId;
-        pp.dispatch(
-            mintList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        tickLimits[0][0] = tickLimitLow;
+        tickLimits[0][1] = tickLimitHigh;
+
+        pp.dispatch(mintList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -338,19 +334,14 @@ contract PanopticPoolTest is PositionUtils {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
         TokenId[] memory burnList = new TokenId[](1);
+        int24[2][] memory tickLimits = new int24[2][](1);
 
         sizeList[0] = 0;
         spreadList[0] = type(uint64).max;
         burnList[0] = tokenId;
-        pp.dispatch(
-            burnList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        tickLimits[0][0] = tickLimitLow;
+        tickLimits[0][1] = tickLimitHigh;
+        pp.dispatch(burnList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -361,21 +352,16 @@ contract PanopticPoolTest is PositionUtils {
         int24 tickLimitHigh,
         bool premiaAsCollateral
     ) internal {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
+        uint128[] memory sizeList = new uint128[](tokenIds.length);
+        uint64[] memory spreadList = new uint64[](tokenIds.length);
+        int24[2][] memory tickLimits = new int24[2][](tokenIds.length);
 
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
+        for (uint256 i; i < tokenIds.length; ++i) {
+            tickLimits[i][0] = tickLimitLow;
+            tickLimits[i][1] = tickLimitHigh;
+        }
 
-        pp.dispatch(
-            tokenIds,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
+        pp.dispatch(tokenIds, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
     }
 
     function liquidate(
@@ -3592,15 +3578,11 @@ contract PanopticPoolTest is PositionUtils {
         uint64[] memory spreadList = new uint64[](1);
         spreadList[0] = type(uint64).max;
 
-        pp.dispatch(
-            posIdList,
-            posIdList,
-            sizeList,
-            spreadList,
-            Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            true
-        );
+        int24[2][] memory tickLimits = new int24[2][](1);
+        tickLimits[0][0] = Constants.MAX_V3POOL_TICK;
+        tickLimits[0][1] = Constants.MIN_V3POOL_TICK;
+
+        pp.dispatch(posIdList, posIdList, sizeList, spreadList, tickLimits, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -3711,15 +3693,11 @@ contract PanopticPoolTest is PositionUtils {
         spreadList[0] = type(uint64).max;
         spreadList[1] = type(uint64).max;
 
-        pp.dispatch(
-            posIdList,
-            posIdList,
-            sizeList,
-            spreadList,
-            Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK,
-            true
-        );
+        int24[2][] memory tickLimits = new int24[2][](1);
+        tickLimits[0][0] = Constants.MIN_V3POOL_TICK;
+        tickLimits[0][1] = Constants.MAX_V3POOL_TICK;
+
+        pp.dispatch(posIdList, posIdList, sizeList, spreadList, tickLimits, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)), positionSizes[0]);
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)), positionSizes[1]);
@@ -3845,31 +3823,18 @@ contract PanopticPoolTest is PositionUtils {
         uint64[] memory spreadList = new uint64[](2);
         spreadList[0] = type(uint64).max;
         spreadList[1] = type(uint64).max;
+        int24[2][] memory tickLimits = new int24[2][](1);
+        tickLimits[0][0] = Constants.MIN_V3POOL_TICK;
+        tickLimits[0][1] = Constants.MAX_V3POOL_TICK;
 
         // mint two positions
-        pp.dispatch(
-            posIdList,
-            posIdList,
-            sizeList,
-            spreadList,
-            Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK,
-            true
-        );
+        pp.dispatch(posIdList, posIdList, sizeList, spreadList, tickLimits, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)), positionSizes[0]);
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)), positionSizes[1]);
 
         // burn two positions
-        pp.dispatch(
-            posIdList,
-            new TokenId[](0),
-            sizeList,
-            spreadList,
-            Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK,
-            true
-        );
+        pp.dispatch(posIdList, new TokenId[](0), sizeList, spreadList, tickLimits, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)), 0);
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)), 0);
@@ -3937,42 +3902,21 @@ contract PanopticPoolTest is PositionUtils {
         uint64[] memory spreadList = new uint64[](2);
         spreadList[0] = type(uint64).max;
         spreadList[1] = type(uint64).max;
+        int24[2][] memory tickLimits = new int24[2][](1);
+        tickLimits[0][0] = Constants.MIN_V3POOL_TICK;
+        tickLimits[0][1] = Constants.MAX_V3POOL_TICK;
 
         vm.expectRevert(Errors.InputListFail.selector);
         // mint two positions
-        pp.dispatch(
-            posIdList,
-            posIdListWrong,
-            sizeList,
-            spreadList,
-            Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK,
-            true
-        );
+        pp.dispatch(posIdList, posIdListWrong, sizeList, spreadList, tickLimits, true);
 
         vm.expectRevert(Errors.InputListFail.selector);
         // mint two positions
-        pp.dispatch(
-            posIdListWrong,
-            posIdList,
-            sizeList,
-            spreadList,
-            Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK,
-            true
-        );
+        pp.dispatch(posIdListWrong, posIdList, sizeList, spreadList, tickLimits, true);
 
         vm.expectRevert(Errors.InputListFail.selector);
         // mint two positions
-        pp.dispatch(
-            posIdListWrong,
-            posIdListWrong,
-            sizeList,
-            spreadList,
-            Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK,
-            true
-        );
+        pp.dispatch(posIdListWrong, posIdListWrong, sizeList, spreadList, tickLimits, true);
     }
 
     function test_Success_dispatch_insolvent_between_states(
@@ -4033,6 +3977,9 @@ contract PanopticPoolTest is PositionUtils {
         sizeListFail[0] = uint128(positionSizes[1]);
         uint64[] memory spreadList = new uint64[](1);
         spreadList[0] = type(uint64).max;
+        int24[2][] memory tickLimits = new int24[2][](1);
+        tickLimits[0][0] = Constants.MIN_V3POOL_TICK;
+        tickLimits[0][1] = Constants.MAX_V3POOL_TICK;
 
         console2.log("sis", positionSizes[0], positionSizes[1]);
         (, LeftRightSigned shortAmounts0) = PanopticMath.computeExercisedAmounts(
@@ -4052,15 +3999,7 @@ contract PanopticPoolTest is PositionUtils {
         ct1.redeem(ct1.maxRedeem(Alice), Alice, Alice);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.dispatch(
-            posIdListFail,
-            posIdListFail,
-            sizeListFail,
-            spreadList,
-            Constants.MIN_V3POOL_TICK,
-            Constants.MAX_V3POOL_TICK,
-            true
-        );
+        pp.dispatch(posIdListFail, posIdListFail, sizeListFail, spreadList, tickLimits, true);
         {
             TokenId[] memory posIdListPass = new TokenId[](3);
             posIdListPass[0] = tokenId0;
@@ -4079,14 +4018,16 @@ contract PanopticPoolTest is PositionUtils {
             spreadListPass[0] = type(uint64).max;
             spreadListPass[1] = type(uint64).max;
             spreadListPass[2] = type(uint64).max;
+            int24[2][] memory tickLimits = new int24[2][](1);
+            tickLimits[0][0] = Constants.MIN_V3POOL_TICK;
+            tickLimits[0][1] = Constants.MAX_V3POOL_TICK;
 
             pp.dispatch(
                 posIdListPass,
                 posIdListFinal,
                 sizeListPass,
                 spreadListPass,
-                Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK,
+                tickLimits,
                 true
             );
         }
@@ -4217,16 +4158,11 @@ contract PanopticPoolTest is PositionUtils {
                 sizeList[i] = uint128(positionSizes[1]);
                 spreadList[i] = type(uint64).max;
             }
+            int24[2][] memory tickLimits = new int24[2][](1);
+            tickLimits[0][0] = Constants.MIN_V3POOL_TICK;
+            tickLimits[0][1] = Constants.MAX_V3POOL_TICK;
 
-            pp.dispatch(
-                posIdList,
-                posIdListFinal,
-                sizeList,
-                spreadList,
-                Constants.MIN_V3POOL_TICK,
-                Constants.MAX_V3POOL_TICK,
-                true
-            );
+            pp.dispatch(posIdList, posIdListFinal, sizeList, spreadList, tickLimits, true);
         }
 
         assertEq(
@@ -6194,17 +6130,12 @@ contract PanopticPoolTest is PositionUtils {
 
             sizeList[0] = positionSize;
             spreadList[0] = type(uint64).max;
-            try
-                pp.dispatch(
-                    posIdList,
-                    posIdList,
-                    sizeList,
-                    spreadList,
-                    Constants.MAX_V3POOL_TICK,
-                    Constants.MIN_V3POOL_TICK,
-                    true
-                )
-            {} catch (bytes memory reason) {
+            int24[2][] memory tickLimits = new int24[2][](1);
+            tickLimits[0][0] = Constants.MAX_V3POOL_TICK;
+            tickLimits[0][1] = Constants.MIN_V3POOL_TICK;
+            try pp.dispatch(posIdList, posIdList, sizeList, spreadList, tickLimits, true) {} catch (
+                bytes memory reason
+            ) {
                 if (bytes4(reason) == Errors.TransferFailed.selector) {
                     vm.assume(false);
                 }

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -81,141 +81,6 @@ contract PanopticPoolHarness is PanopticPool {
         return (premiasByLeg, netExchanged);
     }
 
-    function mintOptions(
-        TokenId[] memory positionIdList,
-        uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-        TokenId[] memory mintList = new TokenId[](1);
-
-        TokenId tokenId = positionIdList[positionIdList.length - 1];
-        sizeList[0] = positionSize;
-        spreadList[0] = effectiveLiquidityLimitX32;
-        mintList[0] = tokenId;
-        this.dispatch(
-            mintList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function burnOptions(
-        TokenId tokenId,
-        TokenId[] memory positionIdList,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-        TokenId[] memory burnList = new TokenId[](1);
-
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
-        burnList[0] = tokenId;
-        this.dispatch(
-            burnList,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function burnOptions(
-        TokenId[] memory tokenIds,
-        TokenId[] memory positionIdList,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
-
-        this.dispatch(
-            tokenIds,
-            positionIdList,
-            sizeList,
-            spreadList,
-            tickLimitLow,
-            tickLimitHigh,
-            premiaAsCollateral
-        );
-    }
-
-    function liquidate(
-        TokenId[] memory liquidatorList,
-        address liquidatee,
-        TokenId[] memory positionIdList
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        this.dispatchFrom(
-            liquidatorList,
-            liquidatee,
-            positionIdList,
-            new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
-        );
-    }
-
-    function forceExercise(
-        address exercisee,
-        TokenId tokenId,
-        TokenId[] memory exerciseeList,
-        TokenId[] memory exercisorList,
-        LeftRightUnsigned premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        TokenId[] memory targetList = new TokenId[](1);
-
-        this.dispatchFrom(
-            exercisorList,
-            exercisee,
-            targetList,
-            exerciseeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
-        );
-    }
-
-    function settleLongPremium(
-        TokenId[] memory settlerList,
-        TokenId[] memory settleeList,
-        address exercisee,
-        uint256 legIndex,
-        bool premiaAsCollateral
-    ) external {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
-        TokenId[] memory targetList = new TokenId[](1);
-
-        this.dispatchFrom(
-            settlerList,
-            exercisee,
-            targetList,
-            settleeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
-        );
-    }
-
     constructor(SemiFungiblePositionManager _sfpm) PanopticPool(_sfpm) {}
 }
 
@@ -433,6 +298,147 @@ contract PanopticPoolTest is PositionUtils {
     LeftRightUnsigned $shortPremiaBefore;
 
     LeftRightSigned $netExchanged;
+
+    function mintOptions(
+        PanopticPool pp,
+        TokenId[] memory positionIdList,
+        uint128 positionSize,
+        uint64 effectiveLiquidityLimitX32,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory mintList = new TokenId[](1);
+
+        TokenId tokenId = positionIdList[positionIdList.length - 1];
+        sizeList[0] = positionSize;
+        spreadList[0] = effectiveLiquidityLimitX32;
+        mintList[0] = tokenId;
+        pp.dispatch(
+            mintList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        PanopticPool pp,
+        TokenId tokenId,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory burnList = new TokenId[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+        burnList[0] = tokenId;
+        pp.dispatch(
+            burnList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        PanopticPool pp,
+        TokenId[] memory tokenIds,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+
+        pp.dispatch(
+            tokenIds,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function liquidate(
+        PanopticPool pp,
+        TokenId[] memory liquidatorList,
+        address liquidatee,
+        TokenId[] memory positionIdList
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        pp.dispatchFrom(
+            liquidatorList,
+            liquidatee,
+            positionIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function forceExercise(
+        PanopticPool pp,
+        address exercisee,
+        TokenId tokenId,
+        TokenId[] memory exerciseeList,
+        TokenId[] memory exercisorList,
+        LeftRightUnsigned premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        pp.dispatchFrom(
+            exercisorList,
+            exercisee,
+            targetList,
+            exerciseeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function settleLongPremium(
+        PanopticPool pp,
+        TokenId[] memory settlerList,
+        TokenId[] memory settleeList,
+        address exercisee,
+        uint256 legIndex,
+        bool premiaAsCollateral
+    ) internal {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        pp.dispatchFrom(
+            settlerList,
+            exercisee,
+            targetList,
+            settleeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
 
     /*//////////////////////////////////////////////////////////////
                                ENV SETUP
@@ -1755,7 +1761,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSizes[0],
                 0,
@@ -1785,7 +1792,8 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSizes[1],
                 0,
@@ -1892,7 +1900,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -1993,7 +2002,8 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         // mint option from another account to change the effective liquidity
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize * 2,
             0,
@@ -2022,7 +2032,8 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         // type(uint64).max = no limit, ensure the operation works given the changed liquidity limit
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             type(uint64).max,
@@ -2117,7 +2128,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
         // mint option from another account to change the effective liquidity
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize * 2,
             0,
@@ -2146,7 +2158,8 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         // type(uint64).max = no limit, ensure the operation works given the changed liquidity limit
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             type(uint64).max - 1,
@@ -2233,7 +2246,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize * 2,
             0,
@@ -2248,7 +2262,8 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.EffectiveLiquidityAboveThreshold.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -2290,7 +2305,7 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK, true);
+        mintOptions(pp, posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -2377,7 +2392,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -2468,7 +2484,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -2589,7 +2606,7 @@ contract PanopticPoolTest is PositionUtils {
 
             // reversing the tick limits here to make sure they get entered into the SFPM properly
             // this test will fail if it does not (because no ITM swaps will occur)
-            pp.mintOptions(posIdList, positionSize, 0, TickMath.MAX_TICK, TickMath.MIN_TICK, true);
+            mintOptions(pp, posIdList, positionSize, 0, TickMath.MAX_TICK, TickMath.MIN_TICK, true);
         }
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
@@ -2694,7 +2711,7 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK, true);
+        mintOptions(pp, posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MAX_TICK, true);
 
         assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
 
@@ -2845,7 +2862,8 @@ contract PanopticPoolTest is PositionUtils {
                 TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                mintOptions(
+                    pp,
                     posIdList,
                     positionSize,
                     0,
@@ -3002,7 +3020,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSize,
                 0,
@@ -3149,7 +3168,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSizes[0],
                 0,
@@ -3249,7 +3269,8 @@ contract PanopticPoolTest is PositionUtils {
                 TokenId[] memory posIdList = new TokenId[](1);
                 posIdList[0] = tokenId;
 
-                pp.mintOptions(
+                mintOptions(
+                    pp,
                     posIdList,
                     positionSizes[1],
                     type(uint64).max,
@@ -3374,7 +3395,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSizes[0],
                 0,
@@ -3444,7 +3466,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSizes[1],
                 type(uint64).max,
@@ -3563,7 +3586,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.PriceBoundFail.selector);
-        pp.mintOptions(posIdList, positionSize, 0, 0, 0, true);
+        mintOptions(pp, posIdList, positionSize, 0, 0, 0, true);
     }
 
     function test_Fail_mintOptions_LowerPriceBoundFail(
@@ -3599,7 +3622,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.PriceBoundFail.selector);
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MAX_TICK - 1, TickMath.MAX_TICK, true);
+        mintOptions(pp, posIdList, positionSize, 0, TickMath.MAX_TICK - 1, TickMath.MAX_TICK, true);
     }
 
     function test_Fail_mintOptions_UpperPriceBoundFail(
@@ -3635,7 +3658,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.PriceBoundFail.selector);
-        pp.mintOptions(posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MIN_TICK + 1, true);
+        mintOptions(pp, posIdList, positionSize, 0, TickMath.MIN_TICK, TickMath.MIN_TICK + 1, true);
     }
 
     function test_Fail_mintOptions_IncorrectPool(
@@ -3671,7 +3694,8 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(abi.encodeWithSelector(Errors.InvalidTokenIdParameter.selector, 0));
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -3713,7 +3737,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -3727,7 +3752,8 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[1] = tokenId;
 
         vm.expectRevert(Errors.PositionAlreadyMinted.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             uint128(positionSize),
             0,
@@ -3770,7 +3796,8 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
 
         vm.expectRevert(Errors.ZeroLiquidity.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize * 0,
             0,
@@ -3826,7 +3853,8 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             uint128(positionSize),
             0,
@@ -3853,7 +3881,8 @@ contract PanopticPoolTest is PositionUtils {
             i += numLegs;
 
             if (i > 25) vm.expectRevert(Errors.TooManyLegsOpen.selector);
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 tokenIds,
                 1_000_000,
                 0,
@@ -3910,7 +3939,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -3918,7 +3948,8 @@ contract PanopticPoolTest is PositionUtils {
             Constants.MIN_V3POOL_TICK,
             true
         );
-        pp.burnOptions(
+        burnOptions(
+            pp,
             tokenId,
             emptyList,
             Constants.MAX_V3POOL_TICK,
@@ -4018,7 +4049,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSize,
                 0,
@@ -4056,7 +4088,8 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         {
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 tokenId,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
@@ -4189,7 +4222,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSize,
                 0,
@@ -4228,7 +4262,8 @@ contract PanopticPoolTest is PositionUtils {
             int128(expectedLiq)
         );
         {
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 tokenId,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
@@ -4367,7 +4402,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenIds[0];
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSize,
                 0,
@@ -4393,7 +4429,8 @@ contract PanopticPoolTest is PositionUtils {
 
             posIdList[0] = tokenIds[1];
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 (positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000,
                 type(uint64).max,
@@ -4421,7 +4458,8 @@ contract PanopticPoolTest is PositionUtils {
 
             posIdList[0] = tokenIds[0];
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 (((positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000) * 100) / 89,
                 0,
@@ -4462,7 +4500,8 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.startPrank(Alice);
         {
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 tokenIds[0],
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
@@ -4580,7 +4619,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenIds[0];
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSize,
                 0,
@@ -4606,7 +4646,8 @@ contract PanopticPoolTest is PositionUtils {
 
             posIdList[0] = tokenIds[1];
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 (positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000,
                 type(uint64).max,
@@ -4634,7 +4675,8 @@ contract PanopticPoolTest is PositionUtils {
 
             posIdList[0] = tokenIds[0];
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 (((positionSize * uint128(bound(longPercentageSeed, 1, 899))) / 1000) * 100) / 89,
                 0,
@@ -4675,7 +4717,8 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.startPrank(Alice);
         {
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 tokenIds[0],
                 emptyList,
                 Constants.MIN_V3POOL_TICK,
@@ -4784,7 +4827,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSizes[0],
                 0,
@@ -4799,7 +4843,8 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 uint128(positionSizes[1]),
                 0,
@@ -4808,7 +4853,8 @@ contract PanopticPoolTest is PositionUtils {
                 true
             );
 
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 posIdList,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
@@ -4894,7 +4940,8 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[0],
                 positionSize * 10,
                 0,
@@ -4920,7 +4967,8 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[1],
                 positionSize,
                 type(uint64).max,
@@ -4942,7 +4990,8 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             if ($posIdLists[3].length > 1) {
-                pp.burnOptions(
+                burnOptions(
+                    pp,
                     $posIdLists[3],
                     $posIdLists[2],
                     Constants.MAX_V3POOL_TICK,
@@ -4950,7 +4999,8 @@ contract PanopticPoolTest is PositionUtils {
                     true
                 );
             } else {
-                pp.burnOptions(
+                burnOptions(
+                    pp,
                     $posIdLists[3][0],
                     $posIdLists[2],
                     Constants.MAX_V3POOL_TICK,
@@ -5060,7 +5110,8 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.expectRevert();
         if ($posIdLists[3].length > 1) {
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdLists[3],
                 $posIdLists[2],
                 Constants.MAX_V3POOL_TICK,
@@ -5068,7 +5119,8 @@ contract PanopticPoolTest is PositionUtils {
                 true
             );
         } else {
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 $posIdLists[3][0],
                 $posIdLists[2],
                 Constants.MAX_V3POOL_TICK,
@@ -5110,7 +5162,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -5121,7 +5174,8 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.expectRevert(Errors.InputListFail.selector);
 
-        pp.burnOptions(
+        burnOptions(
+            pp,
             tokenId,
             posIdList,
             Constants.MAX_V3POOL_TICK,
@@ -5213,7 +5267,8 @@ contract PanopticPoolTest is PositionUtils {
             TokenId[] memory posIdList = new TokenId[](1);
             posIdList[0] = tokenId;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 positionSizes[0],
                 0,
@@ -5223,7 +5278,8 @@ contract PanopticPoolTest is PositionUtils {
             );
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 tokenId,
                 posIdList,
                 Constants.MAX_V3POOL_TICK,
@@ -5237,7 +5293,8 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0] = tokenId;
             posIdList[1] = tokenId2;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 uint128(positionSizes[1]),
                 0,
@@ -5247,7 +5304,8 @@ contract PanopticPoolTest is PositionUtils {
             );
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 tokenId,
                 emptyList,
                 Constants.MAX_V3POOL_TICK,
@@ -5261,7 +5319,8 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[1] = tokenId2;
             posIdList[2] = tokenId3;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 uint128(positionSizes[0]),
                 0,
@@ -5271,7 +5330,8 @@ contract PanopticPoolTest is PositionUtils {
             );
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 tokenId,
                 posIdList,
                 Constants.MAX_V3POOL_TICK,
@@ -5287,7 +5347,8 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[2] = tokenId3;
             posIdList[3] = tokenId4;
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 posIdList,
                 uint128(positionSizes[1]),
                 0,
@@ -5301,7 +5362,8 @@ contract PanopticPoolTest is PositionUtils {
             burnIdList[1] = tokenId2;
 
             vm.expectRevert(Errors.InputListFail.selector);
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 burnIdList,
                 posIdList,
                 Constants.MAX_V3POOL_TICK,
@@ -5313,7 +5375,8 @@ contract PanopticPoolTest is PositionUtils {
             leftoverIdList[0] = tokenId3;
             leftoverIdList[1] = tokenId4;
 
-            pp.burnOptions(
+            burnOptions(
+                pp,
                 burnIdList,
                 leftoverIdList,
                 Constants.MAX_V3POOL_TICK,
@@ -5403,7 +5466,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize * 2,
             0,
@@ -5436,11 +5500,17 @@ contract PanopticPoolTest is PositionUtils {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        sizeList[0] = positionSize;
+        spreadList[0] = type(uint64).max;
         try
-            pp.mintOptions(
+            pp.dispatch(
                 posIdList,
-                positionSize,
-                type(uint64).max,
+                posIdList,
+                sizeList,
+                spreadList,
                 Constants.MAX_V3POOL_TICK,
                 Constants.MIN_V3POOL_TICK,
                 true
@@ -5534,7 +5604,8 @@ contract PanopticPoolTest is PositionUtils {
         exerciseFeeAmounts[0] += (longAmounts.rightSlot() * (-exerciseFee)) / 10_000;
         exerciseFeeAmounts[1] += (longAmounts.leftSlot() * (-exerciseFee)) / 10_000;
 
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             posIdList[0],
             new TokenId[](0),
@@ -5822,7 +5893,8 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[0],
                 positionSize * 10,
                 0,
@@ -5863,7 +5935,8 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[3].pop();
             }
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[1],
                 positionSize,
                 type(uint64).max,
@@ -5881,7 +5954,8 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             vm.startPrank(Bob);
-            pp.forceExercise(
+            forceExercise(
+                pp,
                 Alice,
                 $posIdLists[2][0],
                 $posIdLists[3],
@@ -5953,7 +6027,8 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert();
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             $posIdLists[2][0],
             $posIdLists[3],
@@ -6046,7 +6121,8 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[0],
                 positionSize * 2,
                 0,
@@ -6087,7 +6163,8 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[3].pop();
             }
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[1],
                 positionSize,
                 type(uint64).max,
@@ -6105,7 +6182,8 @@ contract PanopticPoolTest is PositionUtils {
             uint256 snap = vm.snapshot();
 
             vm.startPrank(Bob);
-            pp.forceExercise(
+            forceExercise(
+                pp,
                 Alice,
                 $posIdLists[2][0],
                 $posIdLists[3],
@@ -6177,7 +6255,8 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert();
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             $posIdLists[2][0],
             $posIdLists[3],
@@ -6268,7 +6347,8 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[0],
                 positionSize * 2,
                 0,
@@ -6297,7 +6377,8 @@ contract PanopticPoolTest is PositionUtils {
             );
         }
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[1],
             positionSize,
             type(uint64).max,
@@ -6311,7 +6392,8 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             $posIdLists[1][0],
             $posIdLists[0],
@@ -6361,7 +6443,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -6386,7 +6469,8 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[1] = tokenId2;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -6401,7 +6485,8 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId2;
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             TokenId.wrap(0),
             new TokenId[](0),
@@ -6436,7 +6521,8 @@ contract PanopticPoolTest is PositionUtils {
         touchedIds[0] = tokenId;
 
         vm.startPrank(Alice);
-        pp.mintOptions(
+        mintOptions(
+            pp,
             touchedIds,
             positionSize,
             0,
@@ -6448,7 +6534,8 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
 
         vm.expectRevert(Errors.NoLegsExercisable.selector);
-        pp.forceExercise(
+        forceExercise(
+            pp,
             Alice,
             touchedIds[0],
             touchedIds,
@@ -6531,7 +6618,8 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[0],
                 positionSize * 2,
                 0,
@@ -6560,7 +6648,8 @@ contract PanopticPoolTest is PositionUtils {
                 )
             );
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[1],
                 positionSize,
                 type(uint64).max,
@@ -6834,7 +6923,7 @@ contract PanopticPoolTest is PositionUtils {
             vm.assume(newBalance0 < newRequired0);
         }
 
-        pp.liquidate(new TokenId[](0), Alice, $posIdLists[1]);
+        liquidate(pp, new TokenId[](0), Alice, $posIdLists[1]);
 
         // take the difference between the share deltas after burn and after mint - that should be the bonus
         $shareDelta0 = shareDeltasLiquidatee[0] - (int256(ct0.balanceOf(Alice)) - $shareDelta0);
@@ -7129,7 +7218,8 @@ contract PanopticPoolTest is PositionUtils {
                 widths[i]
             );
         }
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[0],
             positionSize * 2,
             0,
@@ -7156,7 +7246,8 @@ contract PanopticPoolTest is PositionUtils {
             );
         }
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             $posIdLists[1],
             positionSize,
             type(uint64).max,
@@ -7411,7 +7502,7 @@ contract PanopticPoolTest is PositionUtils {
             vm.assume(newBalance0 < newRequired0);
         }
 
-        pp.liquidate(new TokenId[](0), Alice, $posIdLists[1]);
+        liquidate(pp, new TokenId[](0), Alice, $posIdLists[1]);
 
         // take the difference between the share deltas after burn and after mint - that should be the bonus
         $shareDelta0 = shareDeltasLiquidatee[0] - (int256(ct0.balanceOf(Alice)) - $shareDelta0);
@@ -7680,7 +7771,8 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -7705,7 +7797,8 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[1] = tokenId2;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -7720,7 +7813,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId2;
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.liquidate(new TokenId[](0), Alice, posIdList);
+        liquidate(pp, new TokenId[](0), Alice, posIdList);
     }
 
     function test_Fail_liquidate_validatePositionIdListLiquidator(
@@ -7756,7 +7849,8 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -7767,7 +7861,8 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -7780,7 +7875,7 @@ contract PanopticPoolTest is PositionUtils {
         editCollateral(ct1, Alice, 2);
 
         vm.expectRevert(Errors.InputListFail.selector);
-        pp.liquidate(new TokenId[](0), Alice, posIdList);
+        liquidate(pp, new TokenId[](0), Alice, posIdList);
     }
 
     function test_Fail_liquidate_liquidatorIsInsolvent(
@@ -7816,7 +7911,8 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[0] = tokenId;
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -7827,7 +7923,8 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.startPrank(Bob);
 
-        pp.mintOptions(
+        mintOptions(
+            pp,
             posIdList,
             positionSize,
             0,
@@ -7843,7 +7940,7 @@ contract PanopticPoolTest is PositionUtils {
         editCollateral(ct1, Bob, 2);
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
-        pp.liquidate(posIdList, Alice, posIdList);
+        liquidate(pp, posIdList, Alice, posIdList);
     }
 
     function test_Fail_liquidate_StaleTWAP(uint256 x, int256 tickDeltaSeed) public {
@@ -7873,7 +7970,7 @@ contract PanopticPoolTest is PositionUtils {
         );
 
         vm.expectRevert(Errors.StaleOracle.selector);
-        pp.liquidate(new TokenId[](0), Alice, $posIdList);
+        liquidate(pp, new TokenId[](0), Alice, $posIdList);
     }
 
     function test_Fail_liquidate_NotMarginCalled(
@@ -7946,7 +8043,8 @@ contract PanopticPoolTest is PositionUtils {
                     widths[i]
                 )
             );
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[0],
                 positionSize * 2,
                 0,
@@ -7975,7 +8073,8 @@ contract PanopticPoolTest is PositionUtils {
                 )
             );
 
-            pp.mintOptions(
+            mintOptions(
+                pp,
                 $posIdLists[1],
                 positionSize,
                 type(uint64).max,
@@ -8106,7 +8205,15 @@ contract PanopticPoolTest is PositionUtils {
         vm.startPrank(Bob);
         vm.assume(Math.abs(int256(currentTick) - TWAPtick) < 953);
 
-        try pp.liquidate(new TokenId[](0), Alice, $posIdLists[1]) {
+        try
+            pp.dispatchFrom(
+                new TokenId[](0),
+                Alice,
+                $posIdLists[1],
+                new TokenId[](0),
+                LeftRightUnsigned.wrap(0)
+            )
+        {
             assertFalse(true, "liquidation should have failed");
         } catch (bytes memory reason) {
             assertTrue(bytes4(reason) == Errors.NotMarginCalled.selector);

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -5500,28 +5500,29 @@ contract PanopticPoolTest is PositionUtils {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
+        {
+            uint128[] memory sizeList = new uint128[](1);
+            uint64[] memory spreadList = new uint64[](1);
 
-        sizeList[0] = positionSize;
-        spreadList[0] = type(uint64).max;
-        try
-            pp.dispatch(
-                posIdList,
-                posIdList,
-                sizeList,
-                spreadList,
-                Constants.MAX_V3POOL_TICK,
-                Constants.MIN_V3POOL_TICK,
-                true
-            )
-        {} catch (bytes memory reason) {
-            if (bytes4(reason) == Errors.TransferFailed.selector) {
-                vm.assume(false);
+            sizeList[0] = positionSize;
+            spreadList[0] = type(uint64).max;
+            try
+                pp.dispatch(
+                    posIdList,
+                    posIdList,
+                    sizeList,
+                    spreadList,
+                    Constants.MAX_V3POOL_TICK,
+                    Constants.MIN_V3POOL_TICK,
+                    true
+                )
+            {} catch (bytes memory reason) {
+                if (bytes4(reason) == Errors.TransferFailed.selector) {
+                    vm.assume(false);
+                }
+                revert();
             }
-            revert();
         }
-
         lastCollateralBalance0[Alice] = ct0.convertToAssets(ct0.balanceOf(Alice));
         lastCollateralBalance1[Alice] = ct1.convertToAssets(ct1.balanceOf(Alice));
 
@@ -5529,12 +5530,11 @@ contract PanopticPoolTest is PositionUtils {
 
         oneWaySwap(swapSizeSeed, swapDirection);
 
-        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        //(currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
         updatePositionDataVariable(numLegs, isLongs);
 
         updateITMAmountsBurn(numLegs, tokenTypes);
-
         updateIntrinsicValueBurn(longAmounts, shortAmounts);
 
         ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -2660,9 +2660,10 @@ contract PanopticPoolTest is PositionUtils {
 
             int256 notionalVal = int256(expectedSwap0) + amount0Moved - shortAmounts.rightSlot();
 
+            // set itm spread fee to 0
             int256 ITMSpread = notionalVal > 0
-                ? (notionalVal * int24(2 * (fee / 100))) / 10_000
-                : -(notionalVal * int24(2 * (fee / 100))) / 10_000;
+                ? (notionalVal * int24(2 * ((0 * fee) / 100))) / 10_000
+                : -(notionalVal * int24(2 * ((0 * fee) / 100))) / 10_000;
 
             assertApproxEqAbs(
                 ct0.balanceOf(Alice),
@@ -2937,13 +2938,14 @@ contract PanopticPoolTest is PositionUtils {
                     amount0s + $amount0Moveds[0] + $amount0Moveds[1] - shortAmounts.rightSlot(),
                     amount1s + $amount1Moveds[0] + $amount1Moveds[1] - shortAmounts.leftSlot()
                 ];
+                // set itm spread fee to 0
                 int256[2] memory ITMSpreads = [
                     notionalVals[0] > 0
-                        ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
+                        ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000),
                     notionalVals[1] > 0
-                        ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
+                        ? (notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000)
                 ];
 
                 assertApproxEqAbs(
@@ -3164,6 +3166,7 @@ contract PanopticPoolTest is PositionUtils {
             positionSizes[0]
         );
 
+        console2.log("Seller");
         vm.startPrank(Seller);
 
         {
@@ -3225,6 +3228,7 @@ contract PanopticPoolTest is PositionUtils {
             -netSurplus0
         );
 
+        console2.log("Alice");
         vm.startPrank(Alice);
 
         if (pp.isSafeMode() == false) {
@@ -3244,13 +3248,14 @@ contract PanopticPoolTest is PositionUtils {
                     amount1s + $amount1Moveds[1] + $amount1Moveds[2] - shortAmounts.leftSlot()
                 ];
 
+                // set itm spread fee to 0
                 ITMSpreads = [
                     notionalVals[0] > 0
-                        ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
+                        ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000),
                     notionalVals[1] > 0
-                        ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
+                        ? (notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000)
                 ];
 
                 uint256 tokenToPay = uint256(
@@ -3285,49 +3290,62 @@ contract PanopticPoolTest is PositionUtils {
             // price changes afters swap at mint so we need to update the price
             (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-            assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSizes[1]);
+            assertEq(
+                sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)),
+                positionSizes[1],
+                "FAIL: wrong sfpm balances"
+            );
 
             {
                 (, uint256 inAMM, ) = ct0.getPoolData();
                 assertApproxEqAbs(
                     inAMM,
                     uint128(shortAmountsSold.rightSlot() - longAmounts.rightSlot()),
-                    10
+                    10,
+                    "FAIL: wrong inAMM for token0"
                 );
             }
 
             {
                 (, uint256 inAMM, ) = ct1.getPoolData();
-                assertApproxEqAbs(inAMM, uint128(shortAmounts.leftSlot()), 10);
+                assertApproxEqAbs(
+                    inAMM,
+                    uint128(shortAmounts.leftSlot()),
+                    10,
+                    "FAIL: wrong inAMM for token1"
+                );
             }
 
             {
                 assertEq(
                     pp.positionsHash(Alice),
-                    uint248(uint256(keccak256(abi.encodePacked(tokenId))))
+                    uint248(uint256(keccak256(abi.encodePacked(tokenId)))),
+                    "FAIL: wrong position hash"
                 );
 
-                assertEq(pp.numberOfLegs(Alice), 2);
+                assertEq(pp.numberOfLegs(Alice), 2, "FAIL: wrong number of legs");
 
                 TokenId _tokenId = tokenId;
 
                 (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = ph
                     .optionPositionInfo(pp, Alice, _tokenId);
 
-                assertEq(balance, positionSizes[1]);
+                assertEq(balance, positionSizes[1], "FAIL: wrong balance for Alice");
                 assertEq(
                     int64(poolUtilization0),
                     Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
                         ? int64(10_001)
                         : ($amount0Moveds[0] + $amount0Moveds[1] + $amount0Moveds[2] * 10000) /
-                            int256(ct0.totalSupply())
+                            int256(ct0.totalSupply()),
+                    "FAIL: werong pool utiliation0"
                 );
                 assertEq(
                     int64(poolUtilization1),
                     Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
                         ? int64(10_001)
                         : ($amount1Moveds[0] + $amount1Moveds[1] + $amount1Moveds[2] * 10000) /
-                            int256(ct1.totalSupply())
+                            int256(ct1.totalSupply()),
+                    "FAIL: wrong pool utilzation1"
                 );
             }
 
@@ -4835,9 +4853,10 @@ contract PanopticPoolTest is PositionUtils {
             -int256(expectedSwaps[1]) - amount0Moveds[1] + shortAmounts.rightSlot()
         ];
 
+        // set itm spread fee to 0
         int256 ITMSpread = notionalVals[0] > 0
-            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+            ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+            : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000);
 
         assertApproxEqAbs(
             balanceBefores[0],
@@ -5009,9 +5028,10 @@ contract PanopticPoolTest is PositionUtils {
             -int256(expectedSwaps[1]) - amount0Moveds[1] + shortAmounts.rightSlot()
         ];
 
+        // set itm spread fee to 0
         int256 ITMSpread = notionalVals[0] > 0
-            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+            ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+            : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000);
 
         assertApproxEqAbs(
             balanceBefores[0],
@@ -5226,9 +5246,10 @@ contract PanopticPoolTest is PositionUtils {
             -int256(expectedSwaps[1]) - amount0Moveds[1] + shortAmounts.rightSlot()
         ];
 
+        // set itm spread fee to 0
         int256 ITMSpread = notionalVals[0] > 0
-            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+            ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+            : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000);
 
         assertApproxEqAbs(
             int256(balanceBefores[0]) - int256(uint256(type(uint104).max)),

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -3553,6 +3553,692 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
+    function test_Success_dispatch_OTMShortCall(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOTMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        TokenId[] memory posIdList = new TokenId[](1);
+        posIdList[0] = tokenId;
+
+        uint128[] memory sizeList = new uint128[](1);
+        sizeList[0] = positionSize;
+        uint64[] memory spreadList = new uint64[](1);
+        spreadList[0] = type(uint64).max;
+
+        pp.dispatch(
+            posIdList,
+            posIdList,
+            sizeList,
+            spreadList,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
+
+        uint256 amount0 = LiquidityAmounts.getAmount0ForLiquidity(
+            sqrtLower,
+            sqrtUpper,
+            expectedLiq
+        );
+
+        {
+            (, uint256 inAMM, ) = ct0.getPoolData();
+            assertApproxEqAbs(inAMM, amount0, 10, "inAMM 0");
+        }
+
+        {
+            (, uint256 inAMM, ) = ct1.getPoolData();
+            assertEq(inAMM, 0, "inAMM 1");
+        }
+        {
+            assertEq(
+                pp.positionsHash(Alice),
+                uint248(uint256(keccak256(abi.encodePacked(tokenId))))
+            );
+
+            assertEq(pp.numberOfLegs(Alice), 1);
+
+            (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = ph
+                .optionPositionInfo(pp, Alice, tokenId);
+
+            assertEq(balance, positionSize, "user balance");
+            assertEq(poolUtilization0, (amount0 * 10000) / ct0.totalSupply(), "pu 0");
+            assertEq(poolUtilization1, 0, "pu 1");
+        }
+
+        {
+            (, LeftRightSigned shortAmounts) = PanopticMath.computeExercisedAmounts(
+                tokenId,
+                uint128(positionSize)
+            );
+
+            assertApproxEqAbs(
+                ct0.balanceOf(Alice),
+                uint256(type(uint104).max) - uint128((shortAmounts.rightSlot() * 10) / 10000),
+                uint256(int256(shortAmounts.rightSlot()) / 1_000_000 + 10),
+                "alice balance 0"
+            );
+
+            assertEq(ct1.balanceOf(Alice), uint256(type(uint104).max), "alice balance 1");
+        }
+    }
+
+    function test_Success_dispatch_2xOTMShortCall(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds,
+        uint256[2] memory positionSizeSeeds
+    ) public {
+        _initPool(x);
+
+        (int24 width0, int24 strike0) = PositionUtils.getOTMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        (int24 width1, int24 strike1) = PositionUtils.getOTMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData([width0, width1], [strike0, strike1], positionSizeSeeds);
+
+        TokenId tokenId0 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike0,
+            width0
+        );
+
+        TokenId tokenId1 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike1,
+            width1
+        );
+
+        TokenId[] memory posIdList = new TokenId[](2);
+        posIdList[0] = tokenId0;
+        posIdList[1] = tokenId1;
+
+        uint128[] memory sizeList = new uint128[](2);
+        sizeList[0] = uint128(positionSizes[0]);
+        sizeList[1] = uint128(positionSizes[1]);
+        uint64[] memory spreadList = new uint64[](2);
+        spreadList[0] = type(uint64).max;
+        spreadList[1] = type(uint64).max;
+
+        pp.dispatch(
+            posIdList,
+            posIdList,
+            sizeList,
+            spreadList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)), positionSizes[0]);
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)), positionSizes[1]);
+
+        uint256 amount0 = LiquidityAmounts.getAmount0ForLiquidity(
+            sqrtLowers[0],
+            sqrtUppers[0],
+            expectedLiqs[0]
+        ) + LiquidityAmounts.getAmount0ForLiquidity(sqrtLowers[1], sqrtUppers[1], expectedLiqs[1]);
+
+        {
+            (, uint256 inAMM, ) = ct0.getPoolData();
+            assertApproxEqAbs(inAMM, amount0, 10, "inAMM 0");
+        }
+
+        {
+            (, uint256 inAMM, ) = ct1.getPoolData();
+            assertEq(inAMM, 0, "inAMM 1");
+        }
+        {
+            assertEq(
+                pp.positionsHash(Alice),
+                uint248(
+                    uint256(keccak256(abi.encodePacked(tokenId0))) ^
+                        uint256(keccak256(abi.encodePacked(tokenId1)))
+                ),
+                "FAIL: position hashes don't match"
+            );
+
+            assertEq(pp.numberOfLegs(Alice), 2, "FAIL: nLegs don't match");
+
+            (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = ph
+                .optionPositionInfo(pp, Alice, tokenId0);
+
+            assertEq(balance, positionSizes[0], "user balance");
+            assertEq(poolUtilization0, (amount0 * 10000) / ct0.totalSupply(), "pu 0");
+            assertEq(poolUtilization1, 0, "pu 1");
+        }
+
+        {
+            (, LeftRightSigned shortAmounts0) = PanopticMath.computeExercisedAmounts(
+                tokenId0,
+                uint128(positionSizes[0])
+            );
+
+            (, LeftRightSigned shortAmounts1) = PanopticMath.computeExercisedAmounts(
+                tokenId1,
+                uint128(positionSizes[1])
+            );
+
+            console2.log("shortAmounts0", shortAmounts0.rightSlot());
+            console2.log("shortAmounts1", shortAmounts1.rightSlot());
+            assertApproxEqAbs(
+                ct0.balanceOf(Alice),
+                uint256(type(uint104).max) -
+                    uint128((shortAmounts0.rightSlot() * 10) / 10000) -
+                    uint128((shortAmounts1.rightSlot() * 10) / 10000),
+                uint256(
+                    int256(shortAmounts0.rightSlot() + shortAmounts1.rightSlot()) / 1_000_000 + 10
+                ),
+                "alice balance 0"
+            );
+
+            assertEq(ct1.balanceOf(Alice), uint256(type(uint104).max), "alice balance 1");
+        }
+    }
+
+    function test_Success_dispatch_burn(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds,
+        uint256[2] memory positionSizeSeeds
+    ) public {
+        _initPool(x);
+
+        (int24 width0, int24 strike0) = PositionUtils.getOTMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        (int24 width1, int24 strike1) = PositionUtils.getOTMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData([width0, width1], [strike0, strike1], positionSizeSeeds);
+
+        TokenId tokenId0 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike0,
+            width0
+        );
+
+        TokenId tokenId1 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike1,
+            width1
+        );
+
+        TokenId[] memory posIdList = new TokenId[](2);
+        posIdList[0] = tokenId0;
+        posIdList[1] = tokenId1;
+
+        uint128[] memory sizeList = new uint128[](2);
+        sizeList[0] = uint128(positionSizes[0]);
+        sizeList[1] = uint128(positionSizes[1]);
+        uint64[] memory spreadList = new uint64[](2);
+        spreadList[0] = type(uint64).max;
+        spreadList[1] = type(uint64).max;
+
+        // mint two positions
+        pp.dispatch(
+            posIdList,
+            posIdList,
+            sizeList,
+            spreadList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)), positionSizes[0]);
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)), positionSizes[1]);
+
+        // burn two positions
+        pp.dispatch(
+            posIdList,
+            new TokenId[](0),
+            sizeList,
+            spreadList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)), 0);
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)), 0);
+    }
+
+    function test_Fail_dispatch_wrong_final_list(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds,
+        uint256[2] memory positionSizeSeeds
+    ) public {
+        _initPool(x);
+
+        (int24 width0, int24 strike0) = PositionUtils.getOTMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        (int24 width1, int24 strike1) = PositionUtils.getOTMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData([width0, width1], [strike0, strike1], positionSizeSeeds);
+
+        TokenId tokenId0 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike0,
+            width0
+        );
+
+        TokenId tokenId1 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike1,
+            width1
+        );
+
+        TokenId[] memory posIdList = new TokenId[](2);
+        posIdList[0] = tokenId0;
+        posIdList[1] = tokenId1;
+
+        TokenId[] memory posIdListWrong = new TokenId[](2);
+        posIdListWrong[0] = tokenId0;
+        posIdListWrong[1] = tokenId0;
+
+        uint128[] memory sizeList = new uint128[](2);
+        sizeList[0] = uint128(positionSizes[0]);
+        sizeList[1] = uint128(positionSizes[1]);
+        uint64[] memory spreadList = new uint64[](2);
+        spreadList[0] = type(uint64).max;
+        spreadList[1] = type(uint64).max;
+
+        vm.expectRevert(Errors.InputListFail.selector);
+        // mint two positions
+        pp.dispatch(
+            posIdList,
+            posIdListWrong,
+            sizeList,
+            spreadList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.expectRevert(Errors.InputListFail.selector);
+        // mint two positions
+        pp.dispatch(
+            posIdListWrong,
+            posIdList,
+            sizeList,
+            spreadList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+
+        vm.expectRevert(Errors.InputListFail.selector);
+        // mint two positions
+        pp.dispatch(
+            posIdListWrong,
+            posIdListWrong,
+            sizeList,
+            spreadList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+    }
+
+    function test_Success_dispatch_insolvent_between_states(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds
+    ) public {
+        _initPool(x);
+
+        (int24 width0, int24 strike0) = PositionUtils.getOTMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        (int24 width1, int24 strike1) = PositionUtils.getOTMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+        uint256[2] memory positionSizeSeeds;
+
+        positionSizeSeeds[0] = 10 ** 16;
+        positionSizeSeeds[1] = 10 ** 16;
+
+        populatePositionData([width0, width0], [strike0, strike0], positionSizeSeeds);
+
+        TokenId tokenId0 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike0,
+            width0
+        );
+
+        TokenId tokenId1 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            10,
+            isWETH,
+            0,
+            0,
+            0,
+            strike0,
+            width0
+        );
+
+        TokenId[] memory posIdListFail = new TokenId[](1);
+        posIdListFail[0] = tokenId1;
+
+        uint128[] memory sizeListFail = new uint128[](1);
+        sizeListFail[0] = uint128(positionSizes[1]);
+        uint64[] memory spreadList = new uint64[](1);
+        spreadList[0] = type(uint64).max;
+
+        console2.log("sis", positionSizes[0], positionSizes[1]);
+        (, LeftRightSigned shortAmounts0) = PanopticMath.computeExercisedAmounts(
+            tokenId0,
+            uint128(positionSizes[0])
+        );
+
+        (, LeftRightSigned shortAmounts1) = PanopticMath.computeExercisedAmounts(
+            tokenId1,
+            uint128(positionSizes[1])
+        );
+
+        console2.log("shortAmounts0", shortAmounts0.rightSlot());
+        console2.log("shortAmounts1", shortAmounts1.rightSlot());
+        vm.startPrank(Alice);
+        ct0.redeem(ct0.maxRedeem(Alice) - uint128(shortAmounts0.rightSlot()), Alice, Alice);
+        ct1.redeem(ct1.maxRedeem(Alice), Alice, Alice);
+
+        vm.expectRevert(Errors.AccountInsolvent.selector);
+        pp.dispatch(
+            posIdListFail,
+            posIdListFail,
+            sizeListFail,
+            spreadList,
+            Constants.MIN_V3POOL_TICK,
+            Constants.MAX_V3POOL_TICK,
+            true
+        );
+        {
+            TokenId[] memory posIdListPass = new TokenId[](3);
+            posIdListPass[0] = tokenId0;
+            posIdListPass[1] = tokenId1;
+            posIdListPass[2] = tokenId1;
+
+            TokenId[] memory posIdListFinal = new TokenId[](3);
+            posIdListFinal[0] = tokenId0;
+
+            uint128[] memory sizeListPass = new uint128[](3);
+            sizeListPass[0] = uint128(positionSizes[0]);
+            sizeListPass[1] = uint128(positionSizes[1]);
+            sizeListPass[2] = uint128(positionSizes[1]);
+
+            uint64[] memory spreadListPass = new uint64[](3);
+            spreadListPass[0] = type(uint64).max;
+            spreadListPass[1] = type(uint64).max;
+            spreadListPass[2] = type(uint64).max;
+
+            pp.dispatch(
+                posIdListPass,
+                posIdListFinal,
+                sizeListPass,
+                spreadListPass,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK,
+                true
+            );
+        }
+
+        assertEq(
+            sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)),
+            positionSizes[0],
+            "FAIL: sfpm balance token0"
+        );
+        assertEq(
+            sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)),
+            0,
+            "FAIL: sfpm balance token1"
+        );
+
+        uint256 amount0 = LiquidityAmounts.getAmount0ForLiquidity(
+            sqrtLowers[0],
+            sqrtUppers[0],
+            expectedLiqs[0]
+        );
+
+        {
+            (, uint256 inAMM, ) = ct0.getPoolData();
+            assertApproxEqAbs(inAMM, amount0, 10, "inAMM 0");
+        }
+
+        {
+            (, uint256 inAMM, ) = ct1.getPoolData();
+            assertEq(inAMM, 0, "inAMM 1");
+        }
+        {
+            assertEq(
+                pp.positionsHash(Alice),
+                uint248(uint256(keccak256(abi.encodePacked(tokenId0)))),
+                "FAIL: position hashes don't match"
+            );
+
+            assertEq(pp.numberOfLegs(Alice), 1, "FAIL: nLegs don't match");
+
+            {
+                (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = ph
+                    .optionPositionInfo(pp, Alice, tokenId0);
+
+                assertEq(balance, positionSizes[0], "user balance");
+                assertEq(poolUtilization0, (amount0 * 10000) / ct0.totalSupply(), "pu 0");
+                assertEq(poolUtilization1, 0, "pu 1");
+            }
+        }
+
+        {
+            assertApproxEqAbs(
+                ct0.balanceOf(Alice),
+                uint128(shortAmounts0.rightSlot()) -
+                    uint128((shortAmounts0.rightSlot() * 10) / 10000) -
+                    uint128((shortAmounts1.rightSlot() * 10) / 10000),
+                uint256(int256(shortAmounts0.rightSlot()) / 1_000_000 + 10),
+                "alice balance 0"
+            );
+            assertEq(ct1.balanceOf(Alice), 0, "alice balance 1");
+        }
+    }
+
+    function test_Success_dispatch_repeated_states(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds
+    ) public {
+        _initPool(x);
+
+        (int24 width0, int24 strike0) = PositionUtils.getOTMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        (int24 width1, int24 strike1) = PositionUtils.getOTMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+        uint256[2] memory positionSizeSeeds;
+
+        positionSizeSeeds[0] = 10 ** 16;
+        positionSizeSeeds[1] = 10 ** 16;
+
+        populatePositionData([width0, width0], [strike0, strike0], positionSizeSeeds);
+
+        TokenId tokenId0 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike0,
+            width0
+        );
+
+        TokenId tokenId1 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike1,
+            width1
+        );
+
+        TokenId[] memory posIdListFinal = new TokenId[](1);
+        posIdListFinal[0] = tokenId1;
+
+        uint256 numberOfPositions = ((x % 2 ** 10) / 2) * 2 + 3;
+
+        {
+            TokenId[] memory posIdList = new TokenId[](numberOfPositions);
+
+            uint128[] memory sizeList = new uint128[](numberOfPositions);
+
+            uint64[] memory spreadList = new uint64[](numberOfPositions);
+
+            for (uint256 i = 0; i < numberOfPositions; ++i) {
+                posIdList[i] = tokenId1;
+                sizeList[i] = uint128(positionSizes[1]);
+                spreadList[i] = type(uint64).max;
+            }
+
+            pp.dispatch(
+                posIdList,
+                posIdListFinal,
+                sizeList,
+                spreadList,
+                Constants.MIN_V3POOL_TICK,
+                Constants.MAX_V3POOL_TICK,
+                true
+            );
+        }
+
+        assertEq(
+            sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId0)),
+            0,
+            "FAIL: sfpm balance token0"
+        );
+        assertEq(
+            sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId1)),
+            positionSizes[1],
+            "FAIL: sfpm balance token1"
+        );
+    }
+
     function test_Fail_mintOptions_PriceBoundEqualFail(
         uint256 x,
         uint256 widthSeed,

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -597,7 +597,7 @@ contract PanopticPoolTest is PositionUtils {
         // deploy reference pool and collateral token
         poolReference = address(new PanopticPoolHarness(sfpm));
         collateralReference = address(
-            new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000, 20_000)
+            new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000)
         );
     }
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -6218,7 +6218,7 @@ contract PanopticPoolTest is PositionUtils {
 
         oneWaySwap(swapSizeSeed, swapDirection);
 
-        //(currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
         updatePositionDataVariable(numLegs, isLongs);
 
@@ -6254,7 +6254,7 @@ contract PanopticPoolTest is PositionUtils {
 
             rangesFromStrike = legRanges > rangesFromStrike ? legRanges : rangesFromStrike;
 
-            (, , , TWAPtick, ) = pp.getOracleTicks();
+            TWAPtick = pp.getUniV3TWAP_();
             uint160 lastObservedPrice = TickMath.getSqrtRatioAtTick(TWAPtick);
             LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
                 tokenId,
@@ -6291,7 +6291,6 @@ contract PanopticPoolTest is PositionUtils {
 
         exerciseFeeAmounts[0] += (longAmounts.rightSlot() * (-exerciseFee)) / 10_000;
         exerciseFeeAmounts[1] += (longAmounts.leftSlot() * (-exerciseFee)) / 10_000;
-
         forceExercise(
             pp,
             Alice,
@@ -6374,7 +6373,7 @@ contract PanopticPoolTest is PositionUtils {
                     int256(lastCollateralBalance0[Alice]),
                 $balanceDelta0,
                 uint256(
-                    int256((longAmounts.rightSlot() + shortAmounts.rightSlot()) / 1_000_000 + 10)
+                    int256((longAmounts.rightSlot() + shortAmounts.rightSlot()) / 1_00_000 + 10)
                 ),
                 "Incorrect balance delta for token0 (Force Exercisee)"
             );
@@ -7358,7 +7357,7 @@ contract PanopticPoolTest is PositionUtils {
         }
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-        (, , , TWAPtick, ) = pp.getOracleTicks();
+        TWAPtick = pp.getUniV3TWAP_();
         vm.assume(Math.abs(int256(currentTick) - TWAPtick) <= 513);
 
         (, uint256 totalCollateralRequired0) = ph.checkCollateral(
@@ -7955,7 +7954,8 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
-        (, , , TWAPtick, ) = pp.getOracleTicks();
+
+        TWAPtick = pp.getUniV3TWAP_();
         vm.assume(Math.abs(int256(currentTick) - TWAPtick) <= 513);
 
         (, uint256 totalCollateralRequired0) = ph.checkCollateral(

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -81,6 +81,141 @@ contract PanopticPoolHarness is PanopticPool {
         return (premiasByLeg, netExchanged);
     }
 
+    function mintOptions(
+        TokenId[] memory positionIdList,
+        uint128 positionSize,
+        uint64 effectiveLiquidityLimitX32,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory mintList = new TokenId[](1);
+
+        TokenId tokenId = positionIdList[positionIdList.length - 1];
+        sizeList[0] = positionSize;
+        spreadList[0] = effectiveLiquidityLimitX32;
+        mintList[0] = tokenId;
+        this.dispatch(
+            mintList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        TokenId tokenId,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+        TokenId[] memory burnList = new TokenId[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+        burnList[0] = tokenId;
+        this.dispatch(
+            burnList,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function burnOptions(
+        TokenId[] memory tokenIds,
+        TokenId[] memory positionIdList,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        sizeList[0] = 0;
+        spreadList[0] = type(uint64).max;
+
+        this.dispatch(
+            tokenIds,
+            positionIdList,
+            sizeList,
+            spreadList,
+            tickLimitLow,
+            tickLimitHigh,
+            premiaAsCollateral
+        );
+    }
+
+    function liquidate(
+        TokenId[] memory liquidatorList,
+        address liquidatee,
+        TokenId[] memory positionIdList
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        this.dispatchFrom(
+            liquidatorList,
+            liquidatee,
+            positionIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function forceExercise(
+        address exercisee,
+        TokenId tokenId,
+        TokenId[] memory exerciseeList,
+        TokenId[] memory exercisorList,
+        LeftRightUnsigned premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        this.dispatchFrom(
+            exercisorList,
+            exercisee,
+            targetList,
+            exerciseeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
+    function settleLongPremium(
+        TokenId[] memory settlerList,
+        TokenId[] memory settleeList,
+        address exercisee,
+        uint256 legIndex,
+        bool premiaAsCollateral
+    ) external {
+        uint128[] memory sizeList = new uint128[](1);
+        uint64[] memory spreadList = new uint64[](1);
+
+        TokenId[] memory targetList = new TokenId[](1);
+
+        this.dispatchFrom(
+            settlerList,
+            exercisee,
+            targetList,
+            settleeList,
+            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+        );
+    }
+
     constructor(SemiFungiblePositionManager _sfpm) PanopticPool(_sfpm) {}
 }
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -400,20 +400,24 @@ contract PanopticPoolTest is PositionUtils {
         PanopticPool pp,
         address exercisee,
         TokenId tokenId,
-        TokenId[] memory exerciseeList,
+        TokenId[] memory exerciseeListFinal,
         TokenId[] memory exercisorList,
         LeftRightUnsigned premiaAsCollateral
     ) internal {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
 
-        TokenId[] memory targetList = new TokenId[](1);
+        TokenId[] memory exerciseeListInitial = new TokenId[](exerciseeListFinal.length + 1);
+        for (uint256 i = 0; i < exerciseeListFinal.length; ++i) {
+            exerciseeListInitial[i] = exerciseeListFinal[i];
+        }
+        exerciseeListInitial[exerciseeListInitial.length - 1] = tokenId;
 
         pp.dispatchFrom(
             exercisorList,
             exercisee,
-            targetList,
-            exerciseeList,
+            exerciseeListInitial,
+            exerciseeListFinal,
             LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
         );
     }
@@ -429,12 +433,10 @@ contract PanopticPoolTest is PositionUtils {
         uint128[] memory sizeList = new uint128[](1);
         uint64[] memory spreadList = new uint64[](1);
 
-        TokenId[] memory targetList = new TokenId[](1);
-
         pp.dispatchFrom(
             settlerList,
             exercisee,
-            targetList,
+            settleeList,
             settleeList,
             LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
         );
@@ -6639,6 +6641,9 @@ contract PanopticPoolTest is PositionUtils {
         {
             uint256 snap = vm.snapshot();
 
+            vm.warp(block.timestamp + 1200);
+            vm.roll(block.number + 100);
+
             vm.startPrank(Bob);
             forceExercise(
                 pp,
@@ -7224,7 +7229,7 @@ contract PanopticPoolTest is PositionUtils {
             pp,
             Alice,
             touchedIds[0],
-            touchedIds,
+            new TokenId[](0),
             new TokenId[](0),
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
@@ -8900,9 +8905,194 @@ contract PanopticPoolTest is PositionUtils {
                 LeftRightUnsigned.wrap(0)
             )
         {
-            assertFalse(true, "liquidation should have failed");
+            assertFalse($posIdLists[1].length > 1, "liquidation should have failed");
         } catch (bytes memory reason) {
-            assertTrue(bytes4(reason) == Errors.NotMarginCalled.selector);
+            assertTrue(
+                (bytes4(reason) == Errors.NotMarginCalled.selector) ||
+                    (bytes4(reason) == Errors.NoLegsExercisable.selector)
+            );
         }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           DISPATCHFROM TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Fail_dispatchFrom_InvalidCallerList(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getITMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        (int24 width2, int24 strike2) = PositionUtils.getOTMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+        vm.assume(width2 != width || strike2 != strike);
+
+        populatePositionData([width, width2], [strike, strike2], positionSizeSeed);
+
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        TokenId[] memory posIdList = new TokenId[](1);
+        posIdList[0] = tokenId;
+
+        mintOptions(
+            pp,
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        posIdList = new TokenId[](2);
+        posIdList[0] = tokenId;
+
+        TokenId tokenId2 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike2,
+            width2
+        );
+
+        posIdList[1] = tokenId2;
+
+        mintOptions(
+            pp,
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        vm.startPrank(Bob);
+
+        vm.expectRevert(Errors.InputListFail.selector);
+        pp.dispatchFrom(
+            posIdList,
+            Alice,
+            posIdList,
+            posIdList,
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
+    }
+
+    function test_Fail_dispatchFrom_InvalidFinalList(
+        uint256 x,
+        uint256[2] memory widthSeeds,
+        int256[2] memory strikeSeeds,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getITMSW(
+            widthSeeds[0],
+            strikeSeeds[0],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        (int24 width2, int24 strike2) = PositionUtils.getOTMSW(
+            widthSeeds[1],
+            strikeSeeds[1],
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+        vm.assume(width2 != width || strike2 != strike);
+
+        populatePositionData([width, width2], [strike, strike2], positionSizeSeed);
+
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike,
+            width
+        );
+
+        TokenId[] memory posIdList = new TokenId[](1);
+        posIdList[0] = tokenId;
+
+        mintOptions(
+            pp,
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        posIdList = new TokenId[](2);
+        posIdList[0] = tokenId;
+
+        TokenId tokenId2 = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            strike2,
+            width2
+        );
+
+        posIdList[1] = tokenId2;
+
+        mintOptions(
+            pp,
+            posIdList,
+            positionSize,
+            0,
+            Constants.MAX_V3POOL_TICK,
+            Constants.MIN_V3POOL_TICK,
+            true
+        );
+
+        vm.startPrank(Bob);
+
+        vm.expectRevert(Errors.InputListFail.selector);
+        pp.dispatchFrom(
+            new TokenId[](0),
+            Alice,
+            posIdList,
+            new TokenId[](0),
+            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+        );
     }
 }

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -4439,7 +4439,7 @@ contract PanopticPoolTest is PositionUtils {
         posIdList[0] = tokenId;
         posIdList[1] = tokenId;
 
-        vm.expectRevert(Errors.PositionAlreadyMinted.selector);
+        vm.expectRevert(Errors.InputListFail.selector);
         mintOptions(
             pp,
             posIdList,
@@ -9086,7 +9086,7 @@ contract PanopticPoolTest is PositionUtils {
 
         vm.startPrank(Bob);
 
-        vm.expectRevert(Errors.InputListFail.selector);
+        vm.expectRevert(Errors.NotMarginCalled.selector);
         pp.dispatchFrom(
             new TokenId[](0),
             Alice,


### PR DESCRIPTION
This PR introduces a major architectural change to the PanopticPool contract, consolidating mint/burn and liquidate/forceExercise/settleLongPremium operations through a unified dispatch system while improving premium handling and oracle validation.

This supersedes this PR: https://github.com/panoptic-labs/panoptic-next-core-private/pull/163 (which has now been closed)

## Key Changes

### Core Interface Changes:

- Replace individual mintOptions() and burnOptions() methods with unified dispatch() system
- Add new dispatchFrom() for liquidations, force exercises, and premium settlements
- Consolidate multiple operation types (mint, burn, liquidate, force exercise, settle premium) into single entry points

### Contract Architecture:

- Consolidate solvency checking with unified _checkSolvencyAtTicks() return values
- Streamline position validation and liquidity spread checking

### Test Infrastructure:

- Update all tests to use new dispatch-based helper functions
- Maintain backwards compatibility through wrapper functions
 
TODO:

- [ ] add more tests for multiple mints/burns
- [ ] make sure all existing tests still pass 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Toggle to treat accumulated premiums as collateral across withdrawals, settlements, and liquidations.
  - Batch mint/burn via unified dispatch and coordinated multi-list dispatchFrom.
  - ERC1155 single-transfer receipt support.

- Breaking Changes
  - Withdrawal and pool public APIs updated to accept a premiums-as-collateral flag and batch entry points.
  - Public refund API renamed (exercise-deltas → refund-oriented).
  - Oracle staleness error renamed to StaleOracle.

- Improvements
  - Refined solvency, premia settlement, and oracle/tick handling.

- Chores
  - Optimizer runs parameter adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->