### PR TITLE
Feat6: Add support for width-0 positions as simple token transfers in SFPM

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1062,14 +1062,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @return The final utilization of the collateral vault
-    /// @return The total amount of commission (base rate + ITM spread) paid
+    /// @return The final utilization of the collateral vault (rightSlot) and the total amount of commission (base rate + ITM spread) paid (leftSlot)
     function settleMint(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount
-    ) external onlyPanopticPool returns (uint32, uint128) {
+    ) external onlyPanopticPool returns (LeftRightUnsigned, int128) {
         (uint32 utilization, uint128 commission, int128 tokenPaid) = _updateBalancesAndSettle(
             true, // isCreation = true
             optionOwner,
@@ -1078,7 +1077,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             swappedAmount,
             0 // realizedPremium not used
         );
-        return (utilization, commission);
+        return (
+            LeftRightUnsigned.wrap(0).toRightSlot(utilization).toLeftSlot(commission),
+            tokenPaid
+        );
     }
 
     /// @notice Exercise an option and pay to the seller what is owed from the buyer.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -997,7 +997,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount,
-        int128 realizedPremium
+        int128 realizedPremium,
+        bool FLAG
     ) internal returns (uint32, uint128, int128) {
         unchecked {
             int256 tokenToPay;
@@ -1028,19 +1029,20 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 tokenToPay = intrinsicValue - realizedPremium;
             }
 
-            // Mint/Burn Shares
-            if (tokenToPay > 0) {
-                uint256 sharesToBurn = Math.mulDivRoundingUp(
-                    uint256(tokenToPay),
-                    totalSupply,
-                    totalAssets()
-                );
-                _burn(optionOwner, sharesToBurn);
-            } else if (tokenToPay < 0) {
-                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
-                _mint(optionOwner, sharesToMint);
+            if (FLAG) {
+                // Mint/Burn Shares
+                if (tokenToPay > 0) {
+                    uint256 sharesToBurn = Math.mulDivRoundingUp(
+                        uint256(tokenToPay),
+                        totalSupply,
+                        totalAssets()
+                    );
+                    _burn(optionOwner, sharesToBurn);
+                } else if (tokenToPay < 0) {
+                    uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
+                    _mint(optionOwner, sharesToMint);
+                }
             }
-
             // Update Pool Assets
             if (isCreation) {
                 s_poolAssets = uint256(updatedAssets).toUint128();
@@ -1056,7 +1058,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             uint32 utilization = isCreation ? uint32(_poolUtilization()) : 0;
 
-            return (utilization, commission, int128(intrinsicValue - realizedPremium));
+            return (utilization, commission, int128(tokenToPay));
         }
     }
 
@@ -1070,7 +1072,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount
+        int128 swappedAmount,
+        bool FLAG
     ) external onlyPanopticPool returns (LeftRightUnsigned, int128) {
         (uint32 utilization, uint128 commission, int128 tokenPaid) = _updateBalancesAndSettle(
             true, // isCreation = true
@@ -1078,7 +1081,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             longAmount,
             shortAmount,
             swappedAmount,
-            0 // realizedPremium not used
+            0, // realizedPremium not used,
+            FLAG
         );
         return (
             LeftRightUnsigned.wrap(0).toRightSlot(utilization).toLeftSlot(commission),
@@ -1107,7 +1111,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             longAmount,
             shortAmount,
             swappedAmount,
-            realizedPremium
+            realizedPremium,
+            true
         );
         return tokenPaid;
     }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1006,9 +1006,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
+            int256 intrinsicValue;
+
             if (isCreation) {
                 {
-                    int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
+                    intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
 
                     // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
                     commission = uint128(
@@ -1021,8 +1023,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     tokenToPay = intrinsicValue + int128(commission);
                 }
             } else {
+                intrinsicValue = int256(swappedAmount) - (longAmount - shortAmount);
                 // add premium and token deltas not covered by swap to be paid/collected on position close
-                tokenToPay = int256(swappedAmount) - (longAmount - shortAmount) - realizedPremium;
+                tokenToPay = intrinsicValue - realizedPremium;
             }
 
             // Mint/Burn Shares
@@ -1053,7 +1056,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             uint32 utilization = isCreation ? uint32(_poolUtilization()) : 0;
 
-            return (utilization, commission, int128(tokenToPay));
+            return (utilization, commission, int128(intrinsicValue - realizedPremium));
         }
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -984,6 +984,79 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                      OPTION EXERCISE AND COMMISSION
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Internal function to handle all balance and state updates for position creation and closing.
+    /// @param isCreation A boolean flag to indicate if this is for option creation (true) or closing (false).
+    /// @param optionOwner The user minting the option
+    /// @param longAmount The amount of longs
+    /// @param shortAmount The amount of shorts
+    /// @param swappedAmount The amount of tokens moved during creation of the option position
+    ///
+    function _updateBalancesAndSettle(
+        bool isCreation,
+        address optionOwner,
+        int128 longAmount,
+        int128 shortAmount,
+        int128 swappedAmount,
+        int128 realizedPremium
+    ) internal returns (uint32, uint128, int128) {
+        unchecked {
+            int256 tokenToPay;
+            uint128 commission;
+
+            // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
+            int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
+
+            if (isCreation) {
+                {
+                    int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
+
+                    // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
+                    commission = uint128(
+                        Math.unsafeDivRoundingUp(
+                            uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
+                            DECIMALS
+                        )
+                    );
+
+                    tokenToPay = intrinsicValue + int128(commission);
+                }
+            } else {
+                // add premium and token deltas not covered by swap to be paid/collected on position close
+                tokenToPay = int256(swappedAmount) - (longAmount - shortAmount) - realizedPremium;
+            }
+
+            // Mint/Burn Shares
+            if (tokenToPay > 0) {
+                uint256 sharesToBurn = Math.mulDivRoundingUp(
+                    uint256(tokenToPay),
+                    totalSupply,
+                    totalAssets()
+                );
+                _burn(optionOwner, sharesToBurn);
+            } else if (tokenToPay < 0) {
+                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
+                _mint(optionOwner, sharesToMint);
+            }
+
+            // Update Pool Assets
+            if (isCreation) {
+                s_poolAssets = uint256(updatedAssets).toUint128();
+            } else {
+                s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
+            }
+
+            // Update s_inAMM
+            s_inAMM = uint256(
+                int256(uint256(s_inAMM)) +
+                    (isCreation ? (shortAmount - longAmount) : -(shortAmount - longAmount))
+            ).toUint128();
+
+            uint32 utilization = isCreation ? uint32(_poolUtilization()) : 0;
+
+            return (utilization, commission, int128(tokenToPay));
+        }
+    }
+
     /// @notice Take commission and settle ITM amounts on option creation.
     /// @param optionOwner The user minting the option
     /// @param longAmount The amount of longs
@@ -997,52 +1070,15 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 shortAmount,
         int128 swappedAmount
     ) external onlyPanopticPool returns (uint32, uint128) {
-        unchecked {
-            // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
-            int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
-
-            int256 tokenToPay;
-            uint128 commission;
-
-            {
-                int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
-
-                // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
-                commission = uint128(
-                    Math.unsafeDivRoundingUp(
-                        uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
-                        DECIMALS
-                    )
-                );
-
-                tokenToPay = intrinsicValue + int128(commission);
-            }
-
-            // compute tokens to be paid due to swap
-            // mint or burn tokens due to minting in-the-money
-            if (tokenToPay > 0) {
-                // if user must pay tokens, burn them from user balance
-                uint256 sharesToBurn = Math.mulDivRoundingUp(
-                    uint256(tokenToPay),
-                    totalSupply,
-                    totalAssets()
-                );
-                _burn(optionOwner, sharesToBurn);
-            } else if (tokenToPay < 0) {
-                // if user must receive tokens, mint them
-                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
-                _mint(optionOwner, sharesToMint);
-            }
-
-            // update stored asset balances with net moved amounts
-            // the inflow or outflow of pool assets is defined by the swappedAmount: it includes both the ITM swap amounts and the short/long amounts used to create the position
-            // however, any intrinsic value is paid for by the users, so we only add the portion that comes from PLPs: the short/long amounts
-            // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
-            s_poolAssets = uint256(updatedAssets).toUint128();
-            s_inAMM = uint256(int256(uint256(s_inAMM)) + (shortAmount - longAmount)).toUint128();
-
-            return (uint32(_poolUtilization()), commission);
-        }
+        (uint32 utilization, uint128 commission, int128 tokenPaid) = _updateBalancesAndSettle(
+            true, // isCreation = true
+            optionOwner,
+            longAmount,
+            shortAmount,
+            swappedAmount,
+            0 // realizedPremium not used
+        );
+        return (utilization, commission);
     }
 
     /// @notice Exercise an option and pay to the seller what is owed from the buyer.
@@ -1060,37 +1096,15 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 swappedAmount,
         int128 realizedPremium
     ) external onlyPanopticPool returns (int128) {
-        unchecked {
-            // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
-            int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
-
-            // add premium and token deltas not covered by swap to be paid/collected on position close
-            int256 tokenToPay = int256(swappedAmount) -
-                (longAmount - shortAmount) -
-                realizedPremium;
-
-            if (tokenToPay > 0) {
-                // if user must pay tokens, burn them from user balance (revert if balance too small)
-                uint256 sharesToBurn = Math.mulDivRoundingUp(
-                    uint256(tokenToPay),
-                    totalSupply,
-                    totalAssets()
-                );
-                _burn(optionOwner, sharesToBurn);
-            } else if (tokenToPay < 0) {
-                // if user must receive tokens, mint them
-                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
-                _mint(optionOwner, sharesToMint);
-            }
-
-            // update stored asset balances with net moved amounts
-            // any intrinsic value is paid for by the users, so we do not add it to s_inAMM
-            // premia is not included in the balance since it is the property of options buyers and sellers, not PLPs
-            s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
-            s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
-
-            return (int128(tokenToPay));
-        }
+        (, , int128 tokenPaid) = _updateBalancesAndSettle(
+            false, // isCreation = false
+            optionOwner,
+            longAmount,
+            shortAmount,
+            swappedAmount,
+            realizedPremium
+        );
+        return tokenPaid;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -991,7 +991,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param swappedAmount The amount of tokens moved during creation of the option position
     /// @return The final utilization of the collateral vault
     /// @return The total amount of commission (base rate + ITM spread) paid
-    function takeCommissionAddData(
+    function settleMint(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
@@ -1053,7 +1053,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param swappedAmount The amount of tokens moved during the option close
     /// @param realizedPremium Premium to settle on the current positions
     /// @return The amount of tokens paid when closing that position
-    function exercise(
+    function settleBurn(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1103,7 +1103,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount,
-        int128 realizedPremium
+        int128 realizedPremium,
+        bool FLAG
     ) external onlyPanopticPool returns (int128) {
         (, , int128 tokenPaid) = _updateBalancesAndSettle(
             false, // isCreation = false
@@ -1112,7 +1113,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             shortAmount,
             swappedAmount,
             realizedPremium,
-            true
+            FLAG
         );
         return tokenPaid;
     }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -989,15 +989,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @param isCovered Whether the option was minted as covered (no swap occurred if ITM)
     /// @return The final utilization of the collateral vault
     /// @return The total amount of commission (base rate + ITM spread) paid
     function takeCommissionAddData(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount,
-        bool isCovered
+        int128 swappedAmount
     ) external onlyPanopticPool returns (uint32, uint128) {
         unchecked {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
@@ -1006,8 +1004,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             (int256 tokenToPay, uint128 commission) = _getExchangedAmount(
                 longAmount,
                 shortAmount,
-                swappedAmount,
-                isCovered
+                swappedAmount
             );
 
             // compute tokens to be paid due to swap
@@ -1089,14 +1086,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of long options held
     /// @param shortAmount The amount of short options held
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @param isCovered Whether the option was minted as covered (no swap occurred if ITM)
     /// @return The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
     /// @return The total commission (base rate + ITM spread) paid for minting the option
     function _getExchangedAmount(
         int128 longAmount,
         int128 shortAmount,
-        int128 swappedAmount,
-        bool isCovered
+        int128 swappedAmount
     ) internal view returns (int256, uint128) {
         unchecked {
             int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
@@ -1105,15 +1100,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             uint256 commission = Math.unsafeDivRoundingUp(
                 uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
                 DECIMALS
-            ) +
-                (
-                    intrinsicValue == 0 || isCovered
-                        ? 0
-                        : Math.unsafeDivRoundingUp(
-                            s_ITMSpreadFee * uint256(Math.abs(intrinsicValue)),
-                            DECIMALS * 100
-                        )
-                );
+            );
 
             return (intrinsicValue + int256(commission), uint128(commission));
         }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1001,11 +1001,22 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
-            (int256 tokenToPay, uint128 commission) = _getExchangedAmount(
-                longAmount,
-                shortAmount,
-                swappedAmount
-            );
+            int256 tokenToPay;
+            uint128 commission;
+
+            {
+                int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
+
+                // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
+                commission = uint128(
+                    Math.unsafeDivRoundingUp(
+                        uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
+                        DECIMALS
+                    )
+                );
+
+                tokenToPay = intrinsicValue + int128(commission);
+            }
 
             // compute tokens to be paid due to swap
             // mint or burn tokens due to minting in-the-money
@@ -1079,30 +1090,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             s_inAMM = uint256(int256(uint256(s_inAMM)) - (shortAmount - longAmount)).toUint128();
 
             return (int128(tokenToPay));
-        }
-    }
-
-    /// @notice Get the amount exchanged to mint an option, including any fees.
-    /// @param longAmount The amount of long options held
-    /// @param shortAmount The amount of short options held
-    /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @return The amount of funds to be exchanged for minting an option (includes commission, swapFee, and intrinsic value)
-    /// @return The total commission (base rate + ITM spread) paid for minting the option
-    function _getExchangedAmount(
-        int128 longAmount,
-        int128 shortAmount,
-        int128 swappedAmount
-    ) internal view returns (int256, uint128) {
-        unchecked {
-            int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
-
-            // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
-            uint256 commission = Math.unsafeDivRoundingUp(
-                uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
-                DECIMALS
-            );
-
-            return (intrinsicValue + int256(commission), uint128(commission));
         }
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 // Interfaces
-
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
 import {IUniswapV3Pool} from "univ3-core/interfaces/IUniswapV3Pool.sol";
@@ -642,13 +641,13 @@ contract PanopticPool is Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (uint32 utilization0, uint128 commission0) = s_collateralToken0.settleMint(
+        (LeftRightUnsigned utilizationAndCommission0, ) = s_collateralToken0.settleMint(
             owner,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
             totalSwapped.rightSlot()
         );
-        (uint32 utilization1, uint128 commission1) = s_collateralToken1.settleMint(
+        (LeftRightUnsigned utilizationAndCommission1, ) = s_collateralToken1.settleMint(
             owner,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
@@ -658,8 +657,13 @@ contract PanopticPool is Multicall {
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
             return (
-                utilization0 + (utilization1 << 16),
-                LeftRightUnsigned.wrap(commission0).toLeftSlot(commission1)
+                uint32(
+                    utilizationAndCommission0.rightSlot() +
+                        (utilizationAndCommission1.rightSlot() << 16)
+                ),
+                LeftRightUnsigned.wrap(utilizationAndCommission0.leftSlot()).toLeftSlot(
+                    utilizationAndCommission1.leftSlot()
+                )
             );
         }
     }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -886,10 +886,9 @@ contract PanopticPool is Multicall {
     ) external {
         // Assert the account we are liquidating is actually insolvent
         int24 twapTick = getUniV3TWAP();
-
         int24 currentTick;
-
         uint256 path;
+
         TokenId tokenId;
 
         uint256 solvent;
@@ -928,7 +927,7 @@ contract PanopticPool is Multicall {
             numberOfTicks = atTicks.length;
         }
         {
-            // if account is solvent at all ticks, this is a force exercise
+            // if account is solvent at all ticks, this is a force exercise or a settleLongPremium.
             if (solvent == numberOfTicks) {
                 uint256 toLength = positionIdListTo.length;
                 uint256 finalLength = positionIdListToFinal.length;
@@ -945,51 +944,60 @@ contract PanopticPool is Multicall {
                         }
                         path = 0;
                     } else if (toLength == (finalLength + 1)) {
-                        // final is one shorter, that's a force exercise
+                        // final is one element shorter, that's a force exercise
                         tokenId.validateIsExercisable(twapTick);
                         path = 1;
                     } else if (finalLength == 0) {
+                        // if final length was zero, this was intended to be liquidaton, but revert because not marging called
                         revert Errors.NotMarginCalled();
                     } else {
+                        // otherwise, wrong input lists
                         revert Errors.InputListFail();
                     }
                 }
             } else if (solvent == 0) {
                 // if account is insolvent at all ticks, this is a liquidation
+
+                // if the positions lengths are the same, this was intended as a settleLongPremia, but revert because account is insolvent
                 if (positionIdListToFinal.length == positionIdListTo.length)
                     revert Errors.AccountInsolvent();
+
+                // if the final position list has a non-zero length, this can't be a complete liquidation, revert
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
                 path = 2;
             } else {
+                // otherwise, revert because the account is not fully margin called
                 revert Errors.NotMarginCalled();
             }
         }
 
-        if (path == 2) {
-            _liquidate(account, positionIdListTo, twapTick, currentTick);
-            // no need to check that the liquidatee is solvent as all positions are burnt
-        } else {
-            // if path = 0, settleLongPremium
-            if (path == 0) {
-                _settleLongPremium(account, tokenId, twapTick, currentTick);
+        {
+            LeftRightSigned exchangedAmounts;
+            if (path == 2) {
+                exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
+                // no need to check that the liquidatee is solvent as all positions are burnt
+            } else {
+                // if path = 0, settleLongPremium
+                if (path == 0) {
+                    exchangedAmounts = _settleLongPremium(account, tokenId, twapTick, currentTick);
+                }
+
+                // if path = 1, force exercise
+
+                if (path == 1) {
+                    // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
+                    exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
+                }
+
+                // ensure the callee is still solvent after the operation
+                _validateSolvency(
+                    account,
+                    positionIdListToFinal,
+                    NO_BUFFER,
+                    usePremiaAsCollateral.rightSlot() > 0
+                );
             }
-
-            // if path = 1, force exercise
-
-            if (path == 1) {
-                // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-                _forceExercise(account, tokenId, twapTick, currentTick);
-            }
-
-            // ensure the callee is still solvent after the operation
-            _validateSolvency(
-                account,
-                positionIdListToFinal,
-                NO_BUFFER,
-                usePremiaAsCollateral.rightSlot() > 0
-            );
         }
-
         // ensure the caller is still solvent after the operation
         _validateSolvency(
             msg.sender,
@@ -1008,7 +1016,7 @@ contract PanopticPool is Multicall {
         TokenId[] calldata positionIdList,
         int24 twapTick,
         int24 currentTick
-    ) internal {
+    ) internal returns (LeftRightSigned bonusAmounts) {
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
         LeftRightUnsigned shortPremium;
@@ -1044,7 +1052,6 @@ contract PanopticPool is Multicall {
         s_collateralToken0.delegate(liquidatee);
         s_collateralToken1.delegate(liquidatee);
 
-        LeftRightSigned bonusAmounts;
         {
             LeftRightSigned netPaid;
             LeftRightSigned[4][] memory premiasByLeg;
@@ -1112,7 +1119,7 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         int24 twapTick,
         int24 currentTick
-    ) internal {
+    ) internal returns (LeftRightSigned refundAmounts) {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
@@ -1154,13 +1161,7 @@ contract PanopticPool is Multicall {
             );
         }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
-        LeftRightSigned refundAmounts = PanopticMath.getRefundAmounts(
-            account,
-            exerciseFees,
-            twapTick,
-            ct0,
-            ct1
-        );
+        refundAmounts = PanopticMath.getRefundAmounts(account, exerciseFees, twapTick, ct0, ct1);
 
         // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
         ct0.refund(account, msg.sender, refundAmounts.rightSlot());
@@ -1183,15 +1184,13 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         int24 twapTick,
         int24 currentTick
-    ) internal {
+    ) internal returns (LeftRightSigned refundAmounts) {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
         // The protocol delegates some virtual shares to ensure the premia can be settled.
         ct0.delegate(owner);
         ct1.delegate(owner);
-
-        LeftRightSigned refundAmounts;
 
         uint128 positionSize = s_positionBalance[owner][tokenId].positionSize();
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -511,16 +511,10 @@ contract PanopticPool is Multicall {
         int24[2][] calldata tickLimits,
         bool[2] calldata bools //usePremiaAsCollateral
     ) external {
-        // if safeMode, enforce covered at mint and exercise at burn
-        //if (isSafeMode()) {
-        //    if (tickLimitLow > tickLimitHigh) {
-        //        (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
-        //    }
-        //}
+        //bool safeMode = isSafeMode();
         LeftRightSigned netPaid;
-        uint256 pLength = positionIdList.length;
         uint64 poolId;
-        for (uint256 i = 0; i < pLength; ) {
+        for (uint256 i = 0; i < positionIdList.length; ) {
             TokenId tokenId = positionIdList[i];
 
             poolId = tokenId.poolId();
@@ -529,25 +523,32 @@ contract PanopticPool is Multicall {
                 revert Errors.InvalidTokenIdParameter(0);
 
             PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId];
-
-            LeftRightSigned paidAmounts;
+            /*
+            if (safeMode) {
+                if (tickLimitLow > tickLimitHigh) {
+                    (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
+                }
+            }
+            */
             if (PositionBalance.unwrap(positionBalanceData) == 0) {
-                paidAmounts = _mintOptions(
+                LeftRightSigned paidAmounts = _mintOptions(
                     tokenId,
                     positionSizes[i],
                     effectiveLiquidityLimitsX32[i],
                     msg.sender,
-                    tickLimits[i],
+                    tickLimits[i][0],
+                    tickLimits[i][1],
                     bools[1]
                 );
                 netPaid = netPaid.add(paidAmounts);
             } else {
                 _burnOptions(
-                    COMMIT_LONG_SETTLED,
                     tokenId,
                     positionBalanceData.positionSize(),
+                    tickLimits[i][0],
+                    tickLimits[i][1],
                     msg.sender,
-                    tickLimits[i],
+                    COMMIT_LONG_SETTLED,
                     bools[1]
                 );
             }
@@ -583,19 +584,21 @@ contract PanopticPool is Multicall {
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param owner The owner of the option position to be minted
-    /// @param tickLimits The lower and upper bound of an acceptable open interval for the ending price
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     /// @param executeAtSettlement whether to...
     function _mintOptions(
         TokenId tokenId,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
         address owner,
-        int24[2] memory tickLimits,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
         bool executeAtSettlement
     ) internal returns (LeftRightSigned paidAmounts) {
         // Mint in the SFPM and update state of collateral
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
-            .mintTokenizedPosition(tokenId, positionSize, tickLimits[0], tickLimits[1]);
+            .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
         _updateSettlementPostMint(
             tokenId,
@@ -618,15 +621,17 @@ contract PanopticPool is Multicall {
 
         if (isSafeMode()) poolUtilizations = uint32(10_000 + (10_000 << 16));
 
-        uint96 tickData;
-        // update the users options balance of position `tokenId`
-        // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
-        PositionBalance balanceData = PositionBalanceLibrary.storeBalanceData(
-            positionSize,
-            poolUtilizations,
-            tickData
-        );
-
+        PositionBalance balanceData;
+        {
+            uint96 tickData;
+            // update the users options balance of position `tokenId`
+            // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
+            balanceData = PositionBalanceLibrary.storeBalanceData(
+                positionSize,
+                poolUtilizations,
+                tickData
+            );
+        }
         s_positionBalance[owner][tokenId] = balanceData;
 
         emit OptionMinted(owner, tokenId, balanceData, commissions);
@@ -699,13 +704,13 @@ contract PanopticPool is Multicall {
         int128 net1 = netPaid.leftSlot();
         // token0
         TokenId tokenId0 = tokenIdBase.addLeg(0, 1, 0, net0 > 0 ? 0 : 1, 0, 0, 0, 0);
-        int24[2] memory defaultLimits = [MIN_SWAP_TICK, MAX_SWAP_TICK];
         _mintOptions(
             tokenId0,
             uint128(net0 > 0 ? net0 : -net0),
             0,
             recipient,
-            defaultLimits,
+            MIN_SWAP_TICK,
+            MAX_SWAP_TICK,
             false
         );
 
@@ -716,7 +721,8 @@ contract PanopticPool is Multicall {
             uint128(net1 > 0 ? net1 : -net1),
             0,
             recipient,
-            defaultLimits,
+            MIN_SWAP_TICK,
+            MAX_SWAP_TICK,
             false
         );
     }
@@ -727,14 +733,16 @@ contract PanopticPool is Multicall {
 
     /// @notice Close all options in `positionIdList`.
     /// @param owner The owner of the option position to be closed
-    /// @param tickLimits The lower and upperbound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @param positionIdList The list of option positions to close
     /// @return netPaid The net amount of tokens paid after closing the positions
     /// @return premiasByLeg The amount of premia settled by the user for each leg of the position
     function _burnAllOptionsFrom(
         address owner,
-        int24[2] memory tickLimits,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
         bool commitLongSettled,
         TokenId[] calldata positionIdList
     ) internal returns (LeftRightSigned netPaid, LeftRightSigned[4][] memory premiasByLeg) {
@@ -743,11 +751,12 @@ contract PanopticPool is Multicall {
             uint128 positionSize = s_positionBalance[owner][positionIdList[i]].positionSize();
             LeftRightSigned paidAmounts;
             (paidAmounts, premiasByLeg[i]) = _burnOptions(
-                commitLongSettled,
                 positionIdList[i],
                 positionSize,
+                tickLimitLow,
+                tickLimitHigh,
                 owner,
-                tickLimits,
+                commitLongSettled,
                 false
             );
             netPaid = netPaid.add(paidAmounts);
@@ -761,20 +770,22 @@ contract PanopticPool is Multicall {
     /// @param tokenId The option position to burn
     /// @param positionSize The size of the position to burn
     /// @param owner The owner of the option position to be burned
-    /// @param tickLimits The lower and upper bound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @return paidAmounts The net amount of tokens paid after closing the position
     /// @return premiaByLeg The amount of premia settled by the user for each leg of the position
     function _burnOptions(
-        bool commitLongSettled,
         TokenId tokenId,
         uint128 positionSize,
+        int24 tickLimitLow,
+        int24 tickLimitHigh,
         address owner,
-        int24[2] memory tickLimits,
+        bool commitLongSettled,
         bool executeAtSettlement
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
-            .burnTokenizedPosition(tokenId, positionSize, tickLimits[0], tickLimits[1]);
+            .burnTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
         LeftRightSigned realizedPremia;
         (realizedPremia, premiaByLeg) = _updateSettlementPostBurn(
@@ -1097,10 +1108,10 @@ contract PanopticPool is Multicall {
             // Do not commit any settled long premium to storage - we will do this after we determine if any long premium must be revoked
             // This is to prevent any short positions the liquidatee has being settled with tokens that will later be revoked
             // NOTE: tick limits are not applied here since it is not the liquidator's position being liquidated
-            int24[2] memory defaultLimits = [MIN_SWAP_TICK, MAX_SWAP_TICK];
             (netPaid, premiasByLeg) = _burnAllOptionsFrom(
                 liquidatee,
-                defaultLimits,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK,
                 DONOT_COMMIT_LONG_SETTLED,
                 positionIdList
             );
@@ -1186,15 +1197,15 @@ contract PanopticPool is Multicall {
         ct1.delegate(account);
 
         {
-            int24[2] memory defaultLimits = [MIN_SWAP_TICK, MAX_SWAP_TICK];
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
             (LeftRightSigned paidAmounts, ) = _burnOptions(
-                COMMIT_LONG_SETTLED,
                 tokenId,
                 positionSize,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK,
                 account,
-                defaultLimits,
+                COMMIT_LONG_SETTLED,
                 false
             );
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -501,15 +501,14 @@ contract PanopticPool is Multicall {
     /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param tickLimits An array of the lower and upper bounds of an acceptable open interval for the ending price
-    /// @param bools packed bools, 1st bit = usePremiaAsCollateral: whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
-    ///                            2nd bit = executeAtSettlement: whether to execute in the collateraToken contract (true) or issue a token receipt (false)
+    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function dispatch(
         TokenId[] calldata positionIdList,
         TokenId[] calldata finalPositionIdList,
         uint128[] calldata positionSizes,
         uint64[] calldata effectiveLiquidityLimitsX32,
         int24[2][] calldata tickLimits,
-        bool[2] calldata bools //usePremiaAsCollateral
+        bool usePremiaAsCollateral
     ) external {
         //bool safeMode = isSafeMode();
         LeftRightSigned netPaid;
@@ -538,7 +537,7 @@ contract PanopticPool is Multicall {
                     msg.sender,
                     tickLimits[i][0],
                     tickLimits[i][1],
-                    bools[1]
+                    true
                 );
                 netPaid = netPaid.add(paidAmounts);
             } else {
@@ -549,7 +548,7 @@ contract PanopticPool is Multicall {
                     tickLimits[i][1],
                     msg.sender,
                     COMMIT_LONG_SETTLED,
-                    bools[1]
+                    true
                 );
             }
 
@@ -558,16 +557,13 @@ contract PanopticPool is Multicall {
             }
         }
 
-        if (bools[1]) {
-            _issueReceipt(poolId, netPaid, msg.sender);
-        }
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         uint256 medianData = _validateSolvency(
             msg.sender,
             finalPositionIdList,
             BP_DECREASE_BUFFER,
-            bools[0] //usePremiaAsCollateral
+            usePremiaAsCollateral
         );
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
@@ -700,31 +696,60 @@ contract PanopticPool is Multicall {
 
     function _issueReceipt(uint64 poolId, LeftRightSigned netPaid, address recipient) internal {
         TokenId tokenIdBase = TokenId.wrap(0).addPoolId(poolId);
-        int128 net0 = netPaid.rightSlot();
-        int128 net1 = netPaid.leftSlot();
-        // token0
-        TokenId tokenId0 = tokenIdBase.addLeg(0, 1, 0, net0 > 0 ? 0 : 1, 0, 0, 0, 0);
-        _mintOptions(
-            tokenId0,
-            uint128(net0 > 0 ? net0 : -net0),
-            0,
-            recipient,
-            MIN_SWAP_TICK,
-            MAX_SWAP_TICK,
-            false
-        );
+        {
+            int128 net0 = netPaid.rightSlot();
+            // token0
+            TokenId tokenId0 = tokenIdBase.addLeg(0, 1, 0, net0 > 0 ? 0 : 1, 0, 0, 0, 0);
+            PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId0];
+            if (PositionBalance.unwrap(positionBalanceData) != 0) {
+                _burnOptions(
+                    tokenId0,
+                    positionBalanceData.positionSize(),
+                    MIN_SWAP_TICK,
+                    MAX_SWAP_TICK,
+                    recipient,
+                    false,
+                    true
+                );
+            }
 
-        // token1
-        TokenId tokenId1 = tokenIdBase.addLeg(0, 1, 1, net1 > 0 ? 0 : 1, 1, 0, 0, 0);
-        _mintOptions(
-            tokenId1,
-            uint128(net1 > 0 ? net1 : -net1),
-            0,
-            recipient,
-            MIN_SWAP_TICK,
-            MAX_SWAP_TICK,
-            false
-        );
+            _mintOptions(
+                tokenId0,
+                uint128(net0 > 0 ? net0 : -net0),
+                0,
+                recipient,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK,
+                false
+            );
+        }
+        {
+            int128 net1 = netPaid.leftSlot();
+            // token1
+            TokenId tokenId1 = tokenIdBase.addLeg(0, 1, 1, net1 > 0 ? 0 : 1, 1, 0, 0, 0);
+            PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId1];
+            if (PositionBalance.unwrap(positionBalanceData) != 0) {
+                _burnOptions(
+                    tokenId1,
+                    positionBalanceData.positionSize(),
+                    MIN_SWAP_TICK,
+                    MAX_SWAP_TICK,
+                    recipient,
+                    false,
+                    true
+                );
+            }
+
+            _mintOptions(
+                tokenId1,
+                uint128(net1 > 0 ? net1 : -net1),
+                0,
+                recipient,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK,
+                false
+            );
+        }
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -646,15 +646,13 @@ contract PanopticPool is Multicall {
             owner,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
-            totalSwapped.rightSlot(),
-            isCovered
+            totalSwapped.rightSlot()
         );
         (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
             owner,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
-            totalSwapped.leftSlot(),
-            isCovered
+            totalSwapped.leftSlot()
         );
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -550,34 +550,10 @@ contract PanopticPool is Multicall {
                     tickLimitHigh
                 );
             }
-            if (!tokenId.isPureLoan()) {
-                netPaid = netPaid.add(paidAmounts);
-            }
 
             unchecked {
                 ++i;
             }
-        }
-
-        /// @dev craft + mint a tokenId that tokenizes the amount of tokens exchanged
-        /// This means that any ITM amounts will be associated with a liability
-        /// --ie. ITM amount may be 500 USDC, but mint a 500 USDC debt to the account so that
-        /// the account has + 500USDC in their account but a 500 liability
-        {
-            console2.log("netPaid.r", netPaid.rightSlot());
-            console2.log("netPaid.l", netPaid.leftSlot());
-            /*
-            TokenId loanTokenId;
-            uint128 loanSize;
-            _mintOptions(
-                loanTokenId,
-                loanSize,
-                0,
-                msg.sender,
-                MIN_SWAP_TICK,
-                MAX_SWAP_TICK
-            );
-           */
         }
 
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
@@ -1686,96 +1662,101 @@ contract PanopticPool is Multicall {
 
         uint256 numLegs = tokenId.countLegs();
         for (uint256 leg = 0; leg < numLegs; ) {
-            uint256 isLong = tokenId.isLong(leg);
+            if (tokenId.width(leg) != 0) {
+                uint256 isLong = tokenId.isLong(leg);
 
-            bytes32 chunkKey = keccak256(
-                abi.encodePacked(tokenId.strike(leg), tokenId.width(leg), tokenId.tokenType(leg))
-            );
-
-            // add any tokens collected from Uniswap in a given chunk to the settled tokens available for withdrawal by sellers
-            s_settledTokens[chunkKey] = s_settledTokens[chunkKey].add(collectedByLeg[leg]);
-
-            LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-                tokenId,
-                leg,
-                positionSize
-            );
-
-            uint256 grossCurrent0;
-            uint256 grossCurrent1;
-            {
-                uint256 tokenType = tokenId.tokenType(leg);
-                // can use (type(int24).max flag because premia accumulators were updated during the mintTokenizedPosition step.
-                (grossCurrent0, grossCurrent1) = SFPM.getAccountPremium(
-                    address(s_univ3pool),
-                    address(this),
-                    tokenType,
-                    liquidityChunk.tickLower(),
-                    liquidityChunk.tickUpper(),
-                    type(int24).max,
-                    isLong
+                bytes32 chunkKey = keccak256(
+                    abi.encodePacked(
+                        tokenId.strike(leg),
+                        tokenId.width(leg),
+                        tokenId.tokenType(leg)
+                    )
                 );
 
-                s_options[owner][tokenId][leg] = LeftRightUnsigned
-                    .wrap(uint128(grossCurrent0))
-                    .toLeftSlot(uint128(grossCurrent1));
-            }
+                // add any tokens collected from Uniswap in a given chunk to the settled tokens available for withdrawal by sellers
+                s_settledTokens[chunkKey] = s_settledTokens[chunkKey].add(collectedByLeg[leg]);
 
-            // if position is long, ensure that removed liquidity does not deplete strike beyond min(MAX_SPREAD, user-provided effectiveLiquidityLimit)
-            // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (R + N)
-            uint256 totalLiquidity = _checkLiquiditySpread(
-                tokenId,
-                leg,
-                isLong == 0 ? MAX_SPREAD : Math.min(effectiveLiquidityLimitX32, MAX_SPREAD)
-            );
+                LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                    tokenId,
+                    leg,
+                    positionSize
+                );
 
-            // if position is short, adjust `grossPremiumLast` upward to account for the increase in short liquidity
-            if (isLong == 0) {
-                unchecked {
-                    // L
-                    LeftRightUnsigned grossPremiumLast = s_grossPremiumLast[chunkKey];
-                    // R
-                    uint256 positionLiquidity = liquidityChunk.liquidity();
-                    // T (totalLiquidity is (T + R) after minting)
-                    uint256 totalLiquidityBefore = totalLiquidity - positionLiquidity;
+                uint256 grossCurrent0;
+                uint256 grossCurrent1;
+                {
+                    uint256 tokenType = tokenId.tokenType(leg);
+                    // can use (type(int24).max flag because premia accumulators were updated during the mintTokenizedPosition step.
+                    (grossCurrent0, grossCurrent1) = SFPM.getAccountPremium(
+                        address(s_univ3pool),
+                        address(this),
+                        tokenType,
+                        liquidityChunk.tickLower(),
+                        liquidityChunk.tickUpper(),
+                        type(int24).max,
+                        isLong
+                    );
 
-                    // We need to adjust the grossPremiumLast value such that the result of
-                    // (grossPremium - adjustedGrossPremiumLast) * updatedTotalLiquidityPostMint / 2**64 is equal to (grossPremium - grossPremiumLast) * totalLiquidityBeforeMint / 2**64
-                    // G: total gross premium
-                    // T: totalLiquidityBeforeMint
-                    // R: positionLiquidity
-                    // C: current grossPremium value
-                    // L: current grossPremiumLast value
-                    // Ln: updated grossPremiumLast value
-                    // T * (C - L) = G
-                    // (T + R) * (C - Ln) = G
-                    //
-                    // T * (C - L) = (T + R) * (C - Ln)
-                    // (TC - TL) / (T + R) = C - Ln
-                    // Ln = C - (TC - TL)/(T + R)
-                    // Ln = (CT + CR - TC + TL)/(T+R)
-                    // Ln = (CR + TL)/(T+R)
+                    s_options[owner][tokenId][leg] = LeftRightUnsigned
+                        .wrap(uint128(grossCurrent0))
+                        .toLeftSlot(uint128(grossCurrent1));
+                }
 
-                    s_grossPremiumLast[chunkKey] = LeftRightUnsigned
-                        .wrap(
-                            uint128(
-                                (grossCurrent0 *
-                                    positionLiquidity +
-                                    grossPremiumLast.rightSlot() *
-                                    totalLiquidityBefore) / totalLiquidity
+                // if position is long, ensure that removed liquidity does not deplete strike beyond min(MAX_SPREAD, user-provided effectiveLiquidityLimit)
+                // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (R + N)
+                uint256 totalLiquidity = _checkLiquiditySpread(
+                    tokenId,
+                    leg,
+                    isLong == 0 ? MAX_SPREAD : Math.min(effectiveLiquidityLimitX32, MAX_SPREAD)
+                );
+
+                // if position is short, adjust `grossPremiumLast` upward to account for the increase in short liquidity
+                if (isLong == 0) {
+                    unchecked {
+                        // L
+                        LeftRightUnsigned grossPremiumLast = s_grossPremiumLast[chunkKey];
+                        // R
+                        uint256 positionLiquidity = liquidityChunk.liquidity();
+                        // T (totalLiquidity is (T + R) after minting)
+                        uint256 totalLiquidityBefore = totalLiquidity - positionLiquidity;
+
+                        // We need to adjust the grossPremiumLast value such that the result of
+                        // (grossPremium - adjustedGrossPremiumLast) * updatedTotalLiquidityPostMint / 2**64 is equal to (grossPremium - grossPremiumLast) * totalLiquidityBeforeMint / 2**64
+                        // G: total gross premium
+                        // T: totalLiquidityBeforeMint
+                        // R: positionLiquidity
+                        // C: current grossPremium value
+                        // L: current grossPremiumLast value
+                        // Ln: updated grossPremiumLast value
+                        // T * (C - L) = G
+                        // (T + R) * (C - Ln) = G
+                        //
+                        // T * (C - L) = (T + R) * (C - Ln)
+                        // (TC - TL) / (T + R) = C - Ln
+                        // Ln = C - (TC - TL)/(T + R)
+                        // Ln = (CT + CR - TC + TL)/(T+R)
+                        // Ln = (CR + TL)/(T+R)
+
+                        s_grossPremiumLast[chunkKey] = LeftRightUnsigned
+                            .wrap(
+                                uint128(
+                                    (grossCurrent0 *
+                                        positionLiquidity +
+                                        grossPremiumLast.rightSlot() *
+                                        totalLiquidityBefore) / totalLiquidity
+                                )
                             )
-                        )
-                        .toLeftSlot(
-                            uint128(
-                                (grossCurrent1 *
-                                    positionLiquidity +
-                                    grossPremiumLast.leftSlot() *
-                                    totalLiquidityBefore) / totalLiquidity
-                            )
-                        );
+                            .toLeftSlot(
+                                uint128(
+                                    (grossCurrent1 *
+                                        positionLiquidity +
+                                        grossPremiumLast.leftSlot() *
+                                        totalLiquidityBefore) / totalLiquidity
+                                )
+                            );
+                    }
                 }
             }
-
             unchecked {
                 ++leg;
             }
@@ -1892,138 +1873,147 @@ contract PanopticPool is Multicall {
         );
 
         for (uint256 leg = 0; leg < numLegs; ) {
-            LeftRightSigned legPremia = premiaByLeg[leg];
+            if (tokenId.width(leg) != 0) {
+                LeftRightSigned legPremia = premiaByLeg[leg];
 
-            bytes32 chunkKey = keccak256(
-                abi.encodePacked(tokenId.strike(leg), tokenId.width(leg), tokenId.tokenType(leg))
-            );
-
-            // collected from Uniswap
-            LeftRightUnsigned settledTokens = s_settledTokens[chunkKey].add(collectedByLeg[leg]);
-
-            // (will be) paid by long legs
-            if (tokenId.isLong(leg) == 1) {
-                if (commitLongSettled)
-                    settledTokens = LeftRightUnsigned.wrap(
-                        uint256(
-                            LeftRightSigned.unwrap(
-                                LeftRightSigned
-                                    .wrap(int256(LeftRightUnsigned.unwrap(settledTokens)))
-                                    .sub(legPremia)
-                            )
-                        )
-                    );
-                realizedPremia = realizedPremia.add(legPremia);
-            } else {
-                uint256 positionLiquidity;
-                uint256 totalLiquidity;
-                {
-                    LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-                        tokenId,
-                        leg,
-                        positionSize
-                    );
-                    positionLiquidity = liquidityChunk.liquidity();
-
-                    // if position is short, ensure that removed liquidity does not deplete strike beyond MAX_SPREAD when closed
-                    // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (T - R)
-                    totalLiquidity = _checkLiquiditySpread(tokenId, leg, MAX_SPREAD);
-                }
-                // T (totalLiquidity is (T - R) after burning)
-                uint256 totalLiquidityBefore = totalLiquidity + positionLiquidity;
-
-                LeftRightUnsigned grossPremiumLast = s_grossPremiumLast[chunkKey];
-
-                LeftRightUnsigned availablePremium = _getAvailablePremium(
-                    totalLiquidity + positionLiquidity,
-                    settledTokens,
-                    grossPremiumLast,
-                    LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(legPremia))),
-                    premiumAccumulatorsByLeg[leg]
+                bytes32 chunkKey = keccak256(
+                    abi.encodePacked(
+                        tokenId.strike(leg),
+                        tokenId.width(leg),
+                        tokenId.tokenType(leg)
+                    )
                 );
 
-                // subtract settled tokens sent to seller
-                settledTokens = settledTokens.sub(availablePremium);
-
-                // add available premium to amount that should be settled
-                realizedPremia = realizedPremia.add(
-                    LeftRightSigned.wrap(int256(LeftRightUnsigned.unwrap(availablePremium)))
+                // collected from Uniswap
+                LeftRightUnsigned settledTokens = s_settledTokens[chunkKey].add(
+                    collectedByLeg[leg]
                 );
 
-                // update the base `premiaByLeg` value to reflect the amount of premium that will actually be settled
-                premiaByLeg[leg] = LeftRightSigned.wrap(
-                    int256(LeftRightUnsigned.unwrap(availablePremium))
-                );
-
-                // We need to adjust the grossPremiumLast value such that the result of
-                // (grossPremium - adjustedGrossPremiumLast) * updatedTotalLiquidityPostBurn / 2**64 is equal to
-                // (grossPremium - grossPremiumLast) * totalLiquidityBeforeBurn / 2**64 - premiumOwedToPosition
-                // G: total gross premium (- premiumOwedToPosition)
-                // T: totalLiquidityBeforeMint
-                // R: positionLiquidity
-                // C: current grossPremium value
-                // L: current grossPremiumLast value
-                // Ln: updated grossPremiumLast value
-                // T * (C - L) = G
-                // (T - R) * (C - Ln) = G - P
-                //
-                // T * (C - L) = (T - R) * (C - Ln) + P
-                // (TC - TL - P) / (T - R) = C - Ln
-                // Ln = C - (TC - TL - P) / (T - R)
-                // Ln = (TC - CR - TC + LT + P) / (T-R)
-                // Ln = (LT - CR + P) / (T-R)
-
-                unchecked {
-                    uint256[2][4] memory _premiumAccumulatorsByLeg = premiumAccumulatorsByLeg;
-                    uint256 _leg = leg;
-
-                    // if there's still liquidity, compute the new grossPremiumLast
-                    // otherwise, we just reset grossPremiumLast to the current grossPremium
-                    s_grossPremiumLast[chunkKey] = totalLiquidity != 0
-                        ? LeftRightUnsigned
-                            .wrap(
-                                uint128(
-                                    uint256(
-                                        Math.max(
-                                            (int256(
-                                                grossPremiumLast.rightSlot() * totalLiquidityBefore
-                                            ) -
-                                                int256(
-                                                    _premiumAccumulatorsByLeg[_leg][0] *
-                                                        positionLiquidity
-                                                )) + int256(legPremia.rightSlot() * 2 ** 64),
-                                            0
-                                        )
-                                    ) / totalLiquidity
+                // (will be) paid by long legs
+                if (tokenId.isLong(leg) == 1) {
+                    if (commitLongSettled)
+                        settledTokens = LeftRightUnsigned.wrap(
+                            uint256(
+                                LeftRightSigned.unwrap(
+                                    LeftRightSigned
+                                        .wrap(int256(LeftRightUnsigned.unwrap(settledTokens)))
+                                        .sub(legPremia)
                                 )
                             )
-                            .toLeftSlot(
-                                uint128(
-                                    uint256(
-                                        Math.max(
-                                            (int256(
-                                                grossPremiumLast.leftSlot() * totalLiquidityBefore
-                                            ) -
-                                                int256(
-                                                    _premiumAccumulatorsByLeg[_leg][1] *
-                                                        positionLiquidity
-                                                )) + int256(legPremia.leftSlot()) * 2 ** 64,
-                                            0
-                                        )
-                                    ) / totalLiquidity
+                        );
+                    realizedPremia = realizedPremia.add(legPremia);
+                } else {
+                    uint256 positionLiquidity;
+                    uint256 totalLiquidity;
+                    {
+                        LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                            tokenId,
+                            leg,
+                            positionSize
+                        );
+                        positionLiquidity = liquidityChunk.liquidity();
+
+                        // if position is short, ensure that removed liquidity does not deplete strike beyond MAX_SPREAD when closed
+                        // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (T - R)
+                        totalLiquidity = _checkLiquiditySpread(tokenId, leg, MAX_SPREAD);
+                    }
+                    // T (totalLiquidity is (T - R) after burning)
+                    uint256 totalLiquidityBefore = totalLiquidity + positionLiquidity;
+
+                    LeftRightUnsigned grossPremiumLast = s_grossPremiumLast[chunkKey];
+
+                    LeftRightUnsigned availablePremium = _getAvailablePremium(
+                        totalLiquidity + positionLiquidity,
+                        settledTokens,
+                        grossPremiumLast,
+                        LeftRightUnsigned.wrap(uint256(LeftRightSigned.unwrap(legPremia))),
+                        premiumAccumulatorsByLeg[leg]
+                    );
+
+                    // subtract settled tokens sent to seller
+                    settledTokens = settledTokens.sub(availablePremium);
+
+                    // add available premium to amount that should be settled
+                    realizedPremia = realizedPremia.add(
+                        LeftRightSigned.wrap(int256(LeftRightUnsigned.unwrap(availablePremium)))
+                    );
+
+                    // update the base `premiaByLeg` value to reflect the amount of premium that will actually be settled
+                    premiaByLeg[leg] = LeftRightSigned.wrap(
+                        int256(LeftRightUnsigned.unwrap(availablePremium))
+                    );
+
+                    // We need to adjust the grossPremiumLast value such that the result of
+                    // (grossPremium - adjustedGrossPremiumLast) * updatedTotalLiquidityPostBurn / 2**64 is equal to
+                    // (grossPremium - grossPremiumLast) * totalLiquidityBeforeBurn / 2**64 - premiumOwedToPosition
+                    // G: total gross premium (- premiumOwedToPosition)
+                    // T: totalLiquidityBeforeMint
+                    // R: positionLiquidity
+                    // C: current grossPremium value
+                    // L: current grossPremiumLast value
+                    // Ln: updated grossPremiumLast value
+                    // T * (C - L) = G
+                    // (T - R) * (C - Ln) = G - P
+                    //
+                    // T * (C - L) = (T - R) * (C - Ln) + P
+                    // (TC - TL - P) / (T - R) = C - Ln
+                    // Ln = C - (TC - TL - P) / (T - R)
+                    // Ln = (TC - CR - TC + LT + P) / (T-R)
+                    // Ln = (LT - CR + P) / (T-R)
+
+                    unchecked {
+                        uint256[2][4] memory _premiumAccumulatorsByLeg = premiumAccumulatorsByLeg;
+                        uint256 _leg = leg;
+
+                        // if there's still liquidity, compute the new grossPremiumLast
+                        // otherwise, we just reset grossPremiumLast to the current grossPremium
+                        s_grossPremiumLast[chunkKey] = totalLiquidity != 0
+                            ? LeftRightUnsigned
+                                .wrap(
+                                    uint128(
+                                        uint256(
+                                            Math.max(
+                                                (int256(
+                                                    grossPremiumLast.rightSlot() *
+                                                        totalLiquidityBefore
+                                                ) -
+                                                    int256(
+                                                        _premiumAccumulatorsByLeg[_leg][0] *
+                                                            positionLiquidity
+                                                    )) + int256(legPremia.rightSlot() * 2 ** 64),
+                                                0
+                                            )
+                                        ) / totalLiquidity
+                                    )
                                 )
-                            )
-                        : LeftRightUnsigned
-                            .wrap(uint128(premiumAccumulatorsByLeg[_leg][0]))
-                            .toLeftSlot(uint128(premiumAccumulatorsByLeg[_leg][1]));
+                                .toLeftSlot(
+                                    uint128(
+                                        uint256(
+                                            Math.max(
+                                                (int256(
+                                                    grossPremiumLast.leftSlot() *
+                                                        totalLiquidityBefore
+                                                ) -
+                                                    int256(
+                                                        _premiumAccumulatorsByLeg[_leg][1] *
+                                                            positionLiquidity
+                                                    )) + int256(legPremia.leftSlot()) * 2 ** 64,
+                                                0
+                                            )
+                                        ) / totalLiquidity
+                                    )
+                                )
+                            : LeftRightUnsigned
+                                .wrap(uint128(premiumAccumulatorsByLeg[_leg][0]))
+                                .toLeftSlot(uint128(premiumAccumulatorsByLeg[_leg][1]));
+                    }
                 }
+                // update settled tokens in storage with all local deltas
+                s_settledTokens[chunkKey] = settledTokens;
+
+                // erase the s_options entry for that leg
+                s_options[owner][tokenId][leg] = LeftRightUnsigned.wrap(0);
             }
-            // update settled tokens in storage with all local deltas
-            s_settledTokens[chunkKey] = settledTokens;
-
-            // erase the s_options entry for that leg
-            s_options[owner][tokenId][leg] = LeftRightUnsigned.wrap(0);
-
             unchecked {
                 ++leg;
             }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -518,6 +518,9 @@ contract PanopticPool is Multicall {
             }
         }
 
+        LeftRightSigned netPaid;
+        LeftRightSigned[4][] memory premiasByLeg;
+
         for (uint256 i = 0; i < positionIdList.length; ) {
             TokenId tokenId = positionIdList[i];
 
@@ -527,8 +530,9 @@ contract PanopticPool is Multicall {
 
             PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId];
 
+            LeftRightSigned paidAmounts;
             if (PositionBalance.unwrap(positionBalanceData) == 0) {
-                _mintOptions(
+                paidAmounts = _mintOptions(
                     tokenId,
                     positionSizes[i],
                     effectiveLiquidityLimitsX32[i],
@@ -536,8 +540,9 @@ contract PanopticPool is Multicall {
                     tickLimitLow,
                     tickLimitHigh
                 );
+                netPaid = netPaid.add(paidAmounts);
             } else {
-                _burnOptions(
+                (paidAmounts, premiasByLeg[i]) = _burnOptions(
                     COMMIT_LONG_SETTLED,
                     tokenId,
                     positionBalanceData.positionSize(),
@@ -545,6 +550,7 @@ contract PanopticPool is Multicall {
                     tickLimitLow,
                     tickLimitHigh
                 );
+                netPaid = netPaid.add(paidAmounts);
             }
             unchecked {
                 ++i;
@@ -583,7 +589,7 @@ contract PanopticPool is Multicall {
         address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
-    ) internal {
+    ) internal returns (LeftRightSigned paidAmounts) {
         // Mint in the SFPM and update state of collateral
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
@@ -596,12 +602,14 @@ contract PanopticPool is Multicall {
             owner
         );
 
-        (uint32 poolUtilizations, LeftRightUnsigned commissions) = _payCommissionAndWriteData(
+        uint32 poolUtilizations;
+        LeftRightUnsigned commissions;
+
+        (poolUtilizations, commissions, paidAmounts) = _payCommissionAndWriteData(
             tokenId,
             positionSize,
             owner,
-            totalSwapped,
-            tickLimitLow < tickLimitHigh
+            totalSwapped
         );
 
         if (isSafeMode()) poolUtilizations = uint32(10_000 + (10_000 << 16));
@@ -625,7 +633,6 @@ contract PanopticPool is Multicall {
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param owner The owner of the option position to be minted
     /// @param totalSwapped The amount of tokens moved during creation of the option position
-    /// @param isCovered Whether the option was minted as covered (no swap occurred if ITM)
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
@@ -634,37 +641,47 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         uint128 positionSize,
         address owner,
-        LeftRightSigned totalSwapped,
-        bool isCovered
-    ) internal returns (uint32, LeftRightUnsigned) {
+        LeftRightSigned totalSwapped
+    ) internal returns (uint32, LeftRightUnsigned, LeftRightSigned) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (LeftRightUnsigned utilizationAndCommission0, ) = s_collateralToken0.settleMint(
-            owner,
-            longAmounts.rightSlot(),
-            shortAmounts.rightSlot(),
-            totalSwapped.rightSlot()
-        );
-        (LeftRightUnsigned utilizationAndCommission1, ) = s_collateralToken1.settleMint(
-            owner,
-            longAmounts.leftSlot(),
-            shortAmounts.leftSlot(),
-            totalSwapped.leftSlot()
-        );
+        uint32 commissions;
+        LeftRightUnsigned utilizations;
+        LeftRightSigned paidAmounts;
+
+        // stack too deep
+        LeftRightSigned _totalSwapped = totalSwapped;
+
+        {
+            (LeftRightUnsigned utilizationAndCommission0, int128 paid0) = s_collateralToken0
+                .settleMint(
+                    owner,
+                    longAmounts.rightSlot(),
+                    shortAmounts.rightSlot(),
+                    _totalSwapped.rightSlot()
+                );
+            commissions = uint32(utilizationAndCommission0.rightSlot());
+            utilizations = utilizations.toRightSlot(utilizationAndCommission0.leftSlot());
+            paidAmounts = paidAmounts.toRightSlot(paid0);
+        }
+        {
+            (LeftRightUnsigned utilizationAndCommission1, int128 paid1) = s_collateralToken1
+                .settleMint(
+                    owner,
+                    longAmounts.leftSlot(),
+                    shortAmounts.leftSlot(),
+                    _totalSwapped.leftSlot()
+                );
+            commissions = uint32(utilizationAndCommission1.rightSlot() << 16);
+            utilizations = utilizations.toLeftSlot(utilizationAndCommission1.leftSlot());
+            paidAmounts = paidAmounts.toLeftSlot(paid1);
+        }
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
-            return (
-                uint32(
-                    utilizationAndCommission0.rightSlot() +
-                        (utilizationAndCommission1.rightSlot() << 16)
-                ),
-                LeftRightUnsigned.wrap(utilizationAndCommission0.leftSlot()).toLeftSlot(
-                    utilizationAndCommission1.leftSlot()
-                )
-            );
+            return (commissions, utilizations, paidAmounts);
         }
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -642,13 +642,13 @@ contract PanopticPool is Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (uint32 utilization0, uint128 commission0) = s_collateralToken0.takeCommissionAddData(
+        (uint32 utilization0, uint128 commission0) = s_collateralToken0.settleMint(
             owner,
             longAmounts.rightSlot(),
             shortAmounts.rightSlot(),
             totalSwapped.rightSlot()
         );
-        (uint32 utilization1, uint128 commission1) = s_collateralToken1.takeCommissionAddData(
+        (uint32 utilization1, uint128 commission1) = s_collateralToken1.settleMint(
             owner,
             longAmounts.leftSlot(),
             shortAmounts.leftSlot(),
@@ -735,7 +735,7 @@ contract PanopticPool is Multicall {
             .computeExercisedAmounts(tokenId, positionSize);
 
         {
-            int128 paid0 = s_collateralToken0.exercise(
+            int128 paid0 = s_collateralToken0.settleBurn(
                 owner,
                 longAmounts.rightSlot(),
                 shortAmounts.rightSlot(),
@@ -746,7 +746,7 @@ contract PanopticPool is Multicall {
         }
 
         {
-            int128 paid1 = s_collateralToken1.exercise(
+            int128 paid1 = s_collateralToken1.settleBurn(
                 owner,
                 longAmounts.leftSlot(),
                 shortAmounts.leftSlot(),
@@ -1227,8 +1227,8 @@ contract PanopticPool is Multicall {
                 }
                 {
                     // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-                    ct0.exercise(owner, 0, 0, 0, -realizedPremia.rightSlot());
-                    ct1.exercise(owner, 0, 0, 0, -realizedPremia.leftSlot());
+                    ct0.settleBurn(owner, 0, 0, 0, -realizedPremia.rightSlot());
+                    ct1.settleBurn(owner, 0, 0, 0, -realizedPremia.leftSlot());
 
                     bytes32 chunkKey;
                     {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -518,7 +518,7 @@ contract PanopticPool is Multicall {
                 (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
             }
         }
-
+        LeftRightSigned netPaid;
         for (uint256 i = 0; i < positionIdList.length; ) {
             TokenId tokenId = positionIdList[i];
 
@@ -538,7 +538,9 @@ contract PanopticPool is Multicall {
                     tickLimitHigh
                 );
             } else {
-                _burnOptions(
+                LeftRightSigned paidAmounts;
+                LeftRightSigned[4][] memory premiasByLeg;
+                (paidAmounts, premiasByLeg[i]) = _burnOptions(
                     COMMIT_LONG_SETTLED,
                     tokenId,
                     positionBalanceData.positionSize(),

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -500,27 +500,24 @@ contract PanopticPool is Multicall {
     /// @param positionSizes The list of positionSize for the position to be minted (0 for burns)
     /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param tickLimits An array of the lower and upper bounds of an acceptable open interval for the ending price
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function dispatch(
         TokenId[] calldata positionIdList,
         TokenId[] calldata finalPositionIdList,
         uint128[] calldata positionSizes,
         uint64[] calldata effectiveLiquidityLimitsX32,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
+        int24[2][] calldata tickLimits,
         bool usePremiaAsCollateral
     ) external {
         // if safeMode, enforce covered at mint and exercise at burn
-        if (isSafeMode()) {
-            if (tickLimitLow > tickLimitHigh) {
-                (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
-            }
-        }
+        //if (isSafeMode()) {
+        //    if (tickLimitLow > tickLimitHigh) {
+        //        (tickLimitLow, tickLimitHigh) = (tickLimitHigh, tickLimitLow);
+        //    }
+        //}
         LeftRightSigned netPaid;
         uint256 pLength = positionIdList.length;
-        LeftRightSigned[4][] memory premiasByLeg = new LeftRightSigned[4][](pLength);
         for (uint256 i = 0; i < pLength; ) {
             TokenId tokenId = positionIdList[i];
 
@@ -537,17 +534,16 @@ contract PanopticPool is Multicall {
                     positionSizes[i],
                     effectiveLiquidityLimitsX32[i],
                     msg.sender,
-                    tickLimitLow,
-                    tickLimitHigh
+                    tickLimits[i]
                 );
+                netPaid = netPaid.add(paidAmounts);
             } else {
-                (paidAmounts, premiasByLeg[i]) = _burnOptions(
+                _burnOptions(
                     COMMIT_LONG_SETTLED,
                     tokenId,
                     positionBalanceData.positionSize(),
                     msg.sender,
-                    tickLimitLow,
-                    tickLimitHigh
+                    tickLimits[i]
                 );
             }
 
@@ -579,19 +575,17 @@ contract PanopticPool is Multicall {
     /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param owner The owner of the option position to be minted
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
+    /// @param tickLimits The lower and upper bound of an acceptable open interval for the ending price
     function _mintOptions(
         TokenId tokenId,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
         address owner,
-        int24 tickLimitLow,
-        int24 tickLimitHigh
+        int24[2] memory tickLimits
     ) internal returns (LeftRightSigned paidAmounts) {
         // Mint in the SFPM and update state of collateral
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
-            .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
+            .mintTokenizedPosition(tokenId, positionSize, tickLimits[0], tickLimits[1]);
 
         _updateSettlementPostMint(
             tokenId,
@@ -659,7 +653,8 @@ contract PanopticPool is Multicall {
                     owner,
                     longAmounts.rightSlot(),
                     shortAmounts.rightSlot(),
-                    _totalSwapped.rightSlot()
+                    _totalSwapped.rightSlot(),
+                    true
                 );
             commissions = uint32(utilizationAndCommission0.rightSlot());
             utilizations = utilizations.toRightSlot(utilizationAndCommission0.leftSlot());
@@ -671,7 +666,8 @@ contract PanopticPool is Multicall {
                     owner,
                     longAmounts.leftSlot(),
                     shortAmounts.leftSlot(),
-                    _totalSwapped.leftSlot()
+                    _totalSwapped.leftSlot(),
+                    true
                 );
             commissions = uint32(utilizationAndCommission1.rightSlot() << 16);
             utilizations = utilizations.toLeftSlot(utilizationAndCommission1.leftSlot());
@@ -690,16 +686,14 @@ contract PanopticPool is Multicall {
 
     /// @notice Close all options in `positionIdList`.
     /// @param owner The owner of the option position to be closed
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimits The lower and upperbound of an acceptable open interval for the ending price on each option close
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @param positionIdList The list of option positions to close
     /// @return netPaid The net amount of tokens paid after closing the positions
     /// @return premiasByLeg The amount of premia settled by the user for each leg of the position
     function _burnAllOptionsFrom(
         address owner,
-        int24 tickLimitLow,
-        int24 tickLimitHigh,
+        int24[2] memory tickLimits,
         bool commitLongSettled,
         TokenId[] calldata positionIdList
     ) internal returns (LeftRightSigned netPaid, LeftRightSigned[4][] memory premiasByLeg) {
@@ -712,8 +706,7 @@ contract PanopticPool is Multicall {
                 positionIdList[i],
                 positionSize,
                 owner,
-                tickLimitLow,
-                tickLimitHigh
+                tickLimits
             );
             netPaid = netPaid.add(paidAmounts);
             unchecked {
@@ -726,8 +719,7 @@ contract PanopticPool is Multicall {
     /// @param tokenId The option position to burn
     /// @param positionSize The size of the position to burn
     /// @param owner The owner of the option position to be burned
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price on each option close
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price on each option close
+    /// @param tickLimits The lower and upper bound of an acceptable open interval for the ending price on each option close
     /// @param commitLongSettled Whether to commit the long premium that will be settled to storage (disabled during liquidations)
     /// @return paidAmounts The net amount of tokens paid after closing the position
     /// @return premiaByLeg The amount of premia settled by the user for each leg of the position
@@ -736,11 +728,10 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         uint128 positionSize,
         address owner,
-        int24 tickLimitLow,
-        int24 tickLimitHigh
+        int24[2] memory tickLimits
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
-            .burnTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
+            .burnTokenizedPosition(tokenId, positionSize, tickLimits[0], tickLimits[1]);
 
         LeftRightSigned realizedPremia;
         (realizedPremia, premiaByLeg) = _updateSettlementPostBurn(
@@ -1059,10 +1050,10 @@ contract PanopticPool is Multicall {
             // Do not commit any settled long premium to storage - we will do this after we determine if any long premium must be revoked
             // This is to prevent any short positions the liquidatee has being settled with tokens that will later be revoked
             // NOTE: tick limits are not applied here since it is not the liquidator's position being liquidated
+            int24[2] memory defaultLimits = [MIN_SWAP_TICK, MAX_SWAP_TICK];
             (netPaid, premiasByLeg) = _burnAllOptionsFrom(
                 liquidatee,
-                MIN_SWAP_TICK,
-                MAX_SWAP_TICK,
+                defaultLimits,
                 DONOT_COMMIT_LONG_SETTLED,
                 positionIdList
             );
@@ -1148,16 +1139,10 @@ contract PanopticPool is Multicall {
         ct1.delegate(account);
 
         {
+            int24[2] memory defaultLimits = [MIN_SWAP_TICK, MAX_SWAP_TICK];
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
-            _burnOptions(
-                COMMIT_LONG_SETTLED,
-                tokenId,
-                positionSize,
-                account,
-                MIN_SWAP_TICK,
-                MAX_SWAP_TICK
-            );
+            _burnOptions(COMMIT_LONG_SETTLED, tokenId, positionSize, account, defaultLimits);
         }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         refundAmounts = PanopticMath.getRefundAmounts(account, exerciseFees, twapTick, ct0, ct1);

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
+import "forge-std/Test.sol";
 // Interfaces
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {SemiFungiblePositionManager} from "@contracts/SemiFungiblePositionManager.sol";
@@ -539,7 +540,6 @@ contract PanopticPool is Multicall {
                     tickLimitLow,
                     tickLimitHigh
                 );
-                netPaid = netPaid.add(paidAmounts);
             } else {
                 (paidAmounts, premiasByLeg[i]) = _burnOptions(
                     COMMIT_LONG_SETTLED,
@@ -549,11 +549,35 @@ contract PanopticPool is Multicall {
                     tickLimitLow,
                     tickLimitHigh
                 );
+            }
+            if (!tokenId.isPureLoan()) {
                 netPaid = netPaid.add(paidAmounts);
             }
+
             unchecked {
                 ++i;
             }
+        }
+
+        /// @dev craft + mint a tokenId that tokenizes the amount of tokens exchanged
+        /// This means that any ITM amounts will be associated with a liability
+        /// --ie. ITM amount may be 500 USDC, but mint a 500 USDC debt to the account so that
+        /// the account has + 500USDC in their account but a 500 liability
+        {
+            console2.log("netPaid.r", netPaid.rightSlot());
+            console2.log("netPaid.l", netPaid.leftSlot());
+            /*
+            TokenId loanTokenId;
+            uint128 loanSize;
+            _mintOptions(
+                loanTokenId,
+                loanSize,
+                0,
+                msg.sender,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK
+            );
+           */
         }
 
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -501,14 +501,15 @@ contract PanopticPool is Multicall {
     /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param tickLimits An array of the lower and upper bounds of an acceptable open interval for the ending price
-    /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
+    /// @param bools packed bools, 1st bit = usePremiaAsCollateral: whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
+    ///                            2nd bit = executeAtSettlement: whether to execute in the collateraToken contract (true) or issue a token receipt (false)
     function dispatch(
         TokenId[] calldata positionIdList,
         TokenId[] calldata finalPositionIdList,
         uint128[] calldata positionSizes,
         uint64[] calldata effectiveLiquidityLimitsX32,
         int24[2][] calldata tickLimits,
-        bool usePremiaAsCollateral
+        bool[2] calldata bools //usePremiaAsCollateral
     ) external {
         // if safeMode, enforce covered at mint and exercise at burn
         //if (isSafeMode()) {
@@ -518,11 +519,13 @@ contract PanopticPool is Multicall {
         //}
         LeftRightSigned netPaid;
         uint256 pLength = positionIdList.length;
+        uint64 poolId;
         for (uint256 i = 0; i < pLength; ) {
             TokenId tokenId = positionIdList[i];
 
+            poolId = tokenId.poolId();
             // make sure the tokenId is for this Panoptic pool
-            if (tokenId.poolId() != SFPM.getPoolId(address(s_univ3pool)))
+            if (poolId != SFPM.getPoolId(address(s_univ3pool)))
                 revert Errors.InvalidTokenIdParameter(0);
 
             PositionBalance positionBalanceData = s_positionBalance[msg.sender][tokenId];
@@ -534,7 +537,8 @@ contract PanopticPool is Multicall {
                     positionSizes[i],
                     effectiveLiquidityLimitsX32[i],
                     msg.sender,
-                    tickLimits[i]
+                    tickLimits[i],
+                    bools[1]
                 );
                 netPaid = netPaid.add(paidAmounts);
             } else {
@@ -543,7 +547,8 @@ contract PanopticPool is Multicall {
                     tokenId,
                     positionBalanceData.positionSize(),
                     msg.sender,
-                    tickLimits[i]
+                    tickLimits[i],
+                    bools[1]
                 );
             }
 
@@ -552,13 +557,16 @@ contract PanopticPool is Multicall {
             }
         }
 
+        if (bools[1]) {
+            _issueReceipt(poolId, netPaid, msg.sender);
+        }
         // Perform solvency check on user's account to ensure they had enough buying power to mint the option
         // Add an initial buffer to the collateral requirement to prevent users from minting their account close to insolvency
         uint256 medianData = _validateSolvency(
             msg.sender,
             finalPositionIdList,
             BP_DECREASE_BUFFER,
-            usePremiaAsCollateral
+            bools[0] //usePremiaAsCollateral
         );
 
         // Update `s_miniMedian` with a new observation if the last observation is old enough (returned medianData is nonzero)
@@ -576,12 +584,14 @@ contract PanopticPool is Multicall {
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param owner The owner of the option position to be minted
     /// @param tickLimits The lower and upper bound of an acceptable open interval for the ending price
+    /// @param executeAtSettlement whether to...
     function _mintOptions(
         TokenId tokenId,
         uint128 positionSize,
         uint64 effectiveLiquidityLimitX32,
         address owner,
-        int24[2] memory tickLimits
+        int24[2] memory tickLimits,
+        bool executeAtSettlement
     ) internal returns (LeftRightSigned paidAmounts) {
         // Mint in the SFPM and update state of collateral
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
@@ -602,7 +612,8 @@ contract PanopticPool is Multicall {
             tokenId,
             positionSize,
             owner,
-            totalSwapped
+            totalSwapped,
+            executeAtSettlement
         );
 
         if (isSafeMode()) poolUtilizations = uint32(10_000 + (10_000 << 16));
@@ -634,7 +645,8 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         uint128 positionSize,
         address owner,
-        LeftRightSigned totalSwapped
+        LeftRightSigned totalSwapped,
+        bool executeAtSettlement
     ) internal returns (uint32, LeftRightUnsigned, LeftRightSigned) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
@@ -646,15 +658,16 @@ contract PanopticPool is Multicall {
 
         // stack too deep
         LeftRightSigned _totalSwapped = totalSwapped;
-
+        address _owner = owner;
+        bool _executeAtSettlement = executeAtSettlement;
         {
             (LeftRightUnsigned utilizationAndCommission0, int128 paid0) = s_collateralToken0
                 .settleMint(
-                    owner,
+                    _owner,
                     longAmounts.rightSlot(),
                     shortAmounts.rightSlot(),
                     _totalSwapped.rightSlot(),
-                    true
+                    _executeAtSettlement
                 );
             commissions = uint32(utilizationAndCommission0.rightSlot());
             utilizations = utilizations.toRightSlot(utilizationAndCommission0.leftSlot());
@@ -663,11 +676,11 @@ contract PanopticPool is Multicall {
         {
             (LeftRightUnsigned utilizationAndCommission1, int128 paid1) = s_collateralToken1
                 .settleMint(
-                    owner,
+                    _owner,
                     longAmounts.leftSlot(),
                     shortAmounts.leftSlot(),
                     _totalSwapped.leftSlot(),
-                    true
+                    _executeAtSettlement
                 );
             commissions = uint32(utilizationAndCommission1.rightSlot() << 16);
             utilizations = utilizations.toLeftSlot(utilizationAndCommission1.leftSlot());
@@ -678,6 +691,34 @@ contract PanopticPool is Multicall {
         unchecked {
             return (commissions, utilizations, paidAmounts);
         }
+    }
+
+    function _issueReceipt(uint64 poolId, LeftRightSigned netPaid, address recipient) internal {
+        TokenId tokenIdBase = TokenId.wrap(0).addPoolId(poolId);
+        int128 net0 = netPaid.rightSlot();
+        int128 net1 = netPaid.leftSlot();
+        // token0
+        TokenId tokenId0 = tokenIdBase.addLeg(0, 1, 0, net0 > 0 ? 0 : 1, 0, 0, 0, 0);
+        int24[2] memory defaultLimits = [MIN_SWAP_TICK, MAX_SWAP_TICK];
+        _mintOptions(
+            tokenId0,
+            uint128(net0 > 0 ? net0 : -net0),
+            0,
+            recipient,
+            defaultLimits,
+            false
+        );
+
+        // token1
+        TokenId tokenId1 = tokenIdBase.addLeg(0, 1, 1, net1 > 0 ? 0 : 1, 1, 0, 0, 0);
+        _mintOptions(
+            tokenId1,
+            uint128(net1 > 0 ? net1 : -net1),
+            0,
+            recipient,
+            defaultLimits,
+            false
+        );
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -706,7 +747,8 @@ contract PanopticPool is Multicall {
                 positionIdList[i],
                 positionSize,
                 owner,
-                tickLimits
+                tickLimits,
+                false
             );
             netPaid = netPaid.add(paidAmounts);
             unchecked {
@@ -728,7 +770,8 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         uint128 positionSize,
         address owner,
-        int24[2] memory tickLimits
+        int24[2] memory tickLimits,
+        bool executeAtSettlement
     ) internal returns (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) {
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .burnTokenizedPosition(tokenId, positionSize, tickLimits[0], tickLimits[1]);
@@ -751,7 +794,8 @@ contract PanopticPool is Multicall {
                 longAmounts.rightSlot(),
                 shortAmounts.rightSlot(),
                 totalSwapped.rightSlot(),
-                realizedPremia.rightSlot()
+                realizedPremia.rightSlot(),
+                executeAtSettlement
             );
             paidAmounts = paidAmounts.toRightSlot(paid0);
         }
@@ -762,7 +806,8 @@ contract PanopticPool is Multicall {
                 longAmounts.leftSlot(),
                 shortAmounts.leftSlot(),
                 totalSwapped.leftSlot(),
-                realizedPremia.leftSlot()
+                realizedPremia.leftSlot(),
+                executeAtSettlement
             );
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }
@@ -987,7 +1032,9 @@ contract PanopticPool is Multicall {
                     usePremiaAsCollateral.rightSlot() > 0
                 );
             }
+            _issueReceipt(positionIdListTo[0].poolId(), exchangedAmounts, msg.sender);
         }
+
         // ensure the caller is still solvent after the operation
         _validateSolvency(
             msg.sender,
@@ -1142,7 +1189,16 @@ contract PanopticPool is Multicall {
             int24[2] memory defaultLimits = [MIN_SWAP_TICK, MAX_SWAP_TICK];
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
-            _burnOptions(COMMIT_LONG_SETTLED, tokenId, positionSize, account, defaultLimits);
+            (LeftRightSigned paidAmounts, ) = _burnOptions(
+                COMMIT_LONG_SETTLED,
+                tokenId,
+                positionSize,
+                account,
+                defaultLimits,
+                false
+            );
+
+            _issueReceipt(tokenId.poolId(), paidAmounts, account);
         }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         refundAmounts = PanopticMath.getRefundAmounts(account, exerciseFees, twapTick, ct0, ct1);
@@ -1231,8 +1287,8 @@ contract PanopticPool is Multicall {
                 }
                 {
                     // deduct the paid premium tokens from the owner's balance and add them to the cumulative settled token delta
-                    ct0.settleBurn(owner, 0, 0, 0, -realizedPremia.rightSlot());
-                    ct1.settleBurn(owner, 0, 0, 0, -realizedPremia.leftSlot());
+                    ct0.settleBurn(owner, 0, 0, 0, -realizedPremia.rightSlot(), true);
+                    ct1.settleBurn(owner, 0, 0, 0, -realizedPremia.leftSlot(), true);
 
                     bytes32 chunkKey;
                     {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -518,8 +518,9 @@ contract PanopticPool is Multicall {
             }
         }
         LeftRightSigned netPaid;
-        LeftRightSigned[4][] memory premiasByLeg;
-        for (uint256 i = 0; i < positionIdList.length; ) {
+        uint256 pLength = positionIdList.length;
+        LeftRightSigned[4][] memory premiasByLeg = new LeftRightSigned[4][](pLength);
+        for (uint256 i = 0; i < pLength; ) {
             TokenId tokenId = positionIdList[i];
 
             // make sure the tokenId is for this Panoptic pool

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -858,55 +858,72 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         uint256 numLegs = tokenId.countLegs();
 
         for (uint256 leg = 0; leg < numLegs; ) {
-            LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-                tokenId,
-                leg,
-                positionSize
-            );
+            if (tokenId.width(leg) == 0) {
+                LeftRightUnsigned amountsMoved = PanopticMath.getAmountsMoved(
+                    tokenId,
+                    positionSize,
+                    leg
+                );
+                int128 signMultiplier = isBurn ? -int128(1) : int128(1);
+                totalMoved = totalMoved.add(
+                    tokenId.tokenType(leg) == 0
+                        ? LeftRightSigned.wrap(0).toLeftSlot(
+                            signMultiplier * int128(amountsMoved.rightSlot())
+                        )
+                        : LeftRightSigned.wrap(0).toRightSlot(
+                            signMultiplier * int128(amountsMoved.leftSlot())
+                        )
+                );
+            } else {
+                LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                    tokenId,
+                    leg,
+                    positionSize
+                );
 
-            // validate tick range for newly minted positions
-            if (!isBurn) {
-                int24 tickSpacing = tokenId.tickSpacing();
-                int24 tickLower = liquidityChunk.tickLower();
-                int24 tickUpper = liquidityChunk.tickUpper();
+                // validate tick range for newly minted positions
+                if (!isBurn) {
+                    int24 tickSpacing = tokenId.tickSpacing();
+                    int24 tickLower = liquidityChunk.tickLower();
+                    int24 tickUpper = liquidityChunk.tickUpper();
 
-                // Revert if the upper/lower ticks are not multiples of tickSpacing
-                // This is an invalid state, and would revert silently later in `univ3Pool.mint`
-                // Revert if the tick range extends from the strike outside of the enforced tick range
-                if (
-                    tickLower % tickSpacing != 0 ||
-                    tickUpper % tickSpacing != 0 ||
-                    tickLower < poolData.minEnforcedTick ||
-                    tickUpper > poolData.maxEnforcedTick
-                ) revert Errors.InvalidTickBound();
+                    // Revert if the upper/lower ticks are not multiples of tickSpacing
+                    // This is an invalid state, and would revert silently later in `univ3Pool.mint`
+                    // Revert if the tick range extends from the strike outside of the enforced tick range
+                    if (
+                        tickLower % tickSpacing != 0 ||
+                        tickUpper % tickSpacing != 0 ||
+                        tickLower < poolData.minEnforcedTick ||
+                        tickUpper > poolData.maxEnforcedTick
+                    ) revert Errors.InvalidTickBound();
+                }
+
+                unchecked {
+                    // increment accumulators of the upper bound on tokens contained across all legs of the position at any given tick
+                    amount0 += Math.getAmount0ForLiquidity(liquidityChunk);
+                    amount1 += Math.getAmount1ForLiquidity(liquidityChunk);
+                }
+
+                LeftRightSigned movedLeg;
+
+                (movedLeg, collectedByLeg[leg]) = _createLegInAMM(
+                    poolData.pool,
+                    tokenId,
+                    leg,
+                    liquidityChunk,
+                    isBurn
+                );
+
+                totalMoved = totalMoved.add(movedLeg);
+
+                // if tokenType is 1, and we transacted some token0: then this leg is ITM
+                // if tokenType is 0, and we transacted some token1: then this leg is ITM
+                itmAmounts = itmAmounts.add(
+                    tokenId.tokenType(leg) == 0
+                        ? LeftRightSigned.wrap(0).toLeftSlot(movedLeg.leftSlot())
+                        : LeftRightSigned.wrap(0).toRightSlot(movedLeg.rightSlot())
+                );
             }
-
-            unchecked {
-                // increment accumulators of the upper bound on tokens contained across all legs of the position at any given tick
-                amount0 += Math.getAmount0ForLiquidity(liquidityChunk);
-                amount1 += Math.getAmount1ForLiquidity(liquidityChunk);
-            }
-
-            LeftRightSigned movedLeg;
-
-            (movedLeg, collectedByLeg[leg]) = _createLegInAMM(
-                poolData.pool,
-                tokenId,
-                leg,
-                liquidityChunk,
-                isBurn
-            );
-
-            totalMoved = totalMoved.add(movedLeg);
-
-            // if tokenType is 1, and we transacted some token0: then this leg is ITM
-            // if tokenType is 0, and we transacted some token1: then this leg is ITM
-            itmAmounts = itmAmounts.add(
-                tokenId.tokenType(leg) == 0
-                    ? LeftRightSigned.wrap(0).toLeftSlot(movedLeg.leftSlot())
-                    : LeftRightSigned.wrap(0).toRightSlot(movedLeg.rightSlot())
-            );
-
             unchecked {
                 ++leg;
             }

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -863,7 +863,9 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                     positionSize,
                     leg
                 );
-                int128 signMultiplier = isBurn ? -int128(1) : int128(1);
+
+                int128 signMultiplier = tokenId.isLong(leg) != 0 ? int128(1) : int128(-1);
+
                 totalMoved = totalMoved.add(
                     tokenId.tokenType(leg) == 0
                         ? LeftRightSigned.wrap(0).toRightSlot(

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
-
 // Interfaces
 import {IERC20Partial} from "@tokens/interfaces/IERC20Partial.sol";
 import {IUniswapV3Factory} from "univ3-core/interfaces/IUniswapV3Factory.sol";
@@ -867,10 +866,20 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                 int128 signMultiplier = isBurn ? -int128(1) : int128(1);
                 totalMoved = totalMoved.add(
                     tokenId.tokenType(leg) == 0
-                        ? LeftRightSigned.wrap(0).toLeftSlot(
+                        ? LeftRightSigned.wrap(0).toRightSlot(
                             signMultiplier * int128(amountsMoved.rightSlot())
                         )
-                        : LeftRightSigned.wrap(0).toRightSlot(
+                        : LeftRightSigned.wrap(0).toLeftSlot(
+                            signMultiplier * int128(amountsMoved.leftSlot())
+                        )
+                );
+
+                itmAmounts = itmAmounts.add(
+                    tokenId.tokenType(leg) == 0
+                        ? LeftRightSigned.wrap(0).toRightSlot(
+                            signMultiplier * int128(amountsMoved.rightSlot())
+                        )
+                        : LeftRightSigned.wrap(0).toLeftSlot(
                             signMultiplier * int128(amountsMoved.leftSlot())
                         )
                 );

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1029,9 +1029,9 @@ library PanopticMath {
             }
 
             if (haircutTotal.rightSlot() != 0)
-                collateral0.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
+                collateral0.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
             if (haircutTotal.leftSlot() != 0)
-                collateral1.exercise(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
+                collateral1.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
 
             return
                 LeftRightSigned.wrap(0).toRightSlot(int128(collateralDelta0)).toLeftSlot(

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1029,9 +1029,16 @@ library PanopticMath {
             }
 
             if (haircutTotal.rightSlot() != 0)
-                collateral0.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.rightSlot()));
+                collateral0.settleBurn(
+                    _liquidatee,
+                    0,
+                    0,
+                    0,
+                    int128(haircutTotal.rightSlot()),
+                    true
+                );
             if (haircutTotal.leftSlot() != 0)
-                collateral1.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
+                collateral1.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()), true);
 
             return
                 LeftRightSigned.wrap(0).toRightSlot(int128(collateralDelta0)).toLeftSlot(

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -558,4 +558,17 @@ library TokenIdLibrary {
         // Fail if position has no legs that is far-out-of-the-money
         revert Errors.NoLegsExercisable();
     }
+
+    function isPureLoan(TokenId self) internal pure returns (bool) {
+        unchecked {
+            uint256 numLegs = self.countLegs();
+            uint256 loanLegs;
+            for (uint256 i = 0; i < numLegs; ++i) {
+                if (self.width(i) != 0) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
 }

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -485,8 +485,8 @@ library TokenIdLibrary {
                     }
                 }
 
-                // The width cannot be 0; the minimum is 1
-                if ((self.width(i) == 0)) revert Errors.InvalidTokenIdParameter(5);
+                // The width cannot be 0; the minimum is 1 UPDATE: width=0 is a simple token transfer
+                //if ((self.width(i) == 0)) revert Errors.InvalidTokenIdParameter(5);
                 // Strike cannot be MIN_TICK or MAX_TICK
                 if (
                     (self.strike(i) == Constants.MIN_V3POOL_TICK) ||

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1977,16 +1977,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.refund(address(0), address(0), 0);
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
-        collateralToken0.takeCommissionAddData(
+        collateralToken0.settleMint(
             address(0),
             0,
             Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            false
+            Constants.MIN_V3POOL_TICK
         );
 
         vm.expectRevert(Errors.NotPanopticPool.selector);
-        collateralToken0.exercise(
+        collateralToken0.settleBurn(
             address(0),
             0,
             0,

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1831,20 +1831,14 @@ contract Misctest is Test, PositionUtils {
         );
 
         vm.startPrank(address(pp));
-        CollateralTracker(collateralReference).takeCommissionAddData(
-            Alice,
-            0,
-            0,
-            1_000_000_000,
-            false
-        );
+        CollateralTracker(collateralReference).settleMint(Alice, 0, 0, 1_000_000_000);
         assertEq(
             1_000_000_000_000_000 -
                 1 -
                 CollateralTracker(collateralReference).convertToAssets(
                     CollateralTracker(collateralReference).balanceOf(Alice)
                 ),
-            1_000_000_000 + 2000
+            1_000_000_000 + 2000 * 0
         );
     }
 
@@ -5062,9 +5056,10 @@ contract Misctest is Test, PositionUtils {
         // make sure Alice earns no fees on token 0 (her delta is slightly negative due to commission fees/precision etc)
         // the accumulator overflowed, so the accumulation was frozen. If she had poked before the accumulator overflowed,
         // she could have still earned some fees, but now the accumulation is frozen forever.
+        // old with itmSpreadFee = -1244790
         assertEq(
             int256(ct0.convertToAssets(ct0.balanceOf(Alice))) - int256(balanceBefore0),
-            -1244790
+            -930817
         );
 
         // but she earns all of fees on token 1 since the premium accumulator did not overflow (!)

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -2660,9 +2660,10 @@ contract PanopticPoolTest is PositionUtils {
 
             int256 notionalVal = int256(expectedSwap0) + amount0Moved - shortAmounts.rightSlot();
 
+            // set itm spread fee to 0
             int256 ITMSpread = notionalVal > 0
-                ? (notionalVal * int24(2 * (fee / 100))) / 10_000
-                : -(notionalVal * int24(2 * (fee / 100))) / 10_000;
+                ? (notionalVal * int24(2 * ((0 * fee) / 100))) / 10_000
+                : -(notionalVal * int24(2 * ((0 * fee) / 100))) / 10_000;
 
             assertApproxEqAbs(
                 ct0.balanceOf(Alice),
@@ -2937,13 +2938,14 @@ contract PanopticPoolTest is PositionUtils {
                     amount0s + $amount0Moveds[0] + $amount0Moveds[1] - shortAmounts.rightSlot(),
                     amount1s + $amount1Moveds[0] + $amount1Moveds[1] - shortAmounts.leftSlot()
                 ];
+                // set itm spread fee to 0
                 int256[2] memory ITMSpreads = [
                     notionalVals[0] > 0
-                        ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
+                        ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000),
                     notionalVals[1] > 0
-                        ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
+                        ? (notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000)
                 ];
 
                 assertApproxEqAbs(
@@ -3164,6 +3166,7 @@ contract PanopticPoolTest is PositionUtils {
             positionSizes[0]
         );
 
+        console2.log("Seller");
         vm.startPrank(Seller);
 
         {
@@ -3225,6 +3228,7 @@ contract PanopticPoolTest is PositionUtils {
             -netSurplus0
         );
 
+        console2.log("Alice");
         vm.startPrank(Alice);
 
         if (pp.isSafeMode() == false) {
@@ -3244,13 +3248,14 @@ contract PanopticPoolTest is PositionUtils {
                     amount1s + $amount1Moveds[1] + $amount1Moveds[2] - shortAmounts.leftSlot()
                 ];
 
+                // set itm spread fee to 0
                 ITMSpreads = [
                     notionalVals[0] > 0
-                        ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000),
+                        ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000),
                     notionalVals[1] > 0
-                        ? (notionalVals[1] * int24(2 * (fee / 100))) / 10_000
-                        : -((notionalVals[1] * int24(2 * (fee / 100))) / 10_000)
+                        ? (notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000
+                        : -((notionalVals[1] * int24(2 * ((0 * fee) / 100))) / 10_000)
                 ];
 
                 uint256 tokenToPay = uint256(
@@ -3285,49 +3290,62 @@ contract PanopticPoolTest is PositionUtils {
             // price changes afters swap at mint so we need to update the price
             (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
 
-            assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSizes[1]);
+            assertEq(
+                sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)),
+                positionSizes[1],
+                "FAIL: wrong sfpm balances"
+            );
 
             {
                 (, uint256 inAMM, ) = ct0.getPoolData();
                 assertApproxEqAbs(
                     inAMM,
                     uint128(shortAmountsSold.rightSlot() - longAmounts.rightSlot()),
-                    10
+                    10,
+                    "FAIL: wrong inAMM for token0"
                 );
             }
 
             {
                 (, uint256 inAMM, ) = ct1.getPoolData();
-                assertApproxEqAbs(inAMM, uint128(shortAmounts.leftSlot()), 10);
+                assertApproxEqAbs(
+                    inAMM,
+                    uint128(shortAmounts.leftSlot()),
+                    10,
+                    "FAIL: wrong inAMM for token1"
+                );
             }
 
             {
                 assertEq(
                     pp.positionsHash(Alice),
-                    uint248(uint256(keccak256(abi.encodePacked(tokenId))))
+                    uint248(uint256(keccak256(abi.encodePacked(tokenId)))),
+                    "FAIL: wrong position hash"
                 );
 
-                assertEq(pp.numberOfLegs(Alice), 2);
+                assertEq(pp.numberOfLegs(Alice), 2, "FAIL: wrong number of legs");
 
                 TokenId _tokenId = tokenId;
 
                 (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = ph
                     .optionPositionInfo(pp, Alice, _tokenId);
 
-                assertEq(balance, positionSizes[1]);
+                assertEq(balance, positionSizes[1], "FAIL: wrong balance for Alice");
                 assertEq(
                     int64(poolUtilization0),
                     Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
                         ? int64(10_001)
                         : ($amount0Moveds[0] + $amount0Moveds[1] + $amount0Moveds[2] * 10000) /
-                            int256(ct0.totalSupply())
+                            int256(ct0.totalSupply()),
+                    "FAIL: werong pool utiliation0"
                 );
                 assertEq(
                     int64(poolUtilization1),
                     Math.abs(fastOracleTick - slowOracleTick) > int24(2230)
                         ? int64(10_001)
                         : ($amount1Moveds[0] + $amount1Moveds[1] + $amount1Moveds[2] * 10000) /
-                            int256(ct1.totalSupply())
+                            int256(ct1.totalSupply()),
+                    "FAIL: wrong pool utilzation1"
                 );
             }
 
@@ -4835,9 +4853,10 @@ contract PanopticPoolTest is PositionUtils {
             -int256(expectedSwaps[1]) - amount0Moveds[1] + shortAmounts.rightSlot()
         ];
 
+        // set itm spread fee to 0
         int256 ITMSpread = notionalVals[0] > 0
-            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+            ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+            : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000);
 
         assertApproxEqAbs(
             balanceBefores[0],
@@ -5009,9 +5028,10 @@ contract PanopticPoolTest is PositionUtils {
             -int256(expectedSwaps[1]) - amount0Moveds[1] + shortAmounts.rightSlot()
         ];
 
+        // set itm spread fee to 0
         int256 ITMSpread = notionalVals[0] > 0
-            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+            ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+            : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000);
 
         assertApproxEqAbs(
             balanceBefores[0],
@@ -5226,9 +5246,10 @@ contract PanopticPoolTest is PositionUtils {
             -int256(expectedSwaps[1]) - amount0Moveds[1] + shortAmounts.rightSlot()
         ];
 
+        // set itm spread fee to 0
         int256 ITMSpread = notionalVals[0] > 0
-            ? (notionalVals[0] * int24(2 * (fee / 100))) / 10_000
-            : -((notionalVals[0] * int24(2 * (fee / 100))) / 10_000);
+            ? (notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000
+            : -((notionalVals[0] * int24(2 * ((0 * fee) / 100))) / 10_000);
 
         assertApproxEqAbs(
             int256(balanceBefores[0]) - int256(uint256(type(uint104).max)),

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -1999,7 +1999,141 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
     // previously there was a dust threshold on minting for tokens below the amount of 50
     // now there is no restriction on the amount
-    function test_Success_mintTokenizedPosition_width0_noswap(
+    function test_Success_mintTokenizedPosition_width0_long_noswap(
+        uint256 positionSizeSeed,
+        uint256 widthSeed,
+        int256 strikeSeed
+    ) public {
+        // dust threshold is only in effect if both tokens are <10 wei so it's easiest to use a pool with a price close to 1
+        //_cacheWorldState(USDC_USDT_5);
+        _initPool(0);
+
+        // since we didn't go through the standard setup flow we need to repeat some of the initialization tasks here
+        vm.startPrank(Alice);
+
+        deal(token0, Alice, type(uint128).max);
+        deal(token1, Alice, type(uint128).max);
+
+        IERC20Partial(token0).approve(address(sfpm), type(uint256).max);
+        IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
+
+        // Initialize the world pool
+        sfpm.initializeAMMPool(token0, token1, fee);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        positionSize = uint128(bound(positionSizeSeed, 10 ** 18, 10 ** 22));
+
+        LeftRightSigned totalMoved;
+
+        // amount moved = token 0
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, 0);
+
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(totalMoved.rightSlot()), "FAIL: wrong moved amount token0");
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(-totalMoved.rightSlot()), "FAIL: wrong moved amount token0");
+
+        // amount moved = token1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(totalMoved.leftSlot()), "FAIL: wrong moved amount token1");
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(-totalMoved.leftSlot()), "FAIL: wrong moved amount token0");
+
+        // amount moved = token 0, asset = 1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(totalMoved.rightSlot()),
+            1,
+            "FAIL: wrong moved amount token0, asset = 1"
+        );
+        assertGe(
+            uint128(totalMoved.rightSlot()),
+            PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike))
+        );
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(-totalMoved.rightSlot()),
+            1,
+            "FAIL: wrong moved amount token0"
+        );
+
+        // amount moved = token 1, asset = 0
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(totalMoved.leftSlot()),
+            1,
+            "FAIL: wrong moved amount token1, asset = 0"
+        );
+        assertGe(
+            uint128(totalMoved.leftSlot()),
+            PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike))
+        );
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(-totalMoved.leftSlot()),
+            1,
+            "FAIL: wrong moved amount token1, asset = 0"
+        );
+    }
+
+    function test_Success_mintTokenizedPosition_width0_short_noswap(
         uint256 positionSizeSeed,
         uint256 widthSeed,
         int256 strikeSeed
@@ -2040,7 +2174,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );
-        assertEq(positionSize, uint128(totalMoved.rightSlot()), "FAIL: wrong moved amount token0");
+        assertEq(-int128(positionSize), totalMoved.rightSlot(), "FAIL: wrong moved amount token0");
 
         (, totalMoved) = sfpm.burnTokenizedPosition(
             tokenId,
@@ -2048,7 +2182,11 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );
-        assertEq(positionSize, uint128(-totalMoved.rightSlot()), "FAIL: wrong moved amount token0");
+        assertEq(
+            -int128(positionSize),
+            (-totalMoved.rightSlot()),
+            "FAIL: wrong moved amount token0"
+        );
 
         // amount moved = token1
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, 0);
@@ -2058,7 +2196,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );
-        assertEq(positionSize, uint128(totalMoved.leftSlot()), "FAIL: wrong moved amount token1");
+        assertEq(-int128(positionSize), (totalMoved.leftSlot()), "FAIL: wrong moved amount token1");
 
         (, totalMoved) = sfpm.burnTokenizedPosition(
             tokenId,
@@ -2066,7 +2204,11 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MIN_TICK,
             TickMath.MAX_TICK
         );
-        assertEq(positionSize, uint128(-totalMoved.leftSlot()), "FAIL: wrong moved amount token0");
+        assertEq(
+            -int128(positionSize),
+            (-totalMoved.leftSlot()),
+            "FAIL: wrong moved amount token0"
+        );
 
         // amount moved = token 0, asset = 1
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, 0);
@@ -2078,7 +2220,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
         assertApproxEqAbs(
             PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
-            uint128(totalMoved.rightSlot()),
+            uint128(-totalMoved.rightSlot()),
             1,
             "FAIL: wrong moved amount token0, asset = 1"
         );
@@ -2095,7 +2237,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
         assertApproxEqAbs(
             PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
-            uint128(-totalMoved.rightSlot()),
+            uint128(totalMoved.rightSlot()),
             1,
             "FAIL: wrong moved amount token0"
         );
@@ -2110,7 +2252,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
         assertApproxEqAbs(
             PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
-            uint128(totalMoved.leftSlot()),
+            uint128(-totalMoved.leftSlot()),
             1,
             "FAIL: wrong moved amount token1, asset = 0"
         );
@@ -2127,13 +2269,105 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
         assertApproxEqAbs(
             PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
-            uint128(-totalMoved.leftSlot()),
+            uint128(totalMoved.leftSlot()),
             1,
             "FAIL: wrong moved amount token1, asset = 0"
         );
     }
 
-    function test_Success_mintTokenizedPosition_width0_swap(
+    function test_Success_mintTokenizedPosition_width0_long_swap(
+        uint256 x,
+        uint256 positionSizeSeed,
+        uint256 widthSeed,
+        int256 strikeSeed
+    ) public {
+        // dust threshold is only in effect if both tokens are <10 wei so it's easiest to use a pool with a price close to 1
+        //_cacheWorldState(USDC_USDT_5);
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        positionSize = uint128(bound(positionSizeSeed, 10 ** 9, 10 ** 10));
+
+        LeftRightSigned totalMoved;
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        console2.log("");
+        // amount moved = token 0
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 0, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+
+        assertLe(
+            PanopticMath.convert0to1(positionSize, currentSqrtPriceX96),
+            uint128(totalMoved.leftSlot()),
+            "FAIL: wrong moved amount token0"
+        );
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        console2.log("");
+
+        // amount moved = token1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+        assertLe(
+            PanopticMath.convert1to0(positionSize, currentSqrtPriceX96),
+            uint128(totalMoved.rightSlot()),
+            "FAIL: wrong moved amount token1"
+        );
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        console2.log("");
+        // amount moved = token 0, asset = 1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 1, 0, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+        assertLe(
+            PanopticMath.convert0to1(
+                PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+                currentSqrtPriceX96
+            ),
+            uint128(totalMoved.leftSlot())
+        );
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        // amount moved = token 1, asset = 0
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 1, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+        assertLe(
+            PanopticMath.convert1to0(
+                PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+                currentSqrtPriceX96
+            ),
+            uint128(totalMoved.rightSlot())
+        );
+    }
+
+    function test_Success_mintTokenizedPosition_width0_short_swap(
         uint256 x,
         uint256 positionSizeSeed,
         uint256 widthSeed,
@@ -2165,9 +2399,9 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MIN_TICK
         );
 
-        assertLe(
+        assertGe(
             PanopticMath.convert0to1(positionSize, currentSqrtPriceX96),
-            uint128(totalMoved.leftSlot()),
+            uint128(-totalMoved.leftSlot()),
             "FAIL: wrong moved amount token0"
         );
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
@@ -2181,9 +2415,9 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MAX_TICK,
             TickMath.MIN_TICK
         );
-        assertLe(
+        assertGe(
             PanopticMath.convert1to0(positionSize, currentSqrtPriceX96),
-            uint128(totalMoved.rightSlot()),
+            uint128(-totalMoved.rightSlot()),
             "FAIL: wrong moved amount token1"
         );
 
@@ -2198,12 +2432,12 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MAX_TICK,
             TickMath.MIN_TICK
         );
-        assertLe(
+        assertGe(
             PanopticMath.convert0to1(
                 PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
                 currentSqrtPriceX96
             ),
-            uint128(totalMoved.leftSlot())
+            uint128(-totalMoved.leftSlot())
         );
 
         (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
@@ -2216,12 +2450,12 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             TickMath.MAX_TICK,
             TickMath.MIN_TICK
         );
-        assertLe(
+        assertGe(
             PanopticMath.convert1to0(
                 PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
                 currentSqrtPriceX96
             ),
-            uint128(totalMoved.rightSlot())
+            uint128(-totalMoved.rightSlot())
         );
     }
 

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -1997,6 +1997,234 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         }
     }
 
+    // previously there was a dust threshold on minting for tokens below the amount of 50
+    // now there is no restriction on the amount
+    function test_Success_mintTokenizedPosition_width0_noswap(
+        uint256 positionSizeSeed,
+        uint256 widthSeed,
+        int256 strikeSeed
+    ) public {
+        // dust threshold is only in effect if both tokens are <10 wei so it's easiest to use a pool with a price close to 1
+        //_cacheWorldState(USDC_USDT_5);
+        _initPool(0);
+
+        // since we didn't go through the standard setup flow we need to repeat some of the initialization tasks here
+        vm.startPrank(Alice);
+
+        deal(token0, Alice, type(uint128).max);
+        deal(token1, Alice, type(uint128).max);
+
+        IERC20Partial(token0).approve(address(sfpm), type(uint256).max);
+        IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
+
+        // Initialize the world pool
+        sfpm.initializeAMMPool(token0, token1, fee);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        positionSize = uint128(bound(positionSizeSeed, 10 ** 18, 10 ** 22));
+
+        LeftRightSigned totalMoved;
+
+        // amount moved = token 0
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, 0);
+
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(totalMoved.rightSlot()), "FAIL: wrong moved amount token0");
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(-totalMoved.rightSlot()), "FAIL: wrong moved amount token0");
+
+        // amount moved = token1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(totalMoved.leftSlot()), "FAIL: wrong moved amount token1");
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertEq(positionSize, uint128(-totalMoved.leftSlot()), "FAIL: wrong moved amount token0");
+
+        // amount moved = token 0, asset = 1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(totalMoved.rightSlot()),
+            1,
+            "FAIL: wrong moved amount token0, asset = 1"
+        );
+        assertGe(
+            uint128(totalMoved.rightSlot()),
+            PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike))
+        );
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(-totalMoved.rightSlot()),
+            1,
+            "FAIL: wrong moved amount token0"
+        );
+
+        // amount moved = token 1, asset = 0
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(totalMoved.leftSlot()),
+            1,
+            "FAIL: wrong moved amount token1, asset = 0"
+        );
+        assertGe(
+            uint128(totalMoved.leftSlot()),
+            PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike))
+        );
+
+        (, totalMoved) = sfpm.burnTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+        assertApproxEqAbs(
+            PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+            uint128(-totalMoved.leftSlot()),
+            1,
+            "FAIL: wrong moved amount token1, asset = 0"
+        );
+    }
+
+    function test_Success_mintTokenizedPosition_width0_swap(
+        uint256 x,
+        uint256 positionSizeSeed,
+        uint256 widthSeed,
+        int256 strikeSeed
+    ) public {
+        // dust threshold is only in effect if both tokens are <10 wei so it's easiest to use a pool with a price close to 1
+        //_cacheWorldState(USDC_USDT_5);
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick
+        );
+
+        positionSize = uint128(bound(positionSizeSeed, 10 ** 9, 10 ** 10));
+
+        LeftRightSigned totalMoved;
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        console2.log("");
+        // amount moved = token 0
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+
+        assertLe(
+            PanopticMath.convert0to1(positionSize, currentSqrtPriceX96),
+            uint128(totalMoved.leftSlot()),
+            "FAIL: wrong moved amount token0"
+        );
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        console2.log("");
+
+        // amount moved = token1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+        assertLe(
+            PanopticMath.convert1to0(positionSize, currentSqrtPriceX96),
+            uint128(totalMoved.rightSlot()),
+            "FAIL: wrong moved amount token1"
+        );
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        console2.log("");
+        // amount moved = token 0, asset = 1
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 1, 0, 0, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+        assertLe(
+            PanopticMath.convert0to1(
+                PanopticMath.convert1to0(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+                currentSqrtPriceX96
+            ),
+            uint128(totalMoved.leftSlot())
+        );
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        // amount moved = token 1, asset = 0
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 1, 0, strike, 0);
+        (, totalMoved) = sfpm.mintTokenizedPosition(
+            tokenId,
+            positionSize,
+            TickMath.MAX_TICK,
+            TickMath.MIN_TICK
+        );
+        assertLe(
+            PanopticMath.convert1to0(
+                PanopticMath.convert0to1(positionSize, TickMath.getSqrtRatioAtTick(strike)),
+                currentSqrtPriceX96
+            ),
+            uint128(totalMoved.rightSlot())
+        );
+    }
+
     function test_Fail_mintTokenizedPosition_PoolNotInitialized(
         uint256 x,
         uint256 widthSeed,


### PR DESCRIPTION
This PR introduces support for width-0 positions in the SemiFungiblePositionManager, treating them as simple token transfers rather than liquidity positions.

## Changes Made

### Core Logic Updates
- **SemiFungiblePositionManager.sol**: Modified `_createPositionInAMM()` to handle width-0 legs separately from standard liquidity positions
  - Width-0 legs now use `PanopticMath.getAmountsMoved()` for direct token transfers
  - Bypasses Uniswap V3 liquidity operations for these positions
  - Maintains existing validation and accounting logic for standard width > 0 positions

### Validation Changes  
- **TokenId.sol**: Removed the restriction that prevented width-0 positions
  - Updated comment to clarify that width=0 represents simple token transfers
  - Previously would revert with `InvalidTokenIdParameter(5)` for width-0

### Testing
- Added comprehensive test coverage for width-0 positions:
  - `test_Success_mintTokenizedPosition_width0_noswap()`: Tests width-0 positions without price impact
  - `test_Success_mintTokenizedPosition_width0_swap()`: Tests width-0 positions with swapping scenarios
  -  Validates proper amount calculations using conversion functions

### TODO
  - [ ] add burn tests and multileg tests with transfers + options legs
  - [ ] Make sure logic is followed correctly at the PanopticPool.sol level
  - [ ] Add collateral requirement logic in CollateralTracker.sol
  - [ ] Figure out the economics for the best collateral requirement for loans (likely 83% LTV)
  

## Applications

- When a user is force exercised, instead of seeing their balance being different, they receive a "debt" token in their account which reflects the amount of the option exercise. 
- The liquidation bonus could be distributed in terms of a debt token
- My brain needs time to process this




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added an option to treat premia as collateral across withdrawals, mint/burn, liquidation, and settlement flows.
  * Introduced a unified dispatch interface for position actions, simplifying interactions.
  * Enabled zero-width legs (treated as simple transfers).
  * Added basic ERC-1155 single-transfer receive support.

* Refactor
  * Replaced multiple public entry points with consolidated dispatch APIs.
  * Renamed a stale-price error to “StaleOracle” and aligned checks with oracle-based ticks.

* Tests
  * Expanded coverage for dispatch flows, oracle-tick logic, refunds, and zero-width scenarios.

* Chores
  * Adjusted compiler optimization runs for CI size profiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->