### PR TITLE
Feat: capped long premia

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -631,7 +631,8 @@ contract PanopticPool is Multicall {
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
-    /// @return The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
+    /// @return The total amount of commissions (base rate) paid for token0 (right) and token1 (left)
+    /// @return The amount of tokens paid when creating that option for token0 (right) and token1 (left)
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
@@ -872,6 +873,22 @@ contract PanopticPool is Multicall {
                     LIQUIDATIONS & FORCED EXERCISES
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Dispatches liquidations, forced exercises, or long premium settlements based on account solvency
+    /// @dev This function determines the appropriate action based on solvency checks at multiple price points:
+    ///      - If insolvent at all ticks: Execute liquidation (burns all positions)
+    ///      - If solvent at all ticks: Execute force exercise or settle long premium based on list lengths
+    ///      - Otherwise: Revert as account is not fully margin called
+    /// @dev The function uses position list lengths to determine the specific operation:
+    ///      - Same length lists between positionIdListTo and positionIdListToFinal: Settle long premium
+    ///      - Final list one shorter: Force exercise
+    ///      - Final list empty: Liquidation
+    /// @param positionIdListFrom List of positions held by the caller (msg.sender)
+    /// @param account The account being acted upon (liquidated, exercised, or settled)
+    /// @param positionIdListTo Current positions of the target account
+    /// @param positionIdListToFinal Expected positions after the operation completes
+    /// @param usePremiaAsCollateral Packed value indicating whether to use premia as collateral:
+    ///        - leftSlot: For the caller (msg.sender)
+    ///        - rightSlot: For the target account
     function dispatchFrom(
         TokenId[] calldata positionIdListFrom,
         address account,
@@ -882,7 +899,6 @@ contract PanopticPool is Multicall {
         // Assert the account we are liquidating is actually insolvent
         int24 twapTick = getUniV3TWAP();
         int24 currentTick;
-        uint256 path;
 
         TokenId tokenId;
 
@@ -921,6 +937,7 @@ contract PanopticPool is Multicall {
             );
             numberOfTicks = atTicks.length;
         }
+        LeftRightSigned exchangedAmounts;
         {
             // if account is solvent at all ticks, this is a force exercise or a settleLongPremium.
             if (solvent == numberOfTicks) {
@@ -937,18 +954,31 @@ contract PanopticPool is Multicall {
                                 revert Errors.InputListFail();
                             }
                         }
-                        path = 0;
+                        exchangedAmounts = _settleLongPremium(
+                            account,
+                            tokenId,
+                            twapTick,
+                            currentTick
+                        );
                     } else if (toLength == (finalLength + 1)) {
                         // final is one element shorter, that's a force exercise
                         tokenId.validateIsExercisable(twapTick);
-                        path = 1;
+                        exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
                     } else if (finalLength == 0) {
-                        // if final length was zero, this was intended to be liquidaton, but revert because not marging called
+                        // if final length was zero, this was intended to be liquidation, but revert because not margin called and solvent at some of the tested ticks
                         revert Errors.NotMarginCalled();
                     } else {
                         // otherwise, wrong input lists
                         revert Errors.InputListFail();
                     }
+                    // ensure the callee is still solvent after the operation
+                    bool premiaAsCollateral = usePremiaAsCollateral.rightSlot() > 0;
+                    _validateSolvency(
+                        account,
+                        positionIdListToFinal,
+                        NO_BUFFER,
+                        premiaAsCollateral
+                    );
                 }
             } else if (solvent == 0) {
                 // if account is insolvent at all ticks, this is a liquidation
@@ -959,40 +989,13 @@ contract PanopticPool is Multicall {
 
                 // if the final position list has a non-zero length, this can't be a complete liquidation, revert
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
-                path = 2;
+                exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
             } else {
                 // otherwise, revert because the account is not fully margin called
                 revert Errors.NotMarginCalled();
             }
         }
 
-        {
-            LeftRightSigned exchangedAmounts;
-            if (path == 2) {
-                exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
-                // no need to check that the liquidatee is solvent as all positions are burnt
-            } else {
-                // if path = 0, settleLongPremium
-                if (path == 0) {
-                    exchangedAmounts = _settleLongPremium(account, tokenId, twapTick, currentTick);
-                }
-
-                // if path = 1, force exercise
-
-                if (path == 1) {
-                    // to be eligible for force exercise, the price *must* be outside the position's range for at least 1 leg
-                    exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
-                }
-
-                // ensure the callee is still solvent after the operation
-                _validateSolvency(
-                    account,
-                    positionIdListToFinal,
-                    NO_BUFFER,
-                    usePremiaAsCollateral.rightSlot() > 0
-                );
-            }
-        }
         // ensure the caller is still solvent after the operation
         _validateSolvency(
             msg.sender,
@@ -1329,8 +1332,6 @@ contract PanopticPool is Multicall {
         }
 
         return solvent;
-        //if (expectedSolvent && solvent != numberOfTicks) revert Errors.AccountInsolvent();
-        //if (!expectedSolvent && solvent != 0) revert Errors.NotMarginCalled();
     }
 
     /// @notice Check whether an account is solvent at a given `atTick` with a collateral requirement of `buffer/10_000` multiplied by the requirement of `positionBalanceArray`.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -497,15 +497,14 @@ contract PanopticPool is Multicall {
     /// @param positionIdList The list of tokenIds for the option positions to be minted or burnt
     /// @param finalPositionIdList The final positionIdList after all the tokens have been minted/burnt
     /// @param positionSizes The list of positionSize for the position to be minted (0 for burns)
-    /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
-    /// denominated as X32 = (`ratioLimit * 2^32`)
+    /// @param maxLongPremiaX80 Maximum amount of long premia allowed for this position (computed as maxLongPremia = maxLongPremiaX80 * amountsMoved / 2**80)
     /// @param tickLimits The lower and lower bounds of an acceptable open interval for the ending price
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
     function dispatch(
         TokenId[] calldata positionIdList,
         TokenId[] calldata finalPositionIdList,
         uint128[] calldata positionSizes,
-        uint64[] calldata effectiveLiquidityLimitsX32,
+        uint96[] calldata maxLongPremiaX80,
         int24[2][] calldata tickLimits,
         bool usePremiaAsCollateral
     ) external {
@@ -532,7 +531,7 @@ contract PanopticPool is Multicall {
                 _mintOptions(
                     tokenId,
                     positionSizes[i],
-                    effectiveLiquidityLimitsX32[i],
+                    maxLongPremiaX80[i],
                     msg.sender,
                     tickLimitLow,
                     tickLimitHigh
@@ -572,15 +571,14 @@ contract PanopticPool is Multicall {
     /// @notice Validates the current options of the user, and mints a new position.
     /// @param tokenId The tokenId of the newly minted position
     /// @param positionSize The size of the position to be minted, expressed in terms of the asset
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
-    /// denominated as X32 = (`ratioLimit * 2^32`)
+    /// @param maxLongPremiaX80 Maximum amount of long premia allowed for this position (computed as maxLongPremia = maxLongPremiaX80 * amountsMoved / 2**80)
     /// @param owner The owner of the option position to be minted
     /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
     /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function _mintOptions(
         TokenId tokenId,
         uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
+        uint96 maxLongPremiaX80,
         address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
@@ -589,13 +587,7 @@ contract PanopticPool is Multicall {
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
-        _updateSettlementPostMint(
-            tokenId,
-            collectedByLeg,
-            positionSize,
-            effectiveLiquidityLimitX32,
-            owner
-        );
+        _updateSettlementPostMint(tokenId, collectedByLeg, positionSize, owner);
 
         uint32 poolUtilizations;
         LeftRightUnsigned commissions;
@@ -609,13 +601,12 @@ contract PanopticPool is Multicall {
 
         if (isSafeMode()) poolUtilizations = uint32(10_000 + (10_000 << 16));
 
-        uint96 tickData;
         // update the users options balance of position `tokenId`
         // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
         PositionBalance balanceData = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
-            tickData
+            maxLongPremiaX80
         );
 
         s_positionBalance[owner][tokenId] = balanceData;
@@ -904,6 +895,7 @@ contract PanopticPool is Multicall {
 
         uint256 solvent;
         uint256 numberOfTicks;
+
         {
             _validatePositionList(account, positionIdListTo);
 
@@ -963,6 +955,7 @@ contract PanopticPool is Multicall {
                     } else if (toLength == (finalLength + 1)) {
                         // final is one element shorter, that's a force exercise
                         tokenId.validateIsExercisable(twapTick);
+                        // TODO: Add logic to allow force exercises to occur with a bonus when longPremia exceeds maxLongPremia
                         exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
                     } else if (finalLength == 0) {
                         // if final length was zero, this was intended to be liquidation, but revert because not margin called and solvent at some of the tested ticks
@@ -1290,7 +1283,7 @@ contract PanopticPool is Multicall {
     /// @param atTicks An array of ticks to check solvency at
     /// @param buffer The buffer to apply to the collateral requirement
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
-    /// @return boolean flag that determines if account is solvent
+    /// @return solvent A uint256 flag that returns the number of ticks the account is solvent at
     function _checkSolvencyAtTicks(
         address account,
         TokenId[] calldata positionIdList,
@@ -1502,17 +1495,14 @@ contract PanopticPool is Multicall {
     /// @notice Get the `tokenId` position data for `user`.
     /// @param user The account that owns `tokenId`
     /// @param tokenId The position to query
-    /// @return `currentTick` at mint
-    /// @return Fast oracle tick at mint
-    /// @return Slow oracle tick at mint
-    /// @return Last observed tick at mint
+    /// @return maxLongPremia
     /// @return Utilization of token0 at mint
     /// @return Utilization of token1 at mint
     /// @return Size of the position
     function positionData(
         address user,
         TokenId tokenId
-    ) external view returns (int24, int24, int24, int24, int256, int256, uint128) {
+    ) external view returns (uint96, int256, int256, uint128) {
         return s_positionBalance[user][tokenId].unpackAll();
     }
 
@@ -1529,13 +1519,10 @@ contract PanopticPool is Multicall {
     /// @notice Ensure the effective liquidity in a given chunk is above a certain threshold.
     /// @param tokenId An option position
     /// @param leg A leg index of `tokenId` corresponding to a tickLower-tickUpper chunk
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as removedLiquidity/netLiquidity for a new position
-    /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @return totalLiquidity The total liquidity deposited in that chunk: `totalLiquidity = netLiquidity + removedLiquidity`
     function _checkLiquiditySpread(
         TokenId tokenId,
-        uint256 leg,
-        uint256 effectiveLiquidityLimitX32
+        uint256 leg
     ) internal view returns (uint256 totalLiquidity) {
         uint256 netLiquidity;
         uint256 removedLiquidity;
@@ -1551,7 +1538,7 @@ contract PanopticPool is Multicall {
 
         // put a limit on how much new liquidity in one transaction can be deployed into this leg
         // the effective liquidity measures how many times more the newly added liquidity is compared to the existing/base liquidity
-        if (effectiveLiquidityFactorX32 > effectiveLiquidityLimitX32)
+        if (effectiveLiquidityFactorX32 > MAX_SPREAD)
             revert Errors.EffectiveLiquidityAboveThreshold();
     }
 
@@ -1644,13 +1631,11 @@ contract PanopticPool is Multicall {
     /// @param tokenId The option position that was minted
     /// @param collectedByLeg The amount of tokens collected in the corresponding chunk for each leg of the position
     /// @param positionSize The size of the position, expressed in terms of the asset
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity`
     /// @param owner The owner of the option position to be minted
     function _updateSettlementPostMint(
         TokenId tokenId,
         LeftRightUnsigned[4] memory collectedByLeg,
         uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
         address owner
     ) internal {
         // ADD the current tokenId to the position list hash (hash = XOR of all keccak256(tokenId))
@@ -1694,13 +1679,9 @@ contract PanopticPool is Multicall {
                     .toLeftSlot(uint128(grossCurrent1));
             }
 
-            // if position is long, ensure that removed liquidity does not deplete strike beyond min(MAX_SPREAD, user-provided effectiveLiquidityLimit)
+            // if position is long, ensure that removed liquidity does not deplete strike beyond MAX_SPREAD
             // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (R + N)
-            uint256 totalLiquidity = _checkLiquiditySpread(
-                tokenId,
-                leg,
-                isLong == 0 ? MAX_SPREAD : Math.min(effectiveLiquidityLimitX32, MAX_SPREAD)
-            );
+            uint256 totalLiquidity = _checkLiquiditySpread(tokenId, leg);
 
             // if position is short, adjust `grossPremiumLast` upward to account for the increase in short liquidity
             if (isLong == 0) {
@@ -1900,7 +1881,7 @@ contract PanopticPool is Multicall {
 
                     // if position is short, ensure that removed liquidity does not deplete strike beyond MAX_SPREAD when closed
                     // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (T - R)
-                    totalLiquidity = _checkLiquiditySpread(tokenId, leg, MAX_SPREAD);
+                    totalLiquidity = _checkLiquiditySpread(tokenId, leg);
                 }
                 // T (totalLiquidity is (T - R) after burning)
                 uint256 totalLiquidityBefore = totalLiquidity + positionLiquidity;

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -267,6 +267,30 @@ library LeftRightLibrary {
         }
     }
 
+    /// @notice Subtract two LeftRight-encoded words.
+    /// @notice For each slot, if the subtrahend is larger than the minuend, the result is 0 (rectified subtraction).
+    /// @param x The minuend
+    /// @param y The subtrahend
+    /// @return z The rectified difference `max(0, x - y)` for each slot
+    function subRect(
+        LeftRightUnsigned x,
+        LeftRightUnsigned y
+    ) internal pure returns (LeftRightUnsigned z) {
+        unchecked {
+            uint128 x_left = x.leftSlot();
+            uint128 y_left = y.leftSlot();
+            // If x < y, the result is 0; otherwise, it's the difference.
+            uint128 left_diff = (x_left > y_left) ? x_left - y_left : 0;
+
+            uint128 x_right = x.rightSlot();
+            uint128 y_right = y.rightSlot();
+            // Same logic for the right slot.
+            uint128 right_diff = (x_right > y_right) ? x_right - y_right : 0;
+
+            return z.toRightSlot(right_diff).toLeftSlot(left_diff);
+        }
+    }
+
     /// @notice Adds two sets of LeftRight-encoded words, freezing both right slots if either overflows, and vice versa.
     /// @dev Used for linked accumulators, so if the accumulator for one side overflows for a token, both cease to accumulate.
     /// @param x The first augend

--- a/contracts/types/PositionBalance.sol
+++ b/contracts/types/PositionBalance.sol
@@ -11,23 +11,20 @@ using PositionBalanceLibrary for PositionBalance global;
 // PACKING RULES FOR A POSITIONBALANCE:
 // =================================================================================================
 //  From the LSB to the MSB:
-// (1) positionSize     128bits : The size of this position (uint128).
-// (2) poolUtilization0 16bits  : The pool utilization of token0, stored as (10000 * inAMM0)/totalAssets0 (uint16).
-// (3) poolUtilization1 16bits  : The pool utilization of token1, stored as (10000 * inAMM1)/totalAssets1 (uint16).
-// (4) currentTick      24bits  : The currentTick at mint (int24).
-// (5) fastOracleTick   24bits  : The fastOracleTick at mint (int24).
-// (6) slowOracleTick   24bits  : The slowOracleTick at mint (int24).
-// (7) lastObservedTick 24bits  : The lastObservedTick at mint (int24).
-// Total                256bits : Total bits used by a PositionBalance.
+// (1) positionSize       128bits : The size of this position (uint128).
+// (2) poolUtilization0   16bits  : The pool utilization of token0, stored as (10000 * inAMM0)/totalAssets0 (uint16).
+// (3) poolUtilization1   16bits  : The pool utilization of token1, stored as (10000 * inAMM1)/totalAssets1 (uint16).
+// (4) maxLongPremiaX80   96bits  : The maximum amount of long premia to be paid, computed as a function of the amount of tokens moved in that position.
+// Total                  256bits : Total bits used by a PositionBalance.
 // ===============================================================================================
 //
 // The bit pattern is therefore:
 //
-//           (7)             (6)            (5)             (4)             (3)             (2)             (1)
-//    <-- 24 bits --> <-- 24 bits --> <-- 24 bits --> <-- 24 bits --> <-- 16 bits --> <-- 16 bits --> <-- 128 bits -->
-//   lastObservedTick  slowOracleTick  fastOracleTick   currentTick     utilization1    utilization0    positionSize
+//        (4)             (3)             (2)             (1)
+//   <-- 96 bits --> <-- 16 bits --> <-- 16 bits --> <-- 128 bits -->
+//  maxLongPremiaX80   utilization1    utilization0    positionSize
 //
-//    <--- most significant bit                                                             least significant bit --->
+//    <--- most significant bit                            least significant bit --->
 //
 library PositionBalanceLibrary {
     /*//////////////////////////////////////////////////////////////
@@ -37,17 +34,17 @@ library PositionBalanceLibrary {
     /// @notice Create a new `PositionBalance` given by positionSize, utilizations, and its tickData.
     /// @param _positionSize The amount of option minted
     /// @param _utilizations Packed data containing pool utilizations for token0 and token1 at mint
-    /// @param _tickData Packed data containing ticks at mint (currentTick, fastOracleTick, slowOracleTick, lastObservedTick)
+    /// @param _maxLongPremiaX80 The maximum amount of long premia to be paid
     /// @return The new PositionBalance with the given positionSize, utilization, and tickData
     function storeBalanceData(
         uint128 _positionSize,
         uint32 _utilizations,
-        uint96 _tickData
+        uint96 _maxLongPremiaX80
     ) internal pure returns (PositionBalance) {
         unchecked {
             return
                 PositionBalance.wrap(
-                    (uint256(_tickData) << 160) +
+                    (uint256(_maxLongPremiaX80) << 160) +
                         (uint256(_utilizations) << 128) +
                         uint256(_positionSize)
                 );
@@ -78,42 +75,6 @@ library PositionBalanceLibrary {
     /*//////////////////////////////////////////////////////////////
                                 DECODING
     //////////////////////////////////////////////////////////////*/
-
-    /// @notice Get the last observed tick of `self`.
-    /// @param self The PositionBalance to retrieve the last observed tick from
-    /// @return The last observed tick of `self`
-    function lastObservedTick(PositionBalance self) internal pure returns (int24) {
-        unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 232));
-        }
-    }
-
-    /// @notice Get the slow oracle tick of `self`.
-    /// @param self The PositionBalance to retrieve the slow oracle tick from
-    /// @return The slow oracle tick of `self`
-    function slowOracleTick(PositionBalance self) internal pure returns (int24) {
-        unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 208));
-        }
-    }
-
-    /// @notice Get the fast oracle tick of `self`.
-    /// @param self The PositionBalance to retrieve the fast oracle tick from
-    /// @return The fast oracle tick of `self`
-    function fastOracleTick(PositionBalance self) internal pure returns (int24) {
-        unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 184));
-        }
-    }
-
-    /// @notice Get the current tick of `self`.
-    /// @param self The PositionBalance to retrieve the current tick from
-    /// @return The current tick of `self`
-    function currentTick(PositionBalance self) internal pure returns (int24) {
-        unchecked {
-            return int24(int256(PositionBalance.unwrap(self) >> 160));
-        }
-    }
 
     /// @notice Get the tickData of `self`.
     /// @param self The PositionBalance to retrieve the tickData from
@@ -176,12 +137,18 @@ library PositionBalanceLibrary {
         }
     }
 
+    /// @notice Get the maxLongPremiaX80  of `self`.
+    /// @param self The PositionBalance to retrieve the maxLongPremiaX80 from
+    /// @return The maxLongPremiaX80 of `self`
+    function maxLongPremia(PositionBalance self) internal pure returns (uint96) {
+        unchecked {
+            return uint96(PositionBalance.unwrap(self) >> 160);
+        }
+    }
+
     /// @notice Unpack all data from `self`.
     /// @param self The PositionBalance to get all data from
-    /// @return currentTickAtMint `currentTick` at mint
-    /// @return fastOracleTickAtMint Fast oracle tick at mint
-    /// @return slowOracleTickAtMint Slow oracle tick at mint
-    /// @return lastObservedTickAtMint Last observed tick at mint
+    /// @return _maxLongPremia maxLongPremia for this position
     /// @return utilization0AtMint Utilization of token0 at mint
     /// @return utilization1AtMint Utilization of token1 at mint
     /// @return _positionSize Size of the position
@@ -191,21 +158,13 @@ library PositionBalanceLibrary {
         external
         pure
         returns (
-            int24 currentTickAtMint,
-            int24 fastOracleTickAtMint,
-            int24 slowOracleTickAtMint,
-            int24 lastObservedTickAtMint,
+            uint96 _maxLongPremia,
             int256 utilization0AtMint,
             int256 utilization1AtMint,
             uint128 _positionSize
         )
     {
-        (
-            currentTickAtMint,
-            fastOracleTickAtMint,
-            slowOracleTickAtMint,
-            lastObservedTickAtMint
-        ) = unpackTickData(self.tickData());
+        _maxLongPremia = self.maxLongPremia();
 
         utilization0AtMint = self.utilization0();
         utilization1AtMint = self.utilization1();


### PR DESCRIPTION
## Description:
This PR refactors the position validation mechanism by replacing the per-position `effectiveLiquidityLimitX32` parameter with a `maxLongPremiaX80` threshold. Instead of limiting liquidity spread at mint time, the system now tracks maximum allowed long premia for each position.


## TODO
The value of `maxLongPremiaX80` is a uint96 stored as a X80 number, where the threshold criteria for the long premia will be calculated as:

```
premiaCap0 = (Math.max(0, -realizedPremia.rightSlot()) * maxLongPremiaX80) >> 80
premiaCap1 = (Math.max(0, -realizedPremia.leftSlot()) * maxLongPremiaX80) >> 80
```

When that premiaCap is exceeded, then the `_forceExercise` workflow will burn the position with the `DONOT_COMMIT_LONG_SETTLED` flag and will distribute a fixed percentage (15%?) of the exercisee's long premia to the exercisor by appropriately updating the `settledTokens`

### Key Changes:
- Removed per-position liquidity spread limits (`effectiveLiquidityLimitX32`) from the `dispatch()` and `_mintOptions()` functions
- Introduced `maxLongPremiaX80` parameter to set maximum long premia thresholds per position
- Simplified `PositionBalance` struct by replacing tick data (currentTick, fastOracleTick, slowOracleTick, lastObservedTick) with `maxLongPremiaX80` storage
- Liquidity spread validation now uses a fixed `MAX_SPREAD` constant instead of user-provided limits
- Added `subRect()` helper function in LeftRight library for rectified subtraction operations
- Added TODO for implementing force exercise bonuses when long premia exceeds maximum thresholds

This change simplifies position management while providing more direct control over risk through premia-based limits rather than liquidity-based restrictions.