### PR TITLE
feat: protocol fee v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ broadcast
 out
 docs
 safe-txns
+
+scratch

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -241,13 +241,17 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param fee The fee of the Uniswap pool
     /// @param panopticPool The address of the Panoptic Pool being created and linked to this Collateral Tracker
     /// @param feeSwitchController The address permitted to modify protocol fee parameters
+    /// @param initialFeeRecipient The address initially configured to receive protocol fees
+    /// @param feeSwitchController The initial protocol fee, in bps, to charge
     function startToken(
         bool underlyingIsToken0,
         address token0,
         address token1,
         uint24 fee,
         PanopticPool panopticPool,
-        address feeSwitchController
+        address feeSwitchController,
+        address initialFeeRecipient,
+        address initialFee,
     ) external {
         // fails if already initialized
         if (s_initialized) revert Errors.CollateralTokenAlreadyInitialized();
@@ -284,6 +288,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         // Address permitted to alter protocol fee parameters
         FEE_SWITCH_CONTROLLER = feeSwitchController;
+
+        // Initial protocol fee config
+        s_protocolFeeRecipient = initialFeeRecipient;
+        s_protocolFee = initialFee;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -251,7 +251,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         PanopticPool panopticPool,
         address feeSwitchController,
         address initialFeeRecipient,
-        address initialFee,
+        uint256 initialFee
     ) external {
         // fails if already initialized
         if (s_initialized) revert Errors.CollateralTokenAlreadyInitialized();

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1339,8 +1339,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @return The final utilization of the collateral vault (rightSlot, first 32 bits), the commissions paid to the protocol (rightSlot, last 96 bits)
-    ///         and the total amount of commission (base rate + ITM spread) paid (leftSlot)
+    /// @return The final utilization of the collateral vault (leftSlot, first 32 bits), the commissions paid to the protocol (leftSlot, last 96 bits)
+    ///         and the total amount of commission (base rate + ITM spread) paid (rightSlot)
     function settleMint(
         address optionOwner,
         int128 longAmount,
@@ -1356,7 +1356,10 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             0 // realizedPremium not used
         );
         return (
-            LeftRightUnsigned.wrap(0).toRightSlot(utilization >> 32 + uint96(commissions.leftSlot())).toLeftSlot(commissions.rightSlot()),
+            LeftRightUnsigned
+                .wrap(0)
+                .toRightSlot(commissions.rightSlot())
+                .toLeftSlot((uint128(utilization) << 96) | uint128(uint96(commissions.leftSlot()))),
             tokenPaid
         );
     }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -80,6 +80,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @dev int type for composability with signed integer based mathematical operations.
     int128 internal constant DECIMALS_128 = 10_000;
 
+    /// @notice Address authorized to control fee switch parameters.
+    address FEE_SWITCH_CONTROLLER;
+
     /*//////////////////////////////////////////////////////////////
                            UNISWAP POOL DATA
     //////////////////////////////////////////////////////////////*/
@@ -115,6 +118,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
     /// @notice The fee of the Uniswap pool in hundredths of basis points.
     uint24 internal s_poolFee;
+
+    /// @notice Protocol fee recipient address for fee switch.
+    address internal s_protocolFeeRecipient;
+
+    /// @notice Protocol fee in basis points, charged on option mint.
+    uint256 internal s_protocolFee;
 
     /**
      * @notice How the Borrow Index Works
@@ -190,6 +199,12 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         _;
     }
 
+    /// @notice Reverts if the FEE_SWITCH_CONTROLLER is not the caller.
+    modifier onlyFeeSwitchController() {
+        if (msg.sender != FEE_SWITCH_CONTROLLER) revert Errors.NotFeeSwitchController();
+        _;
+    }
+
     /*//////////////////////////////////////////////////////////////
                   INITIALIZATION & PARAMETER SETTINGS
     //////////////////////////////////////////////////////////////*/
@@ -225,12 +240,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param token1 Token 1 of the Uniswap pool
     /// @param fee The fee of the Uniswap pool
     /// @param panopticPool The address of the Panoptic Pool being created and linked to this Collateral Tracker
+    /// @param feeSwitchController The address permitted to modify protocol fee parameters
     function startToken(
         bool underlyingIsToken0,
         address token0,
         address token1,
         uint24 fee,
-        PanopticPool panopticPool
+        PanopticPool panopticPool,
+        address feeSwitchController
     ) external {
         // fails if already initialized
         if (s_initialized) revert Errors.CollateralTokenAlreadyInitialized();
@@ -264,6 +281,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
         // store whether the current collateral token is token0 (true) or token1 (false)
         s_underlyingIsToken0 = underlyingIsToken0;
+
+        // Address permitted to alter protocol fee parameters
+        FEE_SWITCH_CONTROLLER = feeSwitchController;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -1230,7 +1250,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    ///
+    /// @return poolUtilization The pool utilization at moment of settling; returns 0 for option closing as util isnt relevant then
+    /// @return commissions The commissions paid to PLPs (right) and the protocol (left) upon option mint
+    /// @return tokenToPay The amount of tokens the user paid/received for minting/burning their option
     function _updateBalancesAndSettle(
         bool isCreation,
         address optionOwner,
@@ -1238,11 +1260,17 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         int128 shortAmount,
         int128 swappedAmount,
         int128 realizedPremium
-    ) internal returns (uint32, uint128, int128) {
+    ) internal returns (uint32, LeftRightUnsigned, int128) {
         _accrueInterest(optionOwner);
         unchecked {
             int256 tokenToPay;
-            uint128 commission;
+            uint128 plpCommission;
+            uint256 protocolCommission = (isCreation && s_protocolFee > 0) ?
+                            Math.unsafeDivRoundingUp(
+                                uint256(uint128(shortAmount + longAmount)) * s_protocolFee,
+                                DECIMALS
+                            )
+                          : 0
 
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
@@ -1252,14 +1280,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
 
                     // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
-                    commission = uint128(
+                    plpCommission = uint128(
                         Math.unsafeDivRoundingUp(
                             uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
                             DECIMALS
                         )
                     );
 
-                    tokenToPay = intrinsicValue + int128(commission);
+                    tokenToPay = intrinsicValue + int128(plpCommission);
                 }
             } else {
                 // add premium and token deltas not covered by swap to be paid/collected on position close
@@ -1279,8 +1307,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 _mint(optionOwner, sharesToMint);
             }
 
-            // Update Pool Assets
+            // Update Pool Assets & pay protocol fee
             if (isCreation) {
+                if (protocolCommission > 0) {
+                    _mint(s_protocolFeeRecipient, convertToShares(protocolCommission));
+                }
                 s_poolAssets = uint256(updatedAssets).toUint128();
             } else {
                 s_poolAssets = uint256(updatedAssets + realizedPremium).toUint128();
@@ -1299,7 +1330,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             }
             uint32 utilization = isCreation ? uint32(_poolUtilization()) : 0;
 
-            return (utilization, commission, int128(tokenToPay));
+            return (utilization, LeftRightUnsigned.wrap(plpCommission).toLeftSlot(uint128(protocolCommission)), int128(tokenToPay));
         }
     }
 
@@ -1308,14 +1339,15 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     /// @param longAmount The amount of longs
     /// @param shortAmount The amount of shorts
     /// @param swappedAmount The amount of tokens moved during creation of the option position
-    /// @return The final utilization of the collateral vault (rightSlot) and the total amount of commission (base rate + ITM spread) paid (leftSlot)
+    /// @return The final utilization of the collateral vault (rightSlot, first 32 bits), the commissions paid to the protocol (rightSlot, last 96 bits)
+    ///         and the total amount of commission (base rate + ITM spread) paid (leftSlot)
     function settleMint(
         address optionOwner,
         int128 longAmount,
         int128 shortAmount,
         int128 swappedAmount
     ) external onlyPanopticPool returns (LeftRightUnsigned, int128) {
-        (uint32 utilization, uint128 commission, int128 tokenPaid) = _updateBalancesAndSettle(
+        (uint32 utilization, LeftRightUnsigned commissions, int128 tokenPaid) = _updateBalancesAndSettle(
             true, // isCreation = true
             optionOwner,
             longAmount,
@@ -1324,7 +1356,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             0 // realizedPremium not used
         );
         return (
-            LeftRightUnsigned.wrap(0).toRightSlot(utilization).toLeftSlot(commission),
+            LeftRightUnsigned.wrap(0).toRightSlot(utilization >> 32 + uint96(commissions.leftSlot())).toLeftSlot(commissions.rightSlot()),
             tokenPaid
         );
     }
@@ -1573,7 +1605,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                            BUYING
                            POWER
                            REQUIREMENT
-                         
+
                                          ^               .         .
                                          |        <- ITM . <-ATM-> . OTM ->
                            100% + SCR% - |--__           .    .    .
@@ -1584,7 +1616,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                                          +----+----------+----+----+--->   current
                                          0   Liqui-     Pa  strike Pb       price
                                              dation
-                                             price = SCR*strike                                         
+                                             price = SCR*strike
                          */
 
                         uint256 c2 = Constants.FP96 - ratio;
@@ -1820,5 +1852,25 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     poolUtilization
                 );
         }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      PROTOCOL FEE PARAMETERS
+    //////////////////////////////////////////////////////////////*/
+
+    // @notice Update the protocol fee recipient.
+    /// @dev Only callable by the fee switch controller.
+    /// @param newRecipient The new protocol fee recipient address
+    function setProtocolFeeRecipient(address newRecipient) external onlyFeeSwitchController {
+        s_protocolFeeRecipient = newRecipient;
+    }
+
+    /// @notice Update the protocol fee.
+    /// @dev Only callable by the fee switch controller.
+    /// @param newFee The new protocol fee in basis points
+    function setProtocolFee(uint256 newFee) external onlyFeeSwitchController {
+        // TODO: If we want to minimise the importance of the admin key, we could put controls in here,
+        // like only allowing the fee to be 1% at max, or only change 0.1% at a time.
+        s_protocolFee = newFee;
     }
 }

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1270,7 +1270,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                                 uint256(uint128(shortAmount + longAmount)) * s_protocolFee,
                                 DECIMALS
                             )
-                          : 0
+                          : 0;
 
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -157,12 +157,8 @@ contract PanopticFactory is FactoryNFT, Multicall {
         );
 
         // Run state initialization sequence for pool and collateral tokens
-        collateralTracker0.startToken(true, token0, token1, fee, newPoolContract, protocolFeeController);
-        collateralTracker1.startToken(false, token0, token1, fee, newPoolContract, protocolFeeController);
-        collateralTracker0.setProtocolFeeRecipient(initialProtocolFeeRecipient);
-        collateralTracker1.setProtocolFeeRecipient(initialProtocolFeeRecipient);
-        collateralTracker0.setProtocolFee(initialProtocolFee);
-        collateralTracker1.setProtocolFee(initialProtocolFee);
+        collateralTracker0.startToken(true, token0, token1, fee, newPoolContract, protocolFeeController, initialProtocolFeeRecipient, initialProtocolFee);
+        collateralTracker1.startToken(false, token0, token1, fee, newPoolContract, protocolFeeController, initialProtocolFeeRecipient, initialProtocolFee);
 
         newPoolContract.startPool(v3Pool, token0, token1, collateralTracker0, collateralTracker1);
 

--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -108,6 +108,9 @@ contract PanopticFactory is FactoryNFT, Multicall {
     /// @dev Salt used in PanopticPool CREATE2 is `[leading 20 msg.sender chars][leading 20 pool address chars][salt]`.
     /// @param token0 Address of token0 for the underlying Uniswap V3 pool
     /// @param token1 Address of token1 for the underlying Uniswap V3 pool
+    /// @param protocolFeeController Address that will be permitted to alter protocol fee parameters on this pool
+    /// @param initialProtocolFeeRecipient Address that will be configured at first to receive protocol fees
+    /// @param initialProtocolFee The initial commission to charge on option mints as a protocol fee, in basis points
     /// @param fee The fee tier of the underlying Uniswap V3 pool, denominated in hundredths of bips
     /// @param salt User-defined component of salt used in CREATE2 for the PanopticPool (must be a uint96 number)
     /// @return newPoolContract The address of the newly deployed Panoptic pool
@@ -115,6 +118,9 @@ contract PanopticFactory is FactoryNFT, Multicall {
         address token0,
         address token1,
         uint24 fee,
+        address protocolFeeController,
+        address initialProtocolFeeRecipient,
+        uint256 initialProtocolFee,
         uint96 salt
     ) external returns (PanopticPool newPoolContract) {
         // sort the tokens, if necessary:
@@ -151,8 +157,12 @@ contract PanopticFactory is FactoryNFT, Multicall {
         );
 
         // Run state initialization sequence for pool and collateral tokens
-        collateralTracker0.startToken(true, token0, token1, fee, newPoolContract);
-        collateralTracker1.startToken(false, token0, token1, fee, newPoolContract);
+        collateralTracker0.startToken(true, token0, token1, fee, newPoolContract, protocolFeeController);
+        collateralTracker1.startToken(false, token0, token1, fee, newPoolContract, protocolFeeController);
+        collateralTracker0.setProtocolFeeRecipient(initialProtocolFeeRecipient);
+        collateralTracker1.setProtocolFeeRecipient(initialProtocolFeeRecipient);
+        collateralTracker0.setProtocolFee(initialProtocolFee);
+        collateralTracker1.setProtocolFee(initialProtocolFee);
 
         newPoolContract.startPool(v3Pool, token0, token1, collateralTracker0, collateralTracker1);
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -77,12 +77,14 @@ contract PanopticPool is Multicall {
     /// @param recipient User that minted the option
     /// @param tokenId TokenId of the created option
     /// @param balanceData The `PositionBalance` data for `tokenId` containing the number of contracts, pool utilizations, and ticks at mint
-    /// @param commissions The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left)
+    /// @param plpCommissions The total amount of commissions (base rate + ITM spread) paid for token0 (right) and token1 (left) to PLPs
+    /// @param protocolCommissions The total amount of commissions paid for token0 (right) and token1 (left) to the protocol
     event OptionMinted(
         address indexed recipient,
         TokenId indexed tokenId,
         PositionBalance balanceData,
-        LeftRightUnsigned commissions
+        LeftRightUnsigned plpCommissions
+        LeftRightUnsigned protocolCommissions
     );
 
     /*//////////////////////////////////////////////////////////////
@@ -600,7 +602,7 @@ contract PanopticPool is Multicall {
         uint32 poolUtilizations;
         LeftRightUnsigned commissions;
 
-        (poolUtilizations, commissions, paidAmounts) = _payCommissionAndWriteData(
+        (poolUtilizations, plpCommissions, protocolCommissions, paidAmounts) = _payCommissionAndWriteData(
             tokenId,
             positionSize,
             owner,
@@ -620,7 +622,7 @@ contract PanopticPool is Multicall {
 
         s_positionBalance[owner][tokenId] = balanceData;
 
-        emit OptionMinted(owner, tokenId, balanceData, commissions);
+        emit OptionMinted(owner, tokenId, balanceData, plpCommissions, protocolCommissions);
     }
 
     /// @notice Take the commission fees for minting `tokenId` and settle any other required collateral deltas.
@@ -631,19 +633,21 @@ contract PanopticPool is Multicall {
     /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
-    /// @return The total amount of commissions (base rate) paid for token0 (right) and token1 (left)
+    /// @return The total amount of commissions (base rate) paid for token0 (right) and token1 (left) to PLPs
+    /// @return The total amount of commissions (base rate) paid for token0 (right) and token1 (left) to the protocol
     /// @return The amount of tokens paid when creating that option for token0 (right) and token1 (left)
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
         address owner,
         LeftRightSigned totalSwapped
-    ) internal returns (uint32, LeftRightUnsigned, LeftRightSigned) {
+    ) internal returns (uint32, LeftRightUnsigned, LeftRightUnsigned, LeftRightSigned) {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        uint32 commissions;
+        LeftRightUnsigned plpCommissions;
+        LeftRightUnsigned protocolCommissions;
         LeftRightUnsigned utilizations;
         LeftRightSigned paidAmounts;
 
@@ -651,33 +655,35 @@ contract PanopticPool is Multicall {
         LeftRightSigned _totalSwapped = totalSwapped;
 
         {
-            (LeftRightUnsigned utilizationAndCommission0, int128 paid0) = s_collateralToken0
+            (LeftRightUnsigned utilizationAndCommissions0, int128 paid0) = s_collateralToken0
                 .settleMint(
                     owner,
                     longAmounts.rightSlot(),
                     shortAmounts.rightSlot(),
                     _totalSwapped.rightSlot()
                 );
-            commissions = uint32(utilizationAndCommission0.rightSlot());
+            plpCommissions = plpCommissions.wrap(utilizationAndCommissions0.rightSlot());
+            protocolCommissions = protocolCommissions.wrap(uint128(uint96(utilizationAndCommissions0.leftSlot())));
             utilizations = utilizations.toRightSlot(utilizationAndCommission0.leftSlot());
             paidAmounts = paidAmounts.toRightSlot(paid0);
         }
         {
-            (LeftRightUnsigned utilizationAndCommission1, int128 paid1) = s_collateralToken1
+            (LeftRightUnsigned utilizationAndCommissions1, int128 paid1) = s_collateralToken1
                 .settleMint(
                     owner,
                     longAmounts.leftSlot(),
                     shortAmounts.leftSlot(),
                     _totalSwapped.leftSlot()
                 );
-            commissions = uint32(utilizationAndCommission1.rightSlot() << 16);
+            plpCommissions.toLeftSlot(utilizationAndCommissions1.rightSlot());
+            protocolCommissions.toLeftSlot(uint128(uint96(utilizationAndCommissions1.leftSlot())));
             utilizations = utilizations.toLeftSlot(utilizationAndCommission1.leftSlot());
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
-            return (commissions, utilizations, paidAmounts);
+            return (utilizations, plpCommissions, protocolCommissions, paidAmounts);
         }
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -612,13 +612,12 @@ contract PanopticPool is Multicall {
 
         if (isSafeMode()) poolUtilizations = uint32(10_000 + (10_000 << 16));
 
-        uint96 tickData;
         // update the users options balance of position `tokenId`
         // NOTE: user can't mint same position multiple times, so set the positionSize instead of adding
         PositionBalance balanceData = PositionBalanceLibrary.storeBalanceData(
             positionSize,
             poolUtilizations,
-            tickData
+            0
         );
 
         s_positionBalance[owner][tokenId] = balanceData;
@@ -647,21 +646,27 @@ contract PanopticPool is Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        uint32 utilizations;
-        LeftRightUnsigned plpCommissions;
-        LeftRightUnsigned protocolCommissions;
-        LeftRightSigned paidAmounts;
+        (
+            uint32 utilizations,
+            LeftRightUnsigned plpCommissions,
+            LeftRightUnsigned protocolCommissions,
+            LeftRightSigned paidAmounts
+        ) = _settleMints(owner, longAmounts, shortAmounts, totalSwapped);
+    }
 
-        // stack too deep
-        LeftRightSigned _totalSwapped = totalSwapped;
-
+    function _settleMints(address owner, LeftRightSigned longAmounts, LeftRightSigned shortAmounts, LeftRightSigned totalSwapped) internal returns (
+        uint32 utilizations,
+        LeftRightUnsigned plpCommissions,
+        LeftRightUnsigned protocolCommissions,
+        LeftRightSigned paidAmounts
+    ) {
         {
             (LeftRightUnsigned utilizationAndCommissions0, int128 paid0) = s_collateralToken0
                 .settleMint(
                     owner,
                     longAmounts.rightSlot(),
                     shortAmounts.rightSlot(),
-                    _totalSwapped.rightSlot()
+                    totalSwapped.rightSlot()
                 );
             plpCommissions = plpCommissions.toRightSlot(utilizationAndCommissions0.rightSlot());
             protocolCommissions = protocolCommissions.toRightSlot(uint128(uint96(utilizationAndCommissions0.leftSlot())));
@@ -674,7 +679,7 @@ contract PanopticPool is Multicall {
                     owner,
                     longAmounts.leftSlot(),
                     shortAmounts.leftSlot(),
-                    _totalSwapped.leftSlot()
+                    totalSwapped.leftSlot()
                 );
             plpCommissions.toLeftSlot(utilizationAndCommissions1.rightSlot());
             protocolCommissions.toLeftSlot(uint128(uint96(utilizationAndCommissions1.leftSlot())));
@@ -683,9 +688,7 @@ contract PanopticPool is Multicall {
         }
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
-        unchecked {
-            return (utilizations, plpCommissions, protocolCommissions, paidAmounts);
-        }
+        return (utilizations, plpCommissions, protocolCommissions, paidAmounts);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -83,7 +83,7 @@ contract PanopticPool is Multicall {
         address indexed recipient,
         TokenId indexed tokenId,
         PositionBalance balanceData,
-        LeftRightUnsigned plpCommissions
+        LeftRightUnsigned plpCommissions,
         LeftRightUnsigned protocolCommissions
     );
 
@@ -600,7 +600,8 @@ contract PanopticPool is Multicall {
         );
 
         uint32 poolUtilizations;
-        LeftRightUnsigned commissions;
+        LeftRightUnsigned plpCommissions;
+        LeftRightUnsigned protocolCommissions;
 
         (poolUtilizations, plpCommissions, protocolCommissions, paidAmounts) = _payCommissionAndWriteData(
             tokenId,
@@ -646,9 +647,9 @@ contract PanopticPool is Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
+        uint32 utilizations;
         LeftRightUnsigned plpCommissions;
         LeftRightUnsigned protocolCommissions;
-        LeftRightUnsigned utilizations;
         LeftRightSigned paidAmounts;
 
         // stack too deep
@@ -662,9 +663,9 @@ contract PanopticPool is Multicall {
                     shortAmounts.rightSlot(),
                     _totalSwapped.rightSlot()
                 );
-            plpCommissions = plpCommissions.wrap(utilizationAndCommissions0.rightSlot());
-            protocolCommissions = protocolCommissions.wrap(uint128(uint96(utilizationAndCommissions0.leftSlot())));
-            utilizations = utilizations.toRightSlot(utilizationAndCommission0.leftSlot());
+            plpCommissions = plpCommissions.toRightSlot(utilizationAndCommissions0.rightSlot());
+            protocolCommissions = protocolCommissions.toRightSlot(uint128(uint96(utilizationAndCommissions0.leftSlot())));
+            utilizations = uint32(utilizationAndCommissions0.leftSlot() >> 96);
             paidAmounts = paidAmounts.toRightSlot(paid0);
         }
         {
@@ -677,7 +678,7 @@ contract PanopticPool is Multicall {
                 );
             plpCommissions.toLeftSlot(utilizationAndCommissions1.rightSlot());
             protocolCommissions.toLeftSlot(uint128(uint96(utilizationAndCommissions1.leftSlot())));
-            utilizations = utilizations.toLeftSlot(utilizationAndCommission1.leftSlot());
+            utilizations += uint32(utilizationAndCommissions1.leftSlot() >> 96) << 16;
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -646,15 +646,25 @@ contract PanopticPool is Multicall {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
-        (
-            uint32 utilizations,
-            LeftRightUnsigned plpCommissions,
-            LeftRightUnsigned protocolCommissions,
-            LeftRightSigned paidAmounts
-        ) = _settleMints(owner, longAmounts, shortAmounts, totalSwapped);
+        return _settleMints(owner, longAmounts, shortAmounts, totalSwapped);
     }
 
-    function _settleMints(address owner, LeftRightSigned longAmounts, LeftRightSigned shortAmounts, LeftRightSigned totalSwapped) internal returns (
+    /// @notice Settles mint operations with both collateral trackers and aggregates utilization and commission data.
+    /// @dev Helper function to manage stack depth in _payCommissionAndWriteData by handling CollateralTracker interactions.
+    /// @param owner The address minting the position
+    /// @param longAmounts The long amounts for each token (token0 in right slot, token1 in left slot)
+    /// @param shortAmounts The short amounts for each token (token0 in right slot, token1 in left slot)
+    /// @param totalSwapped The amount of tokens swapped during position creation (token0 in right slot, token1 in left slot)
+    /// @return utilizations Packed pool utilizations as two uint16 values (token1 utilization in high 16 bits, token0 in low 16 bits)
+    /// @return plpCommissions The total commissions paid to PLPs for token0 (right slot) and token1 (left slot)
+    /// @return protocolCommissions The total protocol commissions for token0 (right slot) and token1 (left slot)
+    /// @return paidAmounts The net amounts paid for token0 (right slot) and token1 (left slot)
+    function _settleMints(
+        address owner,
+        LeftRightSigned longAmounts,
+        LeftRightSigned shortAmounts,
+        LeftRightSigned totalSwapped
+    ) internal returns (
         uint32 utilizations,
         LeftRightUnsigned plpCommissions,
         LeftRightUnsigned protocolCommissions,
@@ -681,8 +691,8 @@ contract PanopticPool is Multicall {
                     shortAmounts.leftSlot(),
                     totalSwapped.leftSlot()
                 );
-            plpCommissions.toLeftSlot(utilizationAndCommissions1.rightSlot());
-            protocolCommissions.toLeftSlot(uint128(uint96(utilizationAndCommissions1.leftSlot())));
+            plpCommissions = plpCommissions.toLeftSlot(utilizationAndCommissions1.rightSlot());
+            protocolCommissions = protocolCommissions.toLeftSlot(uint128(uint96(utilizationAndCommissions1.leftSlot())));
             utilizations += uint32(utilizationAndCommissions1.leftSlot() >> 96) << 16;
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -56,6 +56,9 @@ library Errors {
     /// @notice CollateralTracker: The caller for a permissioned function is not the Panoptic Pool
     error NotPanopticPool();
 
+    /// @notice CollateralTracker: The caller for a permissioned function is not the FEE_SWITCH_CONTROLLER
+    error NotFeeSwitchController();
+
     /// @notice Uniswap pool has already been initialized in the SFPM or created in the factory
     error PoolAlreadyInitialized();
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -174,8 +174,8 @@ contract PanopticPoolHarness is PanopticPool {
         s_collateralToken1 = new CollateralTrackerHarness();
 
         // initialize the token
-        s_collateralToken0.startToken(true, token0, token1, uniswapPool.fee(), this);
-        s_collateralToken1.startToken(false, token0, token1, uniswapPool.fee(), this);
+        s_collateralToken0.startToken(true, token0, token1, uniswapPool.fee(), this, address(this));
+        s_collateralToken1.startToken(false, token0, token1, uniswapPool.fee(), this, address(this));
     }
 
     function delegate(address delegatee, CollateralTracker collateralToken) external {
@@ -696,7 +696,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
     function test_Success_StartToken_virtualShares() public {
         _initWorld(0);
         CollateralTracker ct = new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000);
-        ct.startToken(false, token0, token1, fee, panopticPool);
+        ct.startToken(false, token0, token1, fee, panopticPool, address(0));
 
         assertEq(ct.totalSupply(), 10 ** 6);
         assertEq(ct.totalAssets(), 1);
@@ -709,11 +709,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0 = new CollateralTrackerHarness();
 
         // initialize the token
-        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)));
+        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)), address(0));
 
         // fails if already initialized
         vm.expectRevert(Errors.CollateralTokenAlreadyInitialized.selector);
-        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)));
+        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)), address(0));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -174,8 +174,8 @@ contract PanopticPoolHarness is PanopticPool {
         s_collateralToken1 = new CollateralTrackerHarness();
 
         // initialize the token
-        s_collateralToken0.startToken(true, token0, token1, uniswapPool.fee(), this, address(this));
-        s_collateralToken1.startToken(false, token0, token1, uniswapPool.fee(), this, address(this));
+        s_collateralToken0.startToken(true, token0, token1, uniswapPool.fee(), this, address(this), address(this), 0);
+        s_collateralToken1.startToken(false, token0, token1, uniswapPool.fee(), this, address(this), address(this), 0);
     }
 
     function delegate(address delegatee, CollateralTracker collateralToken) external {
@@ -696,7 +696,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
     function test_Success_StartToken_virtualShares() public {
         _initWorld(0);
         CollateralTracker ct = new CollateralTracker(10, 2_000, 1_000, -1_024, 5_000, 9_000);
-        ct.startToken(false, token0, token1, fee, panopticPool, address(0));
+        ct.startToken(false, token0, token1, fee, panopticPool, address(0), address(0), 0);
 
         assertEq(ct.totalSupply(), 10 ** 6);
         assertEq(ct.totalAssets(), 1);
@@ -709,11 +709,11 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0 = new CollateralTrackerHarness();
 
         // initialize the token
-        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)), address(0));
+        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)), address(0), address(0), 0);
 
         // fails if already initialized
         vm.expectRevert(Errors.CollateralTokenAlreadyInitialized.selector);
-        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)), address(0));
+        collateralToken0.startToken(false, token0, token1, fee, PanopticPool(address(0)), address(0), address(0), 0);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1804,7 +1804,9 @@ contract Misctest is Test, PositionUtils {
             address(token1),
             1,
             pp,
-            address(0)
+            address(0),
+            address(0),
+            0
         );
 
         vm.startPrank(Bob);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -336,6 +336,9 @@ contract Misctest is Test, PositionUtils {
                     address(token0),
                     address(token1),
                     500,
+                    address(0),
+                    address(0),
+                    0,
                     uint96(block.timestamp)
                 )
             )
@@ -1800,7 +1803,8 @@ contract Misctest is Test, PositionUtils {
             address(token0),
             address(token1),
             1,
-            pp
+            pp,
+            address(0)
         );
 
         vm.startPrank(Bob);

--- a/test/foundry/core/PanopticFactory.t.sol
+++ b/test/foundry/core/PanopticFactory.t.sol
@@ -255,7 +255,7 @@ contract PanopticFactoryTest is Test {
         {
             // Deploy pool
             // links the Uniswap V3 pool to the Panoptic pool
-            PanopticPool deployedPool = panopticFactory.deployNewPool(token0, token1, fee, salt);
+            PanopticPool deployedPool = panopticFactory.deployNewPool(token0, token1, fee, address(0), address(0), 0, salt);
 
             // see if pool exists at the precomputed address
             uint256 size;
@@ -286,7 +286,7 @@ contract PanopticFactoryTest is Test {
 
         // Deploy invalid pool (uninitalized tokens and fee)
         vm.expectRevert(Errors.UniswapPoolNotInitialized.selector);
-        panopticFactory.deployNewPool(token0, token1, fee, salt);
+        panopticFactory.deployNewPool(token0, token1, fee, address(0), address(0), 0, salt);
     }
 
     // Revert if deploying a Panoptic Pool that has already been initalized
@@ -299,12 +299,12 @@ contract PanopticFactoryTest is Test {
         uint96 salt = uint96(block.timestamp);
 
         // Deploy pool
-        panopticFactory.deployNewPool(token0, token1, fee, salt);
+        panopticFactory.deployNewPool(token0, token1, fee, address(0), address(0), 0, salt);
 
         // Attempt to deploy pool again
         vm.expectRevert(Errors.PoolAlreadyInitialized.selector);
         unchecked {
-            panopticFactory.deployNewPool(token0, token1, fee, salt + 1);
+            panopticFactory.deployNewPool(token0, token1, fee, address(0), address(0), 0, salt);
         }
     }
 
@@ -315,7 +315,7 @@ contract PanopticFactoryTest is Test {
     function test_Success_tokenURI_decodes() public {
         _initalizeWorldState(pools[1]);
         uint96 salt = uint96(block.timestamp);
-        PanopticPool deployedPool = panopticFactory.deployNewPool(token0, token1, fee, salt);
+        PanopticPool deployedPool = panopticFactory.deployNewPool(token0, token1, fee, address(0), address(0), 0, salt);
         uint256 panopticPoolAddress = uint256(uint160(address(deployedPool)));
         bytes memory uri = bytes(panopticFactory.tokenURI(panopticPoolAddress));
         uint256 prefixLength = bytes("data:application/json;base64,").length;
@@ -389,7 +389,7 @@ contract PanopticFactoryTest is Test {
 
     /* Internal functions used in base contract logic replicated for redundancy
        If a change is made to the logic makeup of these functions in the core contracts,
-       Then they will have to be equally changed in the tests 
+       Then they will have to be equally changed in the tests
     */
 
     /// Computes the address of a clone deployed using {Clones-cloneDeterministic}.

--- a/test/foundry/core/PanopticFactory.t.sol
+++ b/test/foundry/core/PanopticFactory.t.sol
@@ -304,7 +304,7 @@ contract PanopticFactoryTest is Test {
         // Attempt to deploy pool again
         vm.expectRevert(Errors.PoolAlreadyInitialized.selector);
         unchecked {
-            panopticFactory.deployNewPool(token0, token1, fee, address(0), address(0), 0, salt);
+            panopticFactory.deployNewPool(token0, token1, fee, address(0), address(0), 0, salt + 1);
         }
     }
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -81,6 +81,21 @@ contract PanopticPoolHarness is PanopticPool {
         return (premiasByLeg, netExchanged);
     }
 
+    // Convenience harness to test exact token amounts coming in and out, to confirm protocol fee amounts
+    function settleMintsHarness(
+        address owner,
+        LeftRightSigned longAmounts,
+        LeftRightSigned shortAmounts,
+        LeftRightSigned totalSwapped
+    ) external returns (
+        uint32 utilizations,
+        LeftRightUnsigned plpCommissions,
+        LeftRightUnsigned protocolCommissions,
+        LeftRightSigned paidAmounts
+    ) {
+        return _settleMints(owner, longAmounts, shortAmounts, totalSwapped);
+    }
+
     constructor(SemiFungiblePositionManager _sfpm) PanopticPool(_sfpm) {}
 }
 
@@ -508,6 +523,53 @@ contract PanopticPoolTest is PositionUtils {
 
         ct0 = pp.collateralToken0();
         ct1 = pp.collateralToken1();
+    }
+
+    // Controller & recipients for protocol fee tests
+    address controllerX = address(0xC0117);
+    address protoA = address(0xA11CE);
+    address protoB = address(0xB0B);
+
+    // Deploy a pool where CollateralTrackers are wired with controller/recipient/fee
+    function _deployPanopticPoolWithFee(address controller, address recipient, uint256 bps) internal {
+        vm.startPrank(Deployer);
+
+        // Reuse the same factory & references configured in setUp/_deployPanopticPool
+        if (address(factory) == address(0)) {
+            factory = new PanopticFactory(
+                sfpm,
+                V3FACTORY,
+                poolReference,
+                collateralReference,
+                new bytes32[](0),
+                new uint256[][](0),
+                new Pointer[][](0)
+            );
+            IERC20Partial(token0).approve(address(factory), type(uint104).max);
+            IERC20Partial(token1).approve(address(factory), type(uint104).max);
+        }
+
+        pp = PanopticPoolHarness(
+            address(factory.deployNewPool(
+                token0, token1, fee, controller, recipient, bps, uint96(block.timestamp + 1)
+            ))
+        );
+
+        ct0 = pp.collateralToken0();
+        ct1 = pp.collateralToken1();
+
+        vm.stopPrank();
+    }
+
+    // Signed packer shorthand
+    function _lrS(int128 r, int128 l) internal pure returns (LeftRightSigned x) {
+        x = LeftRightSigned.wrap(0).toRightSlot(r).toLeftSlot(l);
+    }
+
+    // Unpack the two uint16 utilizations (token0 in low 16, token1 in high 16)
+    function _splitUtils(uint32 u) internal pure returns (uint16 u0, uint16 u1) {
+        u0 = uint16(u & 0xFFFF);
+        u1 = uint16(u >> 16);
     }
 
     function _initAccounts() internal {
@@ -9104,4 +9166,230 @@ contract PanopticPoolTest is PositionUtils {
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
     }
+
+    function test_ProtocolFee_SettersRequireController() public {
+        // Set up world and deploy a fee-enabled pool
+        _cacheWorldState(pools[0]);
+        _deployPanopticPoolWithFee(controllerX, protoA, 123);
+
+        // Non-controller cannot set
+        vm.prank(Alice);
+        vm.expectRevert(Errors.NotFeeSwitchController.selector);
+        ct0.setProtocolFeeRecipient(address(1));
+
+        vm.prank(Bob);
+        vm.expectRevert(Errors.NotFeeSwitchController.selector);
+        ct0.setProtocolFee(999);
+
+        // Controller can set
+        vm.prank(controllerX);
+        ct0.setProtocolFeeRecipient(protoB);
+        vm.prank(controllerX);
+        ct0.setProtocolFee(77);
+
+        // Mirror for ct1 just to be thorough
+        vm.prank(controllerX);
+        ct1.setProtocolFeeRecipient(protoB);
+        vm.prank(controllerX);
+        ct1.setProtocolFee(77);
+    }
+
+    function test_ProtocolFee_ZeroFee_NoShares() public {
+        _cacheWorldState(pools[0]);
+        _deployPanopticPoolWithFee(controllerX, protoA, 0); // 0 bps
+
+        // Long == Short, swapped == 0 -> intrinsic=0, still would charge PLP commission, but protocol=0
+        LeftRightSigned L = _lrS(int128(1e18), int128(1e18));
+        LeftRightSigned S = _lrS(int128(1e18), int128(1e18));
+        LeftRightSigned X = _lrS(int128(0),    int128(0));
+
+        uint256 a0 = ct0.balanceOf(protoA);
+        uint256 a1 = ct1.balanceOf(protoA);
+
+        (uint32 u, LeftRightUnsigned plp, LeftRightUnsigned prot, ) =
+            pp.settleMintsHarness(Alice, L, S, X);
+
+        // Protocol fee is zero on both sides
+        assertEq(prot.rightSlot(), 0, "t0 protocol commission");
+        assertEq(prot.leftSlot(),  0, "t1 protocol commission");
+
+        // No shares minted to recipient
+        assertEq(ct0.balanceOf(protoA), a0, "ct0 shares unchanged");
+        assertEq(ct1.balanceOf(protoA), a1, "ct1 shares unchanged");
+
+        // Utilizations well-formed
+        (uint16 u0, uint16 u1) = _splitUtils(u);
+        assertLe(u0, 10000);
+        assertLe(u1, 10000);
+
+        // PLP commissions can be non-zero; we only assert protocol = 0 here.
+        (plp); // silence warning
+    }
+
+    function test_ProtocolFee_MintsSharesToRecipient_NonZeroFee() public {
+        _cacheWorldState(pools[0]);
+        _deployPanopticPoolWithFee(controllerX, protoA, 123); // 1.23%
+
+        LeftRightSigned L = _lrS(int128(1e18), int128(1e18));
+        LeftRightSigned S = _lrS(int128(1e18), int128(1e18));
+        LeftRightSigned X = _lrS(int128(0),    int128(0));   // no swap to avoid asset underflow
+
+        uint256 a0Before = ct0.balanceOf(protoA);
+        uint256 a1Before = ct1.balanceOf(protoA);
+
+        (uint32 u, LeftRightUnsigned plp, LeftRightUnsigned prot, ) =
+            pp.settleMintsHarness(Alice, L, S, X);
+
+        // Protocol commissions show up
+        uint128 prot0 = prot.rightSlot();
+        uint128 prot1 = prot.leftSlot();
+        assertTrue(prot0 > 0 || prot1 > 0, "some protocol commission expected");
+
+        // Shares minted to recipient must equal convertToShares(protocolCommission)
+        uint256 exp0 = ct0.convertToShares(prot0);
+        uint256 exp1 = ct1.convertToShares(prot1);
+
+        assertEq(ct0.balanceOf(protoA) - a0Before, exp0, "ct0 minted shares == convertToShares(prot0)");
+        assertEq(ct1.balanceOf(protoA) - a1Before, exp1, "ct1 minted shares == convertToShares(prot1)");
+
+        // Utilizations are two uint16s
+        (uint16 u0, uint16 u1) = _splitUtils(u);
+        assertLe(u0, 10000);
+        assertLe(u1, 10000);
+
+        (plp); // not asserting numeric here
+    }
+
+    function test_ProtocolFee_ChangeRecipient_RoutesNewMints() public {
+        _cacheWorldState(pools[0]);
+        _deployPanopticPoolWithFee(controllerX, protoA, 200); // 2.00%
+
+        LeftRightSigned L = _lrS(int128(5e17), int128(5e17));
+        LeftRightSigned S = _lrS(int128(5e17), int128(5e17));
+        LeftRightSigned X = _lrS(int128(0),    int128(0));
+
+        // First settle -> protoA gets shares
+        pp.settleMintsHarness(Alice, L, S, X);
+        uint256 a0 = ct0.balanceOf(protoA);
+        uint256 a1 = ct1.balanceOf(protoA);
+
+        // Switch recipient to protoB
+        vm.prank(controllerX); ct0.setProtocolFeeRecipient(protoB);
+        vm.prank(controllerX); ct1.setProtocolFeeRecipient(protoB);
+
+        // Second settle -> protoB should receive new shares
+        pp.settleMintsHarness(Alice, L, S, X);
+
+        assertEq(ct0.balanceOf(protoA), a0, "A ct0 unchanged after reroute");
+        assertEq(ct1.balanceOf(protoA), a1, "A ct1 unchanged after reroute");
+        assertGt(ct0.balanceOf(protoB), 0,  "B received ct0 shares");
+        assertGt(ct1.balanceOf(protoB), 0,  "B received ct1 shares");
+    }
+
+    function test_ProtocolFee_RoundsUp_MinimalCase() public {
+        _cacheWorldState(pools[0]);
+        _deployPanopticPoolWithFee(controllerX, protoA, 1); // 0.01% (1 bps)
+
+        // long+short = 1 + 1 = 2; ceil(2/10000) = 1 -> expect 1 unit protocol fee on each side
+        LeftRightSigned L = _lrS(int128(1), int128(1));
+        LeftRightSigned S = _lrS(int128(1), int128(1));
+        LeftRightSigned X = _lrS(int128(0), int128(0));
+
+        uint256 a0Before = ct0.balanceOf(protoA);
+        uint256 a1Before = ct1.balanceOf(protoA);
+
+        (, , LeftRightUnsigned prot, ) =
+            pp.settleMintsHarness(Alice, L, S, X);
+
+        assertEq(prot.rightSlot(), 1, "t0 protocol fee rounds up to 1");
+        assertEq(prot.leftSlot(),  1, "t1 protocol fee rounds up to 1");
+
+        // Shares match convertToShares(1)
+        assertEq(ct0.balanceOf(protoA) - a0Before, ct0.convertToShares(1), "ct0 minted shares for 1 unit");
+        assertEq(ct1.balanceOf(protoA) - a1Before, ct1.convertToShares(1), "ct1 minted shares for 1 unit");
+    }
+
+    function test_ProtocolFee_ExactAmount_EqualsNotionalTimesBps() public {
+        _cacheWorldState(pools[0]);
+
+        uint256 bps = 250; // 2.50%
+        _deployPanopticPoolWithFee(controllerX, protoA, bps);
+
+        // Choose clean notionals: token0 side = 4e18, token1 side = 7e18
+        LeftRightSigned L = _lrS(int128(1e18), int128(2e18));
+        LeftRightSigned S = _lrS(int128(3e18), int128(5e18));
+        LeftRightSigned X = _lrS(int128(0),    int128(0)); // no swap
+
+        uint256 before0 = ct0.balanceOf(protoA);
+        uint256 before1 = ct1.balanceOf(protoA);
+
+        (, , LeftRightUnsigned prot, ) = pp.settleMintsHarness(Alice, L, S, X);
+
+        // notional per side = (long + short)
+        uint256 notional0 = uint256(uint128(L.rightSlot() + S.rightSlot())); // token0 side (right)
+        uint256 notional1 = uint256(uint128(L.leftSlot()  + S.leftSlot()));  // token1 side (left)
+
+        // expected = ceil(notional * bps / 10_000)
+        uint256 expected0 = Math.unsafeDivRoundingUp(notional0 * bps, 10_000);
+        uint256 expected1 = Math.unsafeDivRoundingUp(notional1 * bps, 10_000);
+
+        assertEq(prot.rightSlot(), expected0, "protocol fee t0 == ceil(notional0*bps/10k)");
+        assertEq(prot.leftSlot(),  expected1, "protocol fee t1 == ceil(notional1*bps/10k)");
+
+        // Shares minted to the recipient == convertToShares(protocolCommission)
+        assertEq(
+            ct0.balanceOf(protoA) - before0,
+            ct0.convertToShares(uint128(expected0)),
+            "ct0 recipient shares == convertToShares(protocol fee)"
+        );
+        assertEq(
+            ct1.balanceOf(protoA) - before1,
+            ct1.convertToShares(uint128(expected1)),
+            "ct1 recipient shares == convertToShares(protocol fee)"
+        );
+    }
+
+    function test_ProtocolFee_FullMintFlow_CreditsRecipientNonZero() public {
+        // World + fee-enabled pool
+        _cacheWorldState(pools[0]);
+        uint256 bps = 150; // 1.50%
+        _deployPanopticPoolWithFee(controllerX, protoA, bps);
+        _initAccounts(); // approvals + deposits against current ct0/ct1/pp
+
+        int24 width = tickSpacing * 4;
+        populatePositionData(width, currentTick, 1e18);
+
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            0,
+            0,
+            currentTick,
+            width
+        );
+        TokenId[] memory posList = new TokenId[](1);
+        posList[0] = tokenId;
+
+        uint256 before0 = ct0.balanceOf(protoA);
+        uint256 before1 = ct1.balanceOf(protoA);
+
+        // effectiveLiquidityLimitX32 can usually be max; premiaAsCollateral=false is fine
+        mintOptions(
+            pp,
+            posList,
+            positionSize,
+            type(uint64).max,
+            tickLower,
+            tickUpper,
+            false
+        );
+
+        // Recipient should have received *some* shares on at least one side for a nonzero bps
+        uint256 delta0 = ct0.balanceOf(protoA) - before0;
+        uint256 delta1 = ct1.balanceOf(protoA) - before1;
+        assertTrue(delta0 > 0 || delta1 > 0, "protocol shares credited to recipient");
+    }
+
 }

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -9171,32 +9171,31 @@ contract PanopticPoolTest is PositionUtils {
         // Set up world and deploy a fee-enabled pool
         _cacheWorldState(pools[0]);
         _deployPanopticPoolWithFee(controllerX, protoA, 123);
+        _initAccounts();
 
         // Non-controller cannot set
-        vm.prank(Alice);
+        vm.startPrank(Alice);
         vm.expectRevert(Errors.NotFeeSwitchController.selector);
         ct0.setProtocolFeeRecipient(address(1));
 
-        vm.prank(Bob);
+        vm.startPrank(Bob);
         vm.expectRevert(Errors.NotFeeSwitchController.selector);
         ct0.setProtocolFee(999);
 
         // Controller can set
-        vm.prank(controllerX);
+        vm.startPrank(controllerX);
         ct0.setProtocolFeeRecipient(protoB);
-        vm.prank(controllerX);
         ct0.setProtocolFee(77);
 
         // Mirror for ct1 just to be thorough
-        vm.prank(controllerX);
         ct1.setProtocolFeeRecipient(protoB);
-        vm.prank(controllerX);
         ct1.setProtocolFee(77);
     }
 
     function test_ProtocolFee_ZeroFee_NoShares() public {
         _cacheWorldState(pools[0]);
         _deployPanopticPoolWithFee(controllerX, protoA, 0); // 0 bps
+        _initAccounts();
 
         // Long == Short, swapped == 0 -> intrinsic=0, still would charge PLP commission, but protocol=0
         LeftRightSigned L = _lrS(int128(1e18), int128(1e18));
@@ -9226,43 +9225,54 @@ contract PanopticPoolTest is PositionUtils {
         (plp); // silence warning
     }
 
-    function test_ProtocolFee_MintsSharesToRecipient_NonZeroFee() public {
+    function test_ProtocolFee_MintsSharesToRecipient_InExpectedAmount() public {
         _cacheWorldState(pools[0]);
-        _deployPanopticPoolWithFee(controllerX, protoA, 123); // 1.23%
+        uint256 bps = 250; // 2.5%
+        _deployPanopticPoolWithFee(controllerX, protoA, bps);
+        _initAccounts();
 
         LeftRightSigned L = _lrS(int128(1e18), int128(1e18));
         LeftRightSigned S = _lrS(int128(1e18), int128(1e18));
         LeftRightSigned X = _lrS(int128(0),    int128(0));   // no swap to avoid asset underflow
 
-        uint256 a0Before = ct0.balanceOf(protoA);
-        uint256 a1Before = ct1.balanceOf(protoA);
+        (
+            uint256 feeRecipientCt0BalanceBefore,
+            uint256 feeRecipientCt1BalanceBefore,
+            uint256 expectedProtocolFee0,
+            uint256 expectedProtocolFee1,
+            uint256 expectedShares0,
+            uint256 expectedShares1
+        ) = _getExpectedProtocolFee(
+            ct0,
+            ct1,
+            uint256(uint128(L.rightSlot() + S.rightSlot())),
+            uint256(uint128(L.leftSlot()  + S.leftSlot())),
+            bps
+        );
 
         (uint32 u, LeftRightUnsigned plp, LeftRightUnsigned prot, ) =
             pp.settleMintsHarness(Alice, L, S, X);
 
         // Protocol commissions show up
-        uint128 prot0 = prot.rightSlot();
-        uint128 prot1 = prot.leftSlot();
-        assertTrue(prot0 > 0 || prot1 > 0, "some protocol commission expected");
+        uint128 actualProtocolFee0 = prot.rightSlot();
+        uint128 actualProtocolFee1 = prot.leftSlot();
+        assertTrue(actualProtocolFee0 > 0 || actualProtocolFee1 > 0, "some protocol commission expected");
+        assertTrue(actualProtocolFee0 == expectedProtocolFee0 && actualProtocolFee1 == expectedProtocolFee1, "protocol commissions should match");
 
-        // Shares minted to recipient must equal convertToShares(protocolCommission)
-        uint256 exp0 = ct0.convertToShares(prot0);
-        uint256 exp1 = ct1.convertToShares(prot1);
-
-        assertEq(ct0.balanceOf(protoA) - a0Before, exp0, "ct0 minted shares == convertToShares(prot0)");
-        assertEq(ct1.balanceOf(protoA) - a1Before, exp1, "ct1 minted shares == convertToShares(prot1)");
+        // Allow up to 3 CT shares of drift due to rounding decisions
+        assertLt(expectedShares0 - ct0.balanceOf(protoA) - feeRecipientCt0BalanceBefore, 3, "ct0 minted shares ~= convertToShares(prot0)");
+        assertLt(expectedShares1 - ct1.balanceOf(protoA) - feeRecipientCt1BalanceBefore, 3, "ct1 minted shares ~= convertToShares(prot1)");
 
         // Utilizations are two uint16s
         (uint16 u0, uint16 u1) = _splitUtils(u);
         assertLe(u0, 10000);
         assertLe(u1, 10000);
-
-        (plp); // not asserting numeric here
     }
 
     function test_ProtocolFee_ChangeRecipient_RoutesNewMints() public {
         _cacheWorldState(pools[0]);
         _deployPanopticPoolWithFee(controllerX, protoA, 200); // 2.00%
+        _initAccounts();
 
         LeftRightSigned L = _lrS(int128(5e17), int128(5e17));
         LeftRightSigned S = _lrS(int128(5e17), int128(5e17));
@@ -9274,8 +9284,9 @@ contract PanopticPoolTest is PositionUtils {
         uint256 a1 = ct1.balanceOf(protoA);
 
         // Switch recipient to protoB
-        vm.prank(controllerX); ct0.setProtocolFeeRecipient(protoB);
-        vm.prank(controllerX); ct1.setProtocolFeeRecipient(protoB);
+        vm.startPrank(controllerX);
+        ct0.setProtocolFeeRecipient(protoB);
+        ct1.setProtocolFeeRecipient(protoB);
 
         // Second settle -> protoB should receive new shares
         pp.settleMintsHarness(Alice, L, S, X);
@@ -9289,6 +9300,7 @@ contract PanopticPoolTest is PositionUtils {
     function test_ProtocolFee_RoundsUp_MinimalCase() public {
         _cacheWorldState(pools[0]);
         _deployPanopticPoolWithFee(controllerX, protoA, 1); // 0.01% (1 bps)
+        _initAccounts();
 
         // long+short = 1 + 1 = 2; ceil(2/10000) = 1 -> expect 1 unit protocol fee on each side
         LeftRightSigned L = _lrS(int128(1), int128(1));
@@ -9309,55 +9321,48 @@ contract PanopticPoolTest is PositionUtils {
         assertEq(ct1.balanceOf(protoA) - a1Before, ct1.convertToShares(1), "ct1 minted shares for 1 unit");
     }
 
-    function test_ProtocolFee_ExactAmount_EqualsNotionalTimesBps() public {
-        _cacheWorldState(pools[0]);
+    function _getExpectedProtocolFee(
+        CollateralTracker ct0,
+        CollateralTracker ct1,
+        uint256 notional0,
+        uint256 notional1,
+        uint256 bps
+    ) internal view returns (
+        uint256 feeRecipientCt0BalanceBefore,
+        uint256 feeRecipientCt1BalanceBefore,
+        uint256 expectedProtocolFee0,
+        uint256 expectedProtocolFee1,
+        uint256 expectedShares0,
+        uint256 expectedShares1
+    ) {
+        feeRecipientCt0BalanceBefore = ct0.balanceOf(protoA);
+        feeRecipientCt1BalanceBefore = ct1.balanceOf(protoA);
 
-        uint256 bps = 250; // 2.50%
-        _deployPanopticPoolWithFee(controllerX, protoA, bps);
+        // compute notional and protocol-asset expected amounts
+        expectedProtocolFee0 = FullMath.mulDiv(notional0, bps, 10_000);
+        expectedProtocolFee1 = FullMath.mulDiv(notional1, bps, 10_000);
 
-        // Choose clean notionals: token0 side = 4e18, token1 side = 7e18
-        LeftRightSigned L = _lrS(int128(1e18), int128(2e18));
-        LeftRightSigned S = _lrS(int128(3e18), int128(5e18));
-        LeftRightSigned X = _lrS(int128(0),    int128(0)); // no swap
-
-        uint256 before0 = ct0.balanceOf(protoA);
-        uint256 before1 = ct1.balanceOf(protoA);
-
-        (, , LeftRightUnsigned prot, ) = pp.settleMintsHarness(Alice, L, S, X);
-
-        // notional per side = (long + short)
-        uint256 notional0 = uint256(uint128(L.rightSlot() + S.rightSlot())); // token0 side (right)
-        uint256 notional1 = uint256(uint128(L.leftSlot()  + S.leftSlot()));  // token1 side (left)
-
-        // expected = ceil(notional * bps / 10_000)
-        uint256 expected0 = Math.unsafeDivRoundingUp(notional0 * bps, 10_000);
-        uint256 expected1 = Math.unsafeDivRoundingUp(notional1 * bps, 10_000);
-
-        assertEq(prot.rightSlot(), expected0, "protocol fee t0 == ceil(notional0*bps/10k)");
-        assertEq(prot.leftSlot(),  expected1, "protocol fee t1 == ceil(notional1*bps/10k)");
-
-        // Shares minted to the recipient == convertToShares(protocolCommission)
-        assertEq(
-            ct0.balanceOf(protoA) - before0,
-            ct0.convertToShares(uint128(expected0)),
-            "ct0 recipient shares == convertToShares(protocol fee)"
-        );
-        assertEq(
-            ct1.balanceOf(protoA) - before1,
-            ct1.convertToShares(uint128(expected1)),
-            "ct1 recipient shares == convertToShares(protocol fee)"
-        );
+        // expected shares using pre-state
+        expectedShares0 = (ct0.totalSupply() == 0 || ct0.totalAssets() == 0) ? expectedProtocolFee0 : ct0.convertToShares(expectedProtocolFee0);
+        expectedShares1 = (ct1.totalSupply() == 0 || ct1.totalAssets() == 0) ? expectedProtocolFee1 : ct1.convertToShares(expectedProtocolFee1);
     }
 
-    function test_ProtocolFee_FullMintFlow_CreditsRecipientNonZero() public {
+    function test_ProtocolFee_FullMintFlow_CreditsRecipientNonZero(uint256 widthSeed, int256 strikeSeed) public {
         // World + fee-enabled pool
         _cacheWorldState(pools[0]);
         uint256 bps = 150; // 1.50%
         _deployPanopticPoolWithFee(controllerX, protoA, bps);
         _initAccounts(); // approvals + deposits against current ct0/ct1/pp
 
-        int24 width = tickSpacing * 4;
-        populatePositionData(width, currentTick, 1e18);
+        (int24 width, int24 strike) = PositionUtils.getOTMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            0
+        );
+
+        populatePositionData(width, strike, 1e18);
 
         TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
             0,
@@ -9366,7 +9371,7 @@ contract PanopticPoolTest is PositionUtils {
             0,
             0,
             0,
-            currentTick,
+            strike,
             width
         );
         TokenId[] memory posList = new TokenId[](1);
@@ -9380,9 +9385,9 @@ contract PanopticPoolTest is PositionUtils {
             pp,
             posList,
             positionSize,
-            type(uint64).max,
-            tickLower,
-            tickUpper,
+            0,
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK,
             false
         );
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -503,7 +503,7 @@ contract PanopticPoolTest is PositionUtils {
         IERC20Partial(token1).approve(address(factory), type(uint104).max);
 
         pp = PanopticPoolHarness(
-            address(factory.deployNewPool(token0, token1, fee, uint96(block.timestamp)))
+            address(factory.deployNewPool(token0, token1, fee, address(0), address(0), 0, uint96(block.timestamp)))
         );
 
         ct0 = pp.collateralToken0();


### PR DESCRIPTION
- Charge it in each CT's `takeCommissionAddData`
- Allow a designated `FEE_SWITCH_CONTROLLER` account to update the fee and the recipient
- Set that FEE_SWITCH_CONTROLLER, as well as an initial fee and recipient, in `deployNewPool`
- Emit the commission charged in `OptionMinted`

Now off of the `dev` branch, where i get the unifying of `exercise` and `takeCommissionAddData`'s duplicated logic for free. Still need to fight stack too deep, however.
