### PR TITLE
WIP: feat: capped premia

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1223,7 +1223,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         }
     }
 
-    /// @notice Refunds tokens to `refunder` from `refundee`.
+    /// @notice Refunds tokens from `refunder` to `refundee`, or vice versa.
     /// @dev Assumes that the refunder has enough money to pay for the refund.
     /// @param refunder The account refunding tokens to `refundee`
     /// @param refundee The account being refunded to

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1083,7 +1083,7 @@ contract PanopticPool is Multicall {
             // It is kind of funky that if liquidatable account owned a position was in the grace period window, third parties have the option
             // of claiming that cap-accumulated bonus there first, then liquidating the account, and getting a different sum bonus
             // than if they had just liquidated
-            (shortPremium, longPremium, , positionBalanceArray) = _calculateAccumulatedPremia(
+            (shortPremium, longPremium, , positionBalanceArray,) = _calculateAccumulatedPremia(
                 liquidatee,
                 positionIdList,
                 COMPUTE_PREMIA_AS_COLLATERAL,
@@ -1880,13 +1880,14 @@ contract PanopticPool is Multicall {
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
         TokenId[] single = new TokenId[](1);
         single[0] = tokenId;
-        (, LeftRightUnsigned longPremium, uint256[2][] positionBalance) = _calculateAccumulatedPremia(owner, single, false, true, currentTick);
+        (, LeftRightUnsigned longPremium, , ,) = _calculateAccumulatedPremia(owner, single, false, true, currentTick);
         uint128 token0Cap = s_premiaCaps[owner][tokenId].rightSlot();
         uint128 token1Cap = s_premiaCaps[owner][tokenId].leftSlot();
-        uint128 owedPremia0 = owedPremia.rightSlot() * positionBalance[0][1]
-        uint128 owedPremia1 = owedPremia.rightSlot() * positionBalance[0][1]
+        uint128 accumulatedPremium0 = longPremium.rightSlot();
+        uint128 accumulatedPremium1 = longPremium.leftSlot();
 
-        if (owedPremia0 > token0Cap || owedPremia1 > token1Cap) {
+        // Caps start getting enforced within 1% (TODO: Can change this later)
+        if (accumulatedPremium0 > (token0Cap * 99 / 100 ) || accumulatedPremium1 > (token1Cap * 99 / 100)) {
             // Close the position either way:
             (LeftRightSigned paidAmounts, LeftRightSigned[4] premiaByLeg) = _burnOptions(
                 tokenId,
@@ -1897,86 +1898,110 @@ contract PanopticPool is Multicall {
                 COMMIT_LONG_SETTLED
             );
 
-            uint128 token0Overage = owedPremia0 - token0Cap;
-            uint128 token1Overage = owedPremia1 - token1Cap;
+            // If we actually exceeded the cap (e.g., {accumulated > cap > gracePeriodStart}),
+            // we want the buyer to shortchange the sellers and pay exactly {cap}
+            // However, _burnOptions paid {accumulated} to the sellers already - Therefore, we have to fix this:
+            // - Move {cap-gracePeriodStart} from the sellers to the caller, as a reward
+            // - Move {accumulated-gracePeriodStart} from the sellers to the buyer
+            // - Let the sellers keep {gracePeriodStart}
 
-            // this is equivalent to: if overage >= 1% of cap, pay out a reward
-            // overage / token0Cap >= 0.01 <=> overage >= token0Cap * 0.01 <=> overage / 0.01 >= token0Cap <=> overage * 100 >= token0Cap
-            bool rewardEligible0 = token0Overage * 100 >= token0Cap;
-            bool rewardEligible1 = token1Overage * 100 >= token1Cap;
+            // If we are in the grace period window, the buyer is going to pay exactly {cap}
+            // _burnOptions moved `accumulated` to the sellers already, so now we are going to:
+            // - Move {cap-accumulated} from buyer to caller
+            // - Let sellers keep {accumulated}
 
-            // Get seller premia:
-            uint256 totalAvail0;
-            uint256 totalAvail1;
-            {
-                uint256 n = tokenId.countLegs();
-                for (uint256 i = 0; i < n; ) {
-                    if (tokenId.isLong(i) == 0) {
-                        LeftRightSigned avail = premiaByLeg[i];
-                        if (avail.rightSlot() > 0) totalAvail0 += uint128(uint256(int256(avail.rightSlot())));
-                        if (avail.leftSlot()  > 0) totalAvail1 += uint128(uint256(int256(avail.leftSlot())));
-                    }
-                    unchecked { ++i; }
-                }
+            uint128 reward0;
+            uint128 reward1;
+            int128 buyerRefund0;
+            int128 buyerRefund1;
+
+            if (accumulatedPremium0 > token0Cap) {
+                // Exceeded cap: buyer pays cap, not accumulated
+                reward0 = token0Cap / 100;  // Caller gets 1% of cap
+                buyerRefund0 = int128(accumulatedPremium0 - token0Cap);  // Buyer gets refund
+            } else {
+                // Grace period: buyer pays cap exactly
+                reward0 = token0Cap - accumulatedPremium0;  // Caller gets difference
+                buyerRefund0 = 0;  // No refund needed
             }
 
-            uint128 reward0 = (rewardEligible0 && totalAvail0 > 0)
-                ? uint128((totalAvail0 * PREMIA_CAP_REWARD_BPS) / 10_000)
-                : 0;
-
-            uint128 reward1 = (rewardEligible1 && totalAvail1 > 0)
-                ? uint128((totalAvail1 * PREMIA_CAP_REWARD_BPS) / 10_000)
-                : 0;
-
-            if (reward0 > 0 || reward1 > 0) {
-                // 6) Delegate so we can pay the caller via CT.refund(...) within this scope
-                s_collateralToken0.delegate(owner);
-                s_collateralToken1.delegate(owner);
-                uint256 remaining0 = reward0;
-                uint256 remaining1 = reward1;
-
-                for (uint256 i = 0; i < tokenId.countLegs(); ) {
-                    if (tokenId.isLong(i) == 0) {
-                        // Identify the chunk
-                        bytes32 chunkKey = keccak256(
-                            abi.encodePacked(tokenId.strike(i), tokenId.width(i), tokenId.tokenType(i))
-                        );
-                        // Per-leg available amounts
-                        LeftRightSigned avail = premiaByLeg[i];
-                        uint256 avail0 = (avail.rightSlot() > 0) ? uint128(uint256(int256(avail.rightSlot()))) : 0;
-                        uint256 avail1 = (avail.leftSlot()  > 0) ? uint128(uint256(int256(avail.leftSlot())))  : 0;
-
-                        // Pro-rata slice for this chunk
-                        uint256 take0 = (totalAvail0 == 0 || remaining0 == 0) ? 0 : (avail0 * reward0) / totalAvail0;
-                        uint256 take1 = (totalAvail1 == 0 || remaining1 == 0) ? 0 : (avail1 * reward1) / totalAvail1;
-
-                        // Last-chunk rounding fix
-                        if (i == n - 1) {
-                            if (take0 < remaining0) take0 = remaining0;
-                            if (take1 < remaining1) take1 = remaining1;
-                        }
-
-                        // Reduce sellers' settled pool for this chunk
-                        LeftRightUnsigned st = s_settledTokens[chunkKey];
-                        s_settledTokens[chunkKey] = LeftRightUnsigned
-                            .wrap(uint128(st.rightSlot() > take0 ? st.rightSlot() - uint128(take0) : 0))
-                            .toLeftSlot(uint128(st.leftSlot()  > take1 ? st.leftSlot()  - uint128(take1) : 0));
-
-                        // Track what's left to allocate
-                        if (take0 <= remaining0) remaining0 -= take0; else remaining0 = 0;
-                        if (take1 <= remaining1) remaining1 -= take1; else remaining1 = 0;
-                    }
-                    unchecked { ++i; }
-                }
-
-                // Pay the caller now (tokens come from the same pool that the buyer just funded via premia)
-                if (reward0 > 0) s_collateralToken0.refund(owner, msg.sender, int128(reward0));
-                if (reward1 > 0) s_collateralToken1.refund(owner, msg.sender, int128(reward1));
-
-                // 11) Revoke delegation
-                s_collateralToken0.revoke(owner);
-                s_collateralToken1.revoke(owner);
+            if (accumulatedPremium1 > token1Cap) {
+                reward1 = token1Cap / 100;
+                buyerRefund1 = int128(accumulatedPremium1 - token1Cap);
+            } else {
+                reward1 = token1Cap - accumulatedPremium1;
+                buyerRefund1 = 0;
             }
+
+            if (buyerRefund0 > 0) {
+                // We have actually exceeded the cap:
+                // refund from sellers to buyer for the overage, such that they have only paid {cap}
+                // AND refund from sellers to caller for the reward
+                s_collateralToken0.refund(
+                    address(this),  // from protocol (where settled tokens sit)
+                    owner,          // to buyer
+                    buyerRefund0    // positive means transfer to buyer
+                );
+                s_collateralToken0.refund(
+                    address(this),
+                    msg.sender,
+                    reward0
+                );
+                // Reduce settled tokens since we're taking from sellers
+                // TODO: Think i need to iterate through legs here actually
+                bytes32 chunkKey = keccak256(
+                    abi.encodePacked(tokenId.strike(0), tokenId.width(0), tokenId.tokenType(0))
+                );
+                s_settledTokens[chunkKey] = s_settledTokens[chunkKey].sub(
+                    LeftRightUnsigned.wrap(0)
+                        .toRightSlot(uint128(buyerRefund0 + reward0))
+                );
+            } else if (reward0 > 0) {
+                // We're in the grace period -
+                // buyer has already paid {accumulated} to sellers in _burnOptions above
+                // So just transfer reward from buyer to caller
+                s_collateralToken0.refund(
+                    owner,      // from buyer
+                    msg.sender, // to caller
+                    int128(reward0)
+                );
+            }
+
+            if (buyerRefund1 > 0) {
+                // We have actually exceeded the cap:
+                // refund from sellers to buyer for the overage, such that they have only paid {cap}
+                // AND refund from sellers to caller for the reward
+                s_collateralToken1.refund(
+                    address(this),
+                    owner,
+                    buyerRefund1
+                );
+                s_collateralToken1.refund(
+                    address(this),
+                    owner,
+                    reward1
+                );
+                // Reduce settled tokens since we're taking from sellers
+                // TODO: Iterate through legs here
+                bytes32 chunkKey = keccak256(
+                    abi.encodePacked(tokenId.strike(0), tokenId.width(0), tokenId.tokenType(0))
+                );
+                s_settledTokens[chunkKey] = s_settledTokens[chunkKey].sub(
+                    LeftRightUnsigned.wrap(0)
+                        .toLeftSlot(uint128(buyerRefund1 + reward1))
+                );
+            } else if (reward1 > 0) {
+                // We're in the grace period -
+                // buyer has already paid {accumulated} to sellers in _burnOptions above
+                // So just transfer reward from buyer to caller
+                s_collateralToken1.refund(
+                    owner,
+                    msg.sender,
+                    int128(reward1)
+                );
+            }
+
+            // TODO: What if the exercise that occurred in _burnOptions altered the token types the user has?
 
             // Clean up storage
             delete s_premiaCaps[owner][tokenId];

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -241,7 +241,7 @@ contract PanopticPool is Multicall {
     mapping(address account => uint256 positionsHash) internal s_positionsHash;
 
     // Store caps as LeftRightUnsigned (token0 cap in right slot, token1 cap in left slot)
-    // TODO: Can we store this in the TokenId?
+    // TODO: We'll eventually store this in the positionBalance data, where tickData currently goes
     mapping(address => mapping(TokenId => LeftRightUnsigned)) s_premiaCaps;
     uint256 constant PREMIA_OVERAGE_REWARD_BPS = 100; // 1% reward threshold
 
@@ -405,6 +405,7 @@ contract PanopticPool is Multicall {
     /// @param atTick The current tick of the Uniswap pool
     /// @return shortPremium The total amount of premium owed (which may `includePendingPremium`) to the short legs in `positionIdList` (token0: right slot, token1: left slot)
     /// @return longPremium The total amount of premium owed by the long legs in `positionIdList` (token0: right slot, token1: left slot)
+    /// @return cappedPremiumCommitment The total amount of premium committed to capped-premia positions (token0: right slot, token1: left slot)
     /// @return balances A list of balances and pool utilization for each position, of the form `[[tokenId0, balances0], [tokenId1, balances1], ...]`
     function _calculateAccumulatedPremia(
         address user,
@@ -418,11 +419,14 @@ contract PanopticPool is Multicall {
         returns (
             LeftRightUnsigned shortPremium,
             LeftRightUnsigned longPremium,
-            uint256[2][] memory balances
+            LeftRightUnsigned cappedPremiumCommitment,
+            uint256[2][] memory balances,
+            uint256[2][] memory uncappedBalances
         )
     {
         uint256 pLength = positionIdList.length;
         balances = new uint256[2][](pLength);
+        uncappedBalances = new uint256[2][](pLength);
 
         address c_user = user;
         // loop through each option position/tokenId
@@ -486,6 +490,16 @@ contract PanopticPool is Multicall {
                             )
                         )
                     );
+                    if (s_premiaCaps[user][tokenId] != 0) {
+                        cappedPremiumCommitment.toRightSlot(s_premiaCaps[user][tokenId].rightSlot()).toLeftSlot(s_premiaCaps[user][tokenId].leftSlot())
+                        // Do NOT put this tokenId in uncappedBalances.
+                        // This means that uncappedBalances will have zero-values in its entries
+                    } else {
+                        uncappedBalances[k] = [
+                            TokenId.unwrap(tokenId),
+                            PositionBalance.unwrap(s_positionBalance[c_user][tokenId])
+                        ];
+                    }
                 }
                 unchecked {
                     ++leg;
@@ -525,7 +539,7 @@ contract PanopticPool is Multicall {
     /// @param positionIdList The list of tokenIds for the option positions to be minted or burnt
     /// @param finalPositionIdList The final positionIdList after all the tokens have been minted/burnt
     /// @param positionSizes The list of positionSize for the position to be minted (0 for burns)
-    /// @param effectiveLiquidityLimitsX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
+    /// @param premiaCaps Maximum amount of long premia to pay, in each token, over the lifetime of the position
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param tickLimits The lower and lower bounds of an acceptable open interval for the ending price
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
@@ -533,7 +547,7 @@ contract PanopticPool is Multicall {
         TokenId[] calldata positionIdList,
         TokenId[] calldata finalPositionIdList,
         uint128[] calldata positionSizes,
-        uint64[] calldata effectiveLiquidityLimitsX32,
+        LeftRightUnsigned[] calldata premiaCaps,
         int24[2][] calldata tickLimits,
         bool usePremiaAsCollateral
     ) external {
@@ -560,7 +574,7 @@ contract PanopticPool is Multicall {
                 _mintOptions(
                     tokenId,
                     positionSizes[i],
-                    effectiveLiquidityLimitsX32[i],
+                    premiaCaps[i],
                     msg.sender,
                     tickLimitLow,
                     tickLimitHigh
@@ -610,7 +624,11 @@ contract PanopticPool is Multicall {
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
         // Store the premia caps & checkpointed accumulator values for this position
+        // TODO: This will move to a field of positionBalance
         s_premiaCaps[owner][tokenId] = premiaCaps;
+
+        // NOTE: The _checkSolvency at the end of dispatch() will enforce that the user pre-deposited enough assets
+        // to cover their premiaCap
 
         _updateSettlementPostMint(
             tokenId,
@@ -1061,7 +1079,11 @@ contract PanopticPool is Multicall {
         {
             uint256[2][] memory positionBalanceArray = new uint256[2][](positionIdList.length);
             LeftRightUnsigned longPremium;
-            (shortPremium, longPremium, positionBalanceArray) = _calculateAccumulatedPremia(
+            // TODO: Should we do anything with the cappedPremiumCommitment here? Or is it fine to ignore?
+            // It is kind of funky that if liquidatable account owned a position was in the grace period window, third parties have the option
+            // of claiming that cap-accumulated bonus there first, then liquidating the account, and getting a different sum bonus
+            // than if they had just liquidated
+            (shortPremium, longPremium, , positionBalanceArray) = _calculateAccumulatedPremia(
                 liquidatee,
                 positionIdList,
                 COMPUTE_PREMIA_AS_COLLATERAL,
@@ -1342,7 +1364,9 @@ contract PanopticPool is Multicall {
         (
             LeftRightUnsigned shortPremium,
             LeftRightUnsigned longPremium,
-            uint256[2][] memory positionBalanceArray
+            LeftRightUnsigned cappedPremiumCommitment,
+            uint256[2][] memory positionBalanceArray,
+            uint256[2][] memory uncappedPositionBalanceArray,
         ) = _calculateAccumulatedPremia(
                 account,
                 positionIdList,
@@ -1361,6 +1385,7 @@ contract PanopticPool is Multicall {
                         account,
                         atTicks[i],
                         positionBalanceArray,
+                        uncappedPositionBalanceArray,
                         shortPremium,
                         longPremium,
                         buffer
@@ -1386,10 +1411,13 @@ contract PanopticPool is Multicall {
         address account,
         int24 atTick,
         uint256[2][] memory positionBalanceArray,
+        uint256[2][] memory uncappedPositionBalanceArray,
         LeftRightUnsigned shortPremium,
         LeftRightUnsigned longPremium,
+        LeftRightUnsigned cappedPremiumCommitment,
         uint256 buffer
-    ) internal view returns (bool) {
+    ) internal view returns (bool isSolvent) {
+        // 1. Must be solvent the regular way
         (uint256 balanceCross, uint256 thresholdCross) = PanopticMath.getCrossBalances(
             s_collateralToken0.getAccountMarginDetails(
                 account,
@@ -1409,7 +1437,45 @@ contract PanopticPool is Multicall {
         );
 
         // compare balance and required tokens, can use unsafe div because denominator is always nonzero
-        return balanceCross >= Math.mulDivRoundingUp(thresholdCross, buffer, 10_000);
+        isSolvent = balanceCross >= Math.mulDivRoundingUp(thresholdCross, buffer, 10_000);
+
+        // 2. Must be solvent for the uncapped positions, even when removing capital that is committed to capped premia positions
+        uint256 crossCappedPremiumCommitment =
+            uint256(cappedPremiumCommitment.rightSlot()) +
+            PanopticMath.convert1to0(uint256(cappedPremiumCommitment.leftSlot()));
+
+        (balanceCross, thresholdCross) = PanopticMath.getCrossBalances(
+            s_collateralToken0.getAccountMarginDetails(
+                account,
+                atTick,
+                // NOTE: This has zero values in its entries.
+                // My hope is that this means that thresholdCross excludes those positions,
+                // and *not* that we get a revert.
+                // If that's not the case, we'll have to do nasty array handling to make this a smaller-length subset array of positionBalanceArray
+                uncappedPositionBalanceArray,
+                shortPremium.rightSlot(),
+                // TODO: This includes long premium from capped positions, which theoretically makes this check stricter than it needs to be -
+                // we're about to also check that the users have enough collateral to pay off capped premium even when removing the collateral
+                // backing uncappedPositionBalanceArray. We could add another returnval to _calculateAccumulatedPremia, longPremiumForUncappedPositions,
+                // but that feels like overkill - I don't think this increased strictness is really too big of a problem.
+                longPremium.rightSlot()
+            ),
+            s_collateralToken1.getAccountMarginDetails(
+                account,
+                atTick,
+                uncappedPositionBalanceArray,
+                shortPremium.leftSlot(),
+                longPremium.leftSlot()
+            ),
+            Math.getSqrtRatioAtTick(atTick)
+        );
+        uint256 balanceCrossExcludingCappedPremiumCommitments -= crossCappedPremiumCommitment;
+
+        // compare balance and required tokens, can use unsafe div because denominator is always nonzero
+        isSolvent = isSolvent && balanceCrossExcludingCappedPremiumCommitments >= Math.mulDivRoundingUp(thresholdCross, buffer, 10_000);
+
+        // 3. And, must have premia available to pay off capped premium commitments, even when removing the collateral requirement for uncapped positions.
+        isSolvent = isSolvent && balanceCross - thresholdCross >= crossCappedPremiumCommitment;
     }
 
     /// @notice Checks whether the current tick has deviated by `> MAX_TICKS_DELTA` from the slow oracle median tick.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -478,8 +478,8 @@ contract PanopticPool is Multicall {
                             )
                         )
                     );
-                    if (s_premiaCaps[user][tokenId] != 0) {
-                        cappedPremiumCommitment.toRightSlot(s_premiaCaps[user][tokenId].rightSlot()).toLeftSlot(s_premiaCaps[user][tokenId].leftSlot())
+                    if ((s_premiaCaps[user][tokenId].rightSlot() != 0) || (s_premiaCaps[user][tokenId].leftSlot() != 0)) {
+                        cappedPremiumCommitment.toRightSlot(s_premiaCaps[user][tokenId].rightSlot()).toLeftSlot(s_premiaCaps[user][tokenId].leftSlot());
                         // Do NOT put this tokenId in uncappedBalances.
                         // This means that uncappedBalances will have zero-values in its entries
                     } else {
@@ -1383,6 +1383,7 @@ contract PanopticPool is Multicall {
                         uncappedPositionBalanceArray,
                         shortPremium,
                         longPremium,
+                        cappedPremiumCommitment,
                         buffer
                     )
                 ) ++solvent;
@@ -1437,7 +1438,7 @@ contract PanopticPool is Multicall {
         // 2. Must be solvent for the uncapped positions, even when removing capital that is committed to capped premia positions
         uint256 crossCappedPremiumCommitment =
             uint256(cappedPremiumCommitment.rightSlot()) +
-            PanopticMath.convert1to0(uint256(cappedPremiumCommitment.leftSlot()));
+            PanopticMath.convert1to0(uint256(cappedPremiumCommitment.leftSlot()), Math.getSqrtRatioAtTick(atTick));
 
         (balanceCross, thresholdCross) = PanopticMath.getCrossBalances(
             s_collateralToken0.getAccountMarginDetails(
@@ -1464,7 +1465,7 @@ contract PanopticPool is Multicall {
             ),
             Math.getSqrtRatioAtTick(atTick)
         );
-        uint256 balanceCrossExcludingCappedPremiumCommitments -= crossCappedPremiumCommitment;
+        uint256 balanceCrossExcludingCappedPremiumCommitments = balanceCross - crossCappedPremiumCommitment;
 
         // compare balance and required tokens, can use unsafe div because denominator is always nonzero
         isSolvent = isSolvent && balanceCrossExcludingCappedPremiumCommitments >= Math.mulDivRoundingUp(thresholdCross, buffer, 10_000);
@@ -1874,7 +1875,7 @@ contract PanopticPool is Multicall {
 
         // Calculate current accumulated premia for long legs
         (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
-        TokenId[] single = new TokenId[](1);
+        TokenId[] memory single = new TokenId[](1);
         single[0] = tokenId;
         (, LeftRightUnsigned longPremium, , ,) = _calculateAccumulatedPremia(owner, single, false, true, currentTick);
         uint128 token0Cap = s_premiaCaps[owner][tokenId].rightSlot();
@@ -1885,7 +1886,7 @@ contract PanopticPool is Multicall {
         // Caps start getting enforced within 1% (TODO: Can change this later)
         if (accumulatedPremium0 > (token0Cap * 99 / 100 ) || accumulatedPremium1 > (token1Cap * 99 / 100)) {
             // Close the position either way:
-            (LeftRightSigned paidAmounts, LeftRightSigned[4] premiaByLeg) = _burnOptions(
+            (LeftRightSigned paidAmounts, LeftRightSigned[4] memory premiaByLeg) = _burnOptions(
                 tokenId,
                 positionSize,
                 MIN_SWAP_TICK,
@@ -2006,9 +2007,9 @@ contract PanopticPool is Multicall {
                 owner,
                 msg.sender,
                 tokenId,
-                totalPremiaOwed,
-                premiaCap,
-                reward
+                longPremium,
+                cap,
+                LeftRightUnsigned.wrap(reward0).toLeftSlot(reward1)
             );
         }
         // else, no-op - could revert here if we wanted i suppose

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1470,6 +1470,7 @@ contract PanopticPool is Multicall {
         isSolvent = isSolvent && balanceCrossExcludingCappedPremiumCommitments >= Math.mulDivRoundingUp(thresholdCross, buffer, 10_000);
 
         // 3. And, must have premia available to pay off capped premium commitments, even when removing the collateral requirement for uncapped positions.
+        // (Fairly sure this is redundant with 2 - just a rearrangement of terms + removal of buffer - but including for now for explicitness)
         isSolvent = isSolvent && balanceCross - thresholdCross >= crossCappedPremiumCommitment;
     }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -243,15 +243,6 @@ contract PanopticPool is Multicall {
     // Store caps as LeftRightUnsigned (token0 cap in right slot, token1 cap in left slot)
     // TODO: We'll eventually store this in the positionBalance data, where tickData currently goes
     mapping(address => mapping(TokenId => LeftRightUnsigned)) s_premiaCaps;
-    uint256 constant PREMIA_OVERAGE_REWARD_BPS = 100; // 1% reward threshold
-
-    /// @notice If the long-premia cap is exceeded by at least this many bps, the caller earns a reward.
-    /// @dev UI passes (X - PREMIA_CAP_REWARD_BPS) to offer "I want to pay X" experience.
-    uint256 internal constant PREMIA_CAP_REWARD_BPS = 100; // 1.00%
-
-    /// @notice Exceedance threshold (>=) to *trigger* a reward siphon from sellers.
-    /// @dev Using the same value as reward size is reasonable and simple; can be set independently if you prefer.
-    uint256 internal constant PREMIA_CAP_REWARD_THRESHOLD_BPS = 100; // 1.00%
 
     /// @notice Emitted when a position is force-closed due to hitting its premia cap.
     event PositionForceClosed(
@@ -262,9 +253,6 @@ contract PanopticPool is Multicall {
         LeftRightUnsigned premiaCap,           // configured caps (token0 right, token1 left)
         LeftRightUnsigned callerReward         // reward paid to the caller siphoned from sellers (token0 right, token1 left)
     );
-
-    /// @notice Revert when owner tries to burn before reaching their premia cap.
-    error PremiaCapNotReached();
 
     /*//////////////////////////////////////////////////////////////
                              INITIALIZATION
@@ -611,10 +599,17 @@ contract PanopticPool is Multicall {
                          POSITION MINTING LOGIC
     //////////////////////////////////////////////////////////////*/
 
+    /// @notice Validates the current options of the user, and mints a new position.
+    /// @param tokenId The tokenId of the newly minted position
+    /// @param positionSize The size of the position to be minted, expressed in terms of the asset
+    /// @param premiaCaps Cap on premia to pay across all long legs (token0:right slot, token1:left slot)
+    /// @param owner The owner of the option position to be minted
+    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
+    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function _mintOptions(
         TokenId tokenId,
         uint128 positionSize,
-        LeftRightUnsigned premiaCaps, // cap on token0 premia across all long legs in right slot, cap on token1 in left slot
+        LeftRightUnsigned premiaCaps,
         address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
@@ -2014,9 +2009,8 @@ contract PanopticPool is Multicall {
                 premiaCap,
                 reward
             );
-        } else {
-          // no-op
         }
+        // else, no-op - could revert here if we wanted i suppose
     }
 
     // TODO: must also delete s_premiaCaps[owner][tokenId]; everywhere else we close a position

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -240,6 +240,32 @@ contract PanopticPool is Multicall {
     //  |<---------------------- 256 bits ------------------------------>|
     mapping(address account => uint256 positionsHash) internal s_positionsHash;
 
+    // Store caps as LeftRightUnsigned (token0 cap in right slot, token1 cap in left slot)
+    // TODO: Can we store this in the TokenId?
+    mapping(address => mapping(TokenId => LeftRightUnsigned)) s_premiaCaps;
+    uint256 constant PREMIA_OVERAGE_REWARD_BPS = 100; // 1% reward threshold
+
+    /// @notice If the long-premia cap is exceeded by at least this many bps, the caller earns a reward.
+    /// @dev UI passes (X - PREMIA_CAP_REWARD_BPS) to offer "I want to pay X" experience.
+    uint256 internal constant PREMIA_CAP_REWARD_BPS = 100; // 1.00%
+
+    /// @notice Exceedance threshold (>=) to *trigger* a reward siphon from sellers.
+    /// @dev Using the same value as reward size is reasonable and simple; can be set independently if you prefer.
+    uint256 internal constant PREMIA_CAP_REWARD_THRESHOLD_BPS = 100; // 1.00%
+
+    /// @notice Emitted when a position is force-closed due to hitting its premia cap.
+    event PositionForceClosed(
+        address indexed owner,
+        address indexed caller,
+        TokenId indexed tokenId,
+        LeftRightUnsigned totalLongPremia,     // what the buyer owed at close (token0 right, token1 left)
+        LeftRightUnsigned premiaCap,           // configured caps (token0 right, token1 left)
+        LeftRightUnsigned callerReward         // reward paid to the caller siphoned from sellers (token0 right, token1 left)
+    );
+
+    /// @notice Revert when owner tries to burn before reaching their premia cap.
+    error PremiaCapNotReached();
+
     /*//////////////////////////////////////////////////////////////
                              INITIALIZATION
     //////////////////////////////////////////////////////////////*/
@@ -571,18 +597,10 @@ contract PanopticPool is Multicall {
                          POSITION MINTING LOGIC
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Validates the current options of the user, and mints a new position.
-    /// @param tokenId The tokenId of the newly minted position
-    /// @param positionSize The size of the position to be minted, expressed in terms of the asset
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity` for a new position and
-    /// denominated as X32 = (`ratioLimit * 2^32`)
-    /// @param owner The owner of the option position to be minted
-    /// @param tickLimitLow The lower bound of an acceptable open interval for the ending price
-    /// @param tickLimitHigh The upper bound of an acceptable open interval for the ending price
     function _mintOptions(
         TokenId tokenId,
         uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
+        LeftRightUnsigned premiaCaps, // cap on token0 premia across all long legs in right slot, cap on token1 in left slot
         address owner,
         int24 tickLimitLow,
         int24 tickLimitHigh
@@ -591,11 +609,13 @@ contract PanopticPool is Multicall {
         (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = SFPM
             .mintTokenizedPosition(tokenId, positionSize, tickLimitLow, tickLimitHigh);
 
+        // Store the premia caps & checkpointed accumulator values for this position
+        s_premiaCaps[owner][tokenId] = premiaCaps;
+
         _updateSettlementPostMint(
             tokenId,
             collectedByLeg,
             positionSize,
-            effectiveLiquidityLimitX32,
             owner
         );
 
@@ -1664,13 +1684,11 @@ contract PanopticPool is Multicall {
     /// @param tokenId The option position that was minted
     /// @param collectedByLeg The amount of tokens collected in the corresponding chunk for each leg of the position
     /// @param positionSize The size of the position, expressed in terms of the asset
-    /// @param effectiveLiquidityLimitX32 Maximum amount of "spread" defined as `removedLiquidity/netLiquidity`
     /// @param owner The owner of the option position to be minted
     function _updateSettlementPostMint(
         TokenId tokenId,
         LeftRightUnsigned[4] memory collectedByLeg,
         uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
         address owner
     ) internal {
         // ADD the current tokenId to the position list hash (hash = XOR of all keccak256(tokenId))
@@ -1714,13 +1732,14 @@ contract PanopticPool is Multicall {
                     .toLeftSlot(uint128(grossCurrent1));
             }
 
-            // if position is long, ensure that removed liquidity does not deplete strike beyond min(MAX_SPREAD, user-provided effectiveLiquidityLimit)
-            // new totalLiquidity (total sold) = removedLiquidity + netLiquidity (R + N)
-            uint256 totalLiquidity = _checkLiquiditySpread(
-                tokenId,
-                leg,
-                isLong == 0 ? MAX_SPREAD : Math.min(effectiveLiquidityLimitX32, MAX_SPREAD)
-            );
+            // No longer enforcing a liquidity limit at mint - instead, reproduce _checkLiquiditySpread's internal logic
+            uint256 totalLiquidity;
+            {
+                (, uint128 netLiquidity, uint128 removedLiquidity) = _getLiquidities(tokenId, leg);
+                unchecked {
+                    totalLiquidity = netLiquidity + removedLiquidity;
+                }
+            }
 
             // if position is short, adjust `grossPremiumLast` upward to account for the increase in short liquidity
             if (isLong == 0) {
@@ -1774,6 +1793,143 @@ contract PanopticPool is Multicall {
             }
         }
     }
+
+    /// @notice Force close a position that has exceeded its premia cap
+    /// @param owner The owner of the position to close
+    /// @param tokenId The position to potentially close
+    /// @return reward The reward paid to the caller for closing the position
+    function exercisePositionExceedingPremiaCap(
+        address owner,
+        TokenId tokenId
+    ) external returns (uint128 reward) {
+        // Sanity: must be an active position
+        uint128 positionSize = s_positionBalance[owner][tokenId].positionSize();
+        if (positionSize == 0) revert Errors.InvalidTokenIdParameter(0);
+
+        LeftRightUnsigned cap = s_premiaCaps[owner][tokenId];
+        // Must have a cap configured
+        if (LeftRightUnsigned.unwrap(cap) == 0) revert Errors.InputListFail();
+
+        // Calculate current accumulated premia for long legs
+        (, int24 currentTick, , , , , ) = s_univ3pool.slot0();
+        TokenId[] single = new TokenId[](1);
+        single[0] = tokenId;
+        (, LeftRightUnsigned longPremium, uint256[2][] positionBalance) = _calculateAccumulatedPremia(owner, single, false, true, currentTick);
+        uint128 token0Cap = s_premiaCaps[owner][tokenId].rightSlot();
+        uint128 token1Cap = s_premiaCaps[owner][tokenId].leftSlot();
+        uint128 owedPremia0 = owedPremia.rightSlot() * positionBalance[0][1]
+        uint128 owedPremia1 = owedPremia.rightSlot() * positionBalance[0][1]
+
+        if (owedPremia0 > token0Cap || owedPremia1 > token1Cap) {
+            // Close the position either way:
+            (LeftRightSigned paidAmounts, LeftRightSigned[4] premiaByLeg) = _burnOptions(
+                tokenId,
+                positionSize,
+                MIN_SWAP_TICK,
+                MAX_SWAP_TICK,
+                owner,
+                COMMIT_LONG_SETTLED
+            );
+
+            uint128 token0Overage = owedPremia0 - token0Cap;
+            uint128 token1Overage = owedPremia1 - token1Cap;
+
+            // this is equivalent to: if overage >= 1% of cap, pay out a reward
+            // overage / token0Cap >= 0.01 <=> overage >= token0Cap * 0.01 <=> overage / 0.01 >= token0Cap <=> overage * 100 >= token0Cap
+            bool rewardEligible0 = token0Overage * 100 >= token0Cap;
+            bool rewardEligible1 = token1Overage * 100 >= token1Cap;
+
+            // Get seller premia:
+            uint256 totalAvail0;
+            uint256 totalAvail1;
+            {
+                uint256 n = tokenId.countLegs();
+                for (uint256 i = 0; i < n; ) {
+                    if (tokenId.isLong(i) == 0) {
+                        LeftRightSigned avail = premiaByLeg[i];
+                        if (avail.rightSlot() > 0) totalAvail0 += uint128(uint256(int256(avail.rightSlot())));
+                        if (avail.leftSlot()  > 0) totalAvail1 += uint128(uint256(int256(avail.leftSlot())));
+                    }
+                    unchecked { ++i; }
+                }
+            }
+
+            uint128 reward0 = (rewardEligible0 && totalAvail0 > 0)
+                ? uint128((totalAvail0 * PREMIA_CAP_REWARD_BPS) / 10_000)
+                : 0;
+
+            uint128 reward1 = (rewardEligible1 && totalAvail1 > 0)
+                ? uint128((totalAvail1 * PREMIA_CAP_REWARD_BPS) / 10_000)
+                : 0;
+
+            if (reward0 > 0 || reward1 > 0) {
+                // 6) Delegate so we can pay the caller via CT.refund(...) within this scope
+                s_collateralToken0.delegate(owner);
+                s_collateralToken1.delegate(owner);
+                uint256 remaining0 = reward0;
+                uint256 remaining1 = reward1;
+
+                for (uint256 i = 0; i < tokenId.countLegs(); ) {
+                    if (tokenId.isLong(i) == 0) {
+                        // Identify the chunk
+                        bytes32 chunkKey = keccak256(
+                            abi.encodePacked(tokenId.strike(i), tokenId.width(i), tokenId.tokenType(i))
+                        );
+                        // Per-leg available amounts
+                        LeftRightSigned avail = premiaByLeg[i];
+                        uint256 avail0 = (avail.rightSlot() > 0) ? uint128(uint256(int256(avail.rightSlot()))) : 0;
+                        uint256 avail1 = (avail.leftSlot()  > 0) ? uint128(uint256(int256(avail.leftSlot())))  : 0;
+
+                        // Pro-rata slice for this chunk
+                        uint256 take0 = (totalAvail0 == 0 || remaining0 == 0) ? 0 : (avail0 * reward0) / totalAvail0;
+                        uint256 take1 = (totalAvail1 == 0 || remaining1 == 0) ? 0 : (avail1 * reward1) / totalAvail1;
+
+                        // Last-chunk rounding fix
+                        if (i == n - 1) {
+                            if (take0 < remaining0) take0 = remaining0;
+                            if (take1 < remaining1) take1 = remaining1;
+                        }
+
+                        // Reduce sellers' settled pool for this chunk
+                        LeftRightUnsigned st = s_settledTokens[chunkKey];
+                        s_settledTokens[chunkKey] = LeftRightUnsigned
+                            .wrap(uint128(st.rightSlot() > take0 ? st.rightSlot() - uint128(take0) : 0))
+                            .toLeftSlot(uint128(st.leftSlot()  > take1 ? st.leftSlot()  - uint128(take1) : 0));
+
+                        // Track what's left to allocate
+                        if (take0 <= remaining0) remaining0 -= take0; else remaining0 = 0;
+                        if (take1 <= remaining1) remaining1 -= take1; else remaining1 = 0;
+                    }
+                    unchecked { ++i; }
+                }
+
+                // Pay the caller now (tokens come from the same pool that the buyer just funded via premia)
+                if (reward0 > 0) s_collateralToken0.refund(owner, msg.sender, int128(reward0));
+                if (reward1 > 0) s_collateralToken1.refund(owner, msg.sender, int128(reward1));
+
+                // 11) Revoke delegation
+                s_collateralToken0.revoke(owner);
+                s_collateralToken1.revoke(owner);
+            }
+
+            // Clean up storage
+            delete s_premiaCaps[owner][tokenId];
+
+            emit PositionForceClosed(
+                owner,
+                msg.sender,
+                tokenId,
+                totalPremiaOwed,
+                premiaCap,
+                reward
+            );
+        } else {
+          // no-op
+        }
+    }
+
+    // TODO: must also delete s_premiaCaps[owner][tokenId]; everywhere else we close a position
+
 
     /// @notice Query the amount of premium available for withdrawal given a certain `premiumOwed` for a chunk.
     /// @dev Based on the ratio between `settledTokens` and the total premium owed to sellers in a chunk.

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -81,6 +81,22 @@ contract PanopticPoolHarness is PanopticPool {
         return (premiasByLeg, netExchanged);
     }
 
+    function getPremiaCap(address owner, TokenId t) external view returns (LeftRightUnsigned) {
+        return s_premiaCaps[owner][t];
+    }
+
+    function viewLongPremiaAt(
+        address user,
+        TokenId[] calldata list,
+        int24 atTick
+    ) external view returns (LeftRightUnsigned longPremium) {
+        (, longPremium, , ,) = _calculateAccumulatedPremia(user, list, false, true, atTick);
+    }
+
+    function setPremiaCapForTest(address owner, TokenId t, LeftRightUnsigned cap) external {
+        s_premiaCaps[owner][t] = cap;
+    }
+
     constructor(SemiFungiblePositionManager _sfpm) PanopticPool(_sfpm) {}
 }
 
@@ -303,24 +319,24 @@ contract PanopticPoolTest is PositionUtils {
         PanopticPool pp,
         TokenId[] memory positionIdList,
         uint128 positionSize,
-        uint64 effectiveLiquidityLimitX32,
+        LeftRightUnsigned premiaCaps,
         int24 tickLimitLow,
         int24 tickLimitHigh,
         bool premiaAsCollateral
     ) internal {
         uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
+        LeftRightUnsigned[] memory capsList = new LeftRightUnsigned[](1);
         TokenId[] memory mintList = new TokenId[](1);
         int24[2][] memory tickLimits = new int24[2][](1);
 
         TokenId tokenId = positionIdList[positionIdList.length - 1];
         sizeList[0] = positionSize;
-        spreadList[0] = effectiveLiquidityLimitX32;
+        capsList[0] = premiaCaps;
         mintList[0] = tokenId;
         tickLimits[0][0] = tickLimitLow;
         tickLimits[0][1] = tickLimitHigh;
 
-        pp.dispatch(mintList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
+        pp.dispatch(mintList, positionIdList, sizeList, capsList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -332,16 +348,16 @@ contract PanopticPoolTest is PositionUtils {
         bool premiaAsCollateral
     ) internal {
         uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
+        LeftRightUnsigned[] memory capsList = new LeftRightUnsigned[](1);
         TokenId[] memory burnList = new TokenId[](1);
         int24[2][] memory tickLimits = new int24[2][](1);
 
         sizeList[0] = 0;
-        spreadList[0] = type(uint64).max;
+        capsList[0] = type(uint64).max;
         burnList[0] = tokenId;
         tickLimits[0][0] = tickLimitLow;
         tickLimits[0][1] = tickLimitHigh;
-        pp.dispatch(burnList, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
+        pp.dispatch(burnList, positionIdList, sizeList, capsList, tickLimits, premiaAsCollateral);
     }
 
     function burnOptions(
@@ -353,7 +369,7 @@ contract PanopticPoolTest is PositionUtils {
         bool premiaAsCollateral
     ) internal {
         uint128[] memory sizeList = new uint128[](tokenIds.length);
-        uint64[] memory spreadList = new uint64[](tokenIds.length);
+        LeftRightUnsigned[] memory capsList = new LeftRightUnsigned[](tokenIds.length);
         int24[2][] memory tickLimits = new int24[2][](tokenIds.length);
 
         for (uint256 i; i < tokenIds.length; ++i) {
@@ -361,7 +377,7 @@ contract PanopticPoolTest is PositionUtils {
             tickLimits[i][1] = tickLimitHigh;
         }
 
-        pp.dispatch(tokenIds, positionIdList, sizeList, spreadList, tickLimits, premiaAsCollateral);
+        pp.dispatch(tokenIds, positionIdList, sizeList, capsList, tickLimits, premiaAsCollateral);
     }
 
     function liquidate(
@@ -370,9 +386,6 @@ contract PanopticPoolTest is PositionUtils {
         address liquidatee,
         TokenId[] memory positionIdList
     ) internal {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
         pp.dispatchFrom(
             liquidatorList,
             liquidatee,
@@ -390,9 +403,6 @@ contract PanopticPoolTest is PositionUtils {
         TokenId[] memory exercisorList,
         LeftRightUnsigned premiaAsCollateral
     ) internal {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
         TokenId[] memory exerciseeListInitial = new TokenId[](exerciseeListFinal.length + 1);
         for (uint256 i = 0; i < exerciseeListFinal.length; ++i) {
             exerciseeListInitial[i] = exerciseeListFinal[i];
@@ -416,9 +426,6 @@ contract PanopticPoolTest is PositionUtils {
         uint256 legIndex,
         bool premiaAsCollateral
     ) internal {
-        uint128[] memory sizeList = new uint128[](1);
-        uint64[] memory spreadList = new uint64[](1);
-
         pp.dispatchFrom(
             settlerList,
             exercisee,
@@ -2013,6 +2020,8 @@ contract PanopticPoolTest is PositionUtils {
     /*//////////////////////////////////////////////////////////////
                      SLIPPAGE/EFFECTIVE LIQ LIMITS
     //////////////////////////////////////////////////////////////*/
+
+    // TODO: These 3 liquidity limit tests need to be updated now that this functionality no longer exists
 
     function test_Success_mintOptions_OTMShortCall_NoLiquidityLimit(
         uint256 x,
@@ -9104,4 +9113,209 @@ contract PanopticPoolTest is PositionUtils {
             LeftRightUnsigned.wrap(1).toLeftSlot(1)
         );
     }
+
+    /*//////////////////////////////////////////////////////////////
+      CAPPED PREMIA TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_CappedPremia_MintStoresCap_AndSolvency(uint256 seed) public {
+        _initWorld(seed);
+        // Place price exactly at currentTick with mock
+        _initWorldAtTick(seed, currentTick);
+
+        // Build a simple 1-leg long position using existing utilities
+        populatePositionData(/*width*/ 60, /*strike*/ currentTick, /*sizeSeed*/ 5e18);
+        TokenId[] memory list = new TokenId[](1);
+        // Use PositionUtils or your builder to construct a long leg tokenId from tickLower/tickUpper
+        list[0] = PositionUtils.constructLongCallTokenId(tickLower, tickUpper);
+
+        // Small but nonzero caps (right=token0, left=token1)
+        LeftRightUnsigned caps = LeftRightUnsigned
+            .wrap(0)
+            .toRightSlot(uint128(2e6))
+            .toLeftSlot(uint128(3e6));
+
+        vm.startPrank(Alice);
+        // Ensure Alice is well funded; _initAccounts() already deposited for Alice
+        mintOptions(
+            pp,
+            list,
+            positionSize,
+            caps,
+            /*tickLimitLow*/ tickLower,
+            /*tickLimitHigh*/ tickUpper,
+            /*premiaAsCollateral*/ false
+        );
+        vm.stopPrank();
+
+        // Cap persisted
+        LeftRightUnsigned got = pp.getPremiaCap(Alice, list[0]);
+        assertEq(got.rightSlot(), caps.rightSlot(), "token0 cap mismatch");
+        assertEq(got.leftSlot(),  caps.leftSlot(),  "token1 cap mismatch");
+
+        // If dispatch returned, `_isSolventWithBuffer` checks passed implicitly.
+        // (Optional) You can also verify that positionsHash updated:
+        assertGt(pp.positionsHash(Alice), 0, "positionsHash not updated");
+    }
+
+    function test_CappedPremia_GraceWindow_ClosePaysCap_ToCallerFromBuyer(uint256 seed) public {
+        _initWorld(seed);
+        _initWorldAtTick(seed, currentTick);
+
+        // Build + mint a long position
+        populatePositionData(/*width*/ 60, /*strike*/ currentTick, /*sizeSeed*/ 5e18);
+        TokenId[] memory list = new TokenId[](1);
+        list[0] = PositionUtils.constructLongCallTokenId(tickLower, tickUpper);
+
+        vm.startPrank(Alice);
+        // Start with a generous cap, then we will set an exact cap after reading premia (test-only)
+        LeftRightUnsigned tmpCaps = LeftRightUnsigned.wrap(0).toRightSlot(1e18).toLeftSlot(1e18);
+        mintOptions(pp, list, positionSize, tmpCaps, tickLower, tickUpper, false);
+        vm.stopPrank();
+
+        // Accrue some premia via swaps, then read current long premia
+        twoWaySwap(2e18); // light accrual to avoid overshooting
+        (, int24 tick,, ,,,) = pool.slot0();
+
+        LeftRightUnsigned longPremia = pp.viewLongPremiaAt(Alice, list, tick);
+
+        // Target grace: set cap slightly above accumulated (within 1%; your grace threshold is 99%).
+        // token0: cap0 = accum0 + delta where delta is small
+        // token1: cap1 = accum1 + delta
+        uint128 delta0 = uint128(longPremia.rightSlot() / 200); // 0.5%
+        uint128 delta1 = uint128(longPremia.leftSlot()  / 200); // 0.5%
+        LeftRightUnsigned graceCaps = LeftRightUnsigned
+            .wrap(0)
+            .toRightSlot(uint128(longPremia.rightSlot()) + delta0)
+            .toLeftSlot(uint128(longPremia.leftSlot())  + delta1);
+
+        // Set exact caps for the grace window (harness-only)
+        pp.setPremiaCapForTest(Alice, list[0], graceCaps);
+
+        // Pre balances
+        uint256 caller0Before = ct0.balanceOf(Charlie);
+        uint256 caller1Before = ct1.balanceOf(Charlie);
+        uint256 buyer0Before  = ct0.balanceOf(Alice);
+        uint256 buyer1Before  = ct1.balanceOf(Alice);
+
+        // Anyone may call
+        vm.prank(Charlie);
+        pp.exercisePositionExceedingPremiaCap(Alice, list[0]);
+
+        // In grace: caller gets (cap - accum), buyer ends up paying exactly cap (so post-call delta matches that top-up)
+        uint256 caller0Gain = ct0.balanceOf(Charlie) - caller0Before;
+        uint256 caller1Gain = ct1.balanceOf(Charlie) - caller1Before;
+
+        assertEq(caller0Gain, uint256(graceCaps.rightSlot() - longPremia.rightSlot()), "caller0 reward (grace)");
+        assertEq(caller1Gain, uint256(graceCaps.leftSlot()  - longPremia.leftSlot()),  "caller1 reward (grace)");
+
+        // Cap cleared
+        LeftRightUnsigned cleared = pp.getPremiaCap(Alice, list[0]);
+        assertEq(LeftRightUnsigned.unwrap(cleared), 0, "cap should be deleted post-close");
+
+        // Buyer paid the top-up in this call (can’t strictly assert exact buyer delta without tracking _burnOptions path);
+        // but at minimum, buyer shouldn't gain here:
+        assertLe(ct0.balanceOf(Alice), buyer0Before, "buyer0 should not have net gain in grace");
+        assertLe(ct1.balanceOf(Alice), buyer1Before, "buyer1 should not have net gain in grace");
+    }
+
+    function test_CappedPremia_Exceeded_CloseRefundsBuyer_AndPaysCaller_FromSellers(uint256 seed) public {
+        _initWorld(seed);
+        _initWorldAtTick(seed, currentTick);
+
+        // Build + mint a long position with a tiny cap so we can exceed it
+        populatePositionData(/*width*/ 60, /*strike*/ currentTick, /*sizeSeed*/ 5e18);
+        TokenId[] memory list = new TokenId[](1);
+        list[0] = PositionUtils.constructLongCallTokenId(tickLower, tickUpper);
+
+        LeftRightUnsigned tinyCaps = LeftRightUnsigned
+            .wrap(0)
+            .toRightSlot(uint128(2e6))  // very small
+            .toLeftSlot(uint128(2e6));
+
+        vm.prank(Alice);
+        mintOptions(pp, list, positionSize, tinyCaps, tickLower, tickUpper, false);
+
+        // Accrue more premia to *exceed* the cap
+        twoWaySwapBig();
+        twoWaySwapBig();
+
+        (, int24 tick,, ,,,) = pool.slot0();
+        LeftRightUnsigned prem = pp.viewLongPremiaAt(Alice, list, tick);
+        assertGt(prem.rightSlot(), tinyCaps.rightSlot(), "token0 not exceeded");
+        assertGt(prem.leftSlot(),  tinyCaps.leftSlot(),  "token1 not exceeded");
+
+        // Pre balances (protocol = sellers bucket is modeled via pp/ct balances depending on your accounting)
+        uint256 buyer0Before  = ct0.balanceOf(Alice);
+        uint256 buyer1Before  = ct1.balanceOf(Alice);
+        uint256 caller0Before = ct0.balanceOf(Bob);
+        uint256 caller1Before = ct1.balanceOf(Bob);
+        uint256 proto0Before  = ct0.balanceOf(address(pp));
+        uint256 proto1Before  = ct1.balanceOf(address(pp));
+
+        // Bob calls for the reward
+        vm.prank(Bob);
+        pp.exercisePositionExceedingPremiaCap(Alice, list[0]);
+
+        // Exceeded math per your impl:
+        // reward = cap/100 to caller; buyerRefund = (accum - cap) back to buyer
+        uint128 reward0 = tinyCaps.rightSlot() / 100;
+        uint128 reward1 = tinyCaps.leftSlot()  / 100;
+        uint128 refund0 = uint128(prem.rightSlot() - tinyCaps.rightSlot());
+        uint128 refund1 = uint128(prem.leftSlot()  - tinyCaps.leftSlot());
+
+        assertEq(ct0.balanceOf(Bob)   - caller0Before, reward0, "caller0 reward");
+        assertEq(ct1.balanceOf(Bob)   - caller1Before, reward1, "caller1 reward");
+        assertEq(ct0.balanceOf(Alice) - buyer0Before,  refund0, "buyer0 refund");
+        assertEq(ct1.balanceOf(Alice) - buyer1Before,  refund1, "buyer1 refund");
+
+        // Sellers/protocol paid reward + refund (net decrease)
+        assertEq(proto0Before - ct0.balanceOf(address(pp)), reward0 + refund0, "proto0 out");
+        assertEq(proto1Before - ct1.balanceOf(address(pp)), reward1 + refund1, "proto1 out");
+
+        // Cap cleared
+        LeftRightUnsigned cleared = pp.getPremiaCap(Alice, list[0]);
+        assertEq(LeftRightUnsigned.unwrap(cleared), 0, "cap should be deleted after exceeded close");
+    }
+
+    function test_CappedPremia_Mixed_ExceededOn0_GraceOn1(uint256 seed) public {
+        _initWorld(seed);
+        _initWorldAtTick(seed, currentTick);
+
+        populatePositionData(/*width*/ 60, /*strike*/ currentTick, /*sizeSeed*/ 5e18);
+        TokenId[] memory list = new TokenId[](1);
+        list[0] = PositionUtils.constructLongCallTokenId(tickLower, tickUpper);
+
+        vm.prank(Alice);
+        // tiny cap0 (exceed), huge cap1 (grace/no trigger)
+        mintOptions(pp, list, positionSize, LeftRightUnsigned.wrap(0).toRightSlot(5e6).toLeftSlot(5e18), tickLower, tickUpper, false);
+
+        twoWaySwapBig();
+        (, int24 tick,, ,,,) = pool.slot0();
+        LeftRightUnsigned prem = pp.viewLongPremiaAt(Alice, list, tick);
+
+        // Now set cap1 to sit just above accum1 (grace) while cap0 remains exceeded
+        uint128 delta1 = uint128(prem.leftSlot() / 200); // +0.5%
+        pp.setPremiaCapForTest(
+            Alice,
+            list[0],
+            LeftRightUnsigned.wrap(0).toRightSlot(uint128(5e6)).toLeftSlot(uint128(prem.leftSlot()) + delta1)
+        );
+
+        uint256 caller0Before = ct0.balanceOf(Charlie);
+        uint256 caller1Before = ct1.balanceOf(Charlie);
+
+        vm.prank(Charlie);
+        pp.exercisePositionExceedingPremiaCap(Alice, list[0]);
+
+        // token0: exceeded -> reward = cap/100
+        assertEq(ct0.balanceOf(Charlie) - caller0Before, uint256(uint128(5e6) / 100), "caller0 reward exceeded");
+        // token1: grace -> reward = cap1 - accum1 (~0.5% of accum1)
+        assertEq(
+            ct1.balanceOf(Charlie) - caller1Before,
+            uint256((uint128(prem.leftSlot()) + delta1) - uint128(prem.leftSlot())),
+            "caller1 reward grace"
+        );
+    }
+
 }


### PR DESCRIPTION
- Remove `effectiveLiquidityLimitX32`
- Specify the total token0 / token1 you are willing to let your long legs owe (in sum) for your position in mintOptions, replacing effectiveLiquidityLimitX32
- Store it
- Expose a exercisePositionExceedingPremiaCap, which when called will: a) close any position that has exceeded its premia cap in either token0 or token1, and b) 

Notes:

- I decided that it's preferable to have a window where the sellers don't suffer a penalty, but the position is still force-closeable for free. The way i see this working is that the UI shows a cap of 1 ETH, in the contracts we pass that in as 0.99 ETH, and sellers have the 0.99 to 1 ETH window as their chance to close the position without penalty.

Design decisions:

- Should the cap be an either/or cap on each token amount, or a cross-balance cap? I kind of think cross-balance, but doing it either-or was easier for a first pass
- Should we try to fit the cap into the TokenId, so that we don't have to store it?

TODO:

- Implement the fancier reward/penalty mechanism - caller gets proportionally more as we exceed the cap more severely - in this version, it's just: No penalty if exercised within 1% of cap, and 1% penalty otherwise.
- test