### PR TITLE
Fix: Use Uniswap's Actual Liquidity Math for Notional Calculations

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1505,6 +1505,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // amount moved is right slot if tokenType=0, left slot otherwise
         uint128 amountMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
+        // revert if the position did not move any token
         if (amountMoved == 0) revert Errors.ZeroLiquidity();
 
         uint256 isLong = tokenId.isLong(index);

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1124,6 +1124,9 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 bonusAbs = uint256(-bonus);
             }
 
+            uint256 underlyingTokenBalance = ERC20Minimal(s_underlyingToken).balanceOf(liquidator);
+            if (underlyingTokenBalance < bonusAbs)
+                revert Errors.NotEnoughTokens(s_underlyingToken, bonusAbs, underlyingTokenBalance);
             SafeTransferLib.safeTransferFrom(s_underlyingToken, liquidator, msg.sender, bonusAbs);
 
             _mint(liquidatee, convertToShares(bonusAbs));
@@ -1264,6 +1267,14 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                     totalSupply,
                     totalAssets()
                 );
+                address _optionOwner = optionOwner;
+                if (balanceOf[_optionOwner] < sharesToBurn)
+                    revert Errors.NotEnoughTokens(
+                        address(this),
+                        uint256(tokenToPay),
+                        convertToAssets(balanceOf[_optionOwner])
+                    );
+
                 _burn(optionOwner, sharesToBurn);
             } else if (tokenToPay < 0) {
                 uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
@@ -1505,9 +1516,6 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // amount moved is right slot if tokenType=0, left slot otherwise
         uint128 amountMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
-        // revert if the position did not move any token
-        if (amountMoved == 0) revert Errors.ZeroLiquidity();
-
         uint256 isLong = tokenId.isLong(index);
 
         // start with base requirement, which is based on isLong value
@@ -1598,6 +1606,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 }
             }
         }
+        // revert if the position does not require any collateral
+        if (required == 0) revert Errors.ZeroCollateralRequirement();
     }
 
     /// @notice Calculate the required amount of collateral for leg `index` for position `tokenId` accounting for its partner leg.

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1505,6 +1505,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         // amount moved is right slot if tokenType=0, left slot otherwise
         uint128 amountMoved = tokenType == 0 ? amountsMoved.rightSlot() : amountsMoved.leftSlot();
 
+        if (amountMoved == 0) revert Errors.ZeroLiquidity();
+
         uint256 isLong = tokenId.isLong(index);
 
         // start with base requirement, which is based on isLong value

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1540,7 +1540,7 @@ contract PanopticPool is Multicall {
         // compute and return effective liquidity. Return if short=net=0, which is closing short position
         if (netLiquidity == 0 && removedLiquidity == 0) return totalLiquidity;
 
-        if (netLiquidity == 0) revert Errors.NotEnoughLiquidity();
+        if (netLiquidity == 0) revert Errors.NetLiquidityZero();
 
         uint256 effectiveLiquidityFactorX32;
         unchecked {

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1540,6 +1540,8 @@ contract PanopticPool is Multicall {
         // compute and return effective liquidity. Return if short=net=0, which is closing short position
         if (netLiquidity == 0 && removedLiquidity == 0) return totalLiquidity;
 
+        if (netLiquidity == 0) revert Errors.NotEnoughLiquidity();
+
         uint256 effectiveLiquidityFactorX32;
         unchecked {
             effectiveLiquidityFactorX32 = (removedLiquidity * 2 ** 32) / netLiquidity;

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -628,27 +628,23 @@ contract PanopticPool is Multicall {
     /// @param positionSize The size of the position, expressed in terms of the asset
     /// @param owner The owner of the option position to be minted
     /// @param totalSwapped The amount of tokens moved during creation of the option position
-    /// @return Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
+    /// @return utilizations Packing of the pool utilization (how much funds are in the Panoptic pool versus the AMM pool at the time of minting),
     /// right 64bits for token0 and left 64bits for token1, defined as `(inAMM * 10_000) / totalAssets()`
     /// where totalAssets is the total tracked assets in the AMM and PanopticPool minus fees and donations to the Panoptic pool
-    /// @return The total amount of commissions (base rate) paid for token0 (right) and token1 (left)
-    /// @return The amount of tokens paid when creating that option for token0 (right) and token1 (left)
+    /// @return commissions The total amount of commissions (base rate) paid for token0 (right) and token1 (left)
+    /// @return paidAmounts The amount of tokens paid when creating that option for token0 (right) and token1 (left)
     function _payCommissionAndWriteData(
         TokenId tokenId,
         uint128 positionSize,
         address owner,
         LeftRightSigned totalSwapped
-    ) internal returns (uint32, LeftRightUnsigned, LeftRightSigned) {
+    )
+        internal
+        returns (uint32 utilizations, LeftRightUnsigned commissions, LeftRightSigned paidAmounts)
+    {
         // compute how much of tokenId is long and short positions
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
-
-        uint32 commissions;
-        LeftRightUnsigned utilizations;
-        LeftRightSigned paidAmounts;
-
-        // stack too deep
-        LeftRightSigned _totalSwapped = totalSwapped;
 
         {
             (LeftRightUnsigned utilizationAndCommission0, int128 paid0) = s_collateralToken0
@@ -656,10 +652,10 @@ contract PanopticPool is Multicall {
                     owner,
                     longAmounts.rightSlot(),
                     shortAmounts.rightSlot(),
-                    _totalSwapped.rightSlot()
+                    totalSwapped.rightSlot()
                 );
-            commissions = uint32(utilizationAndCommission0.rightSlot());
-            utilizations = utilizations.toRightSlot(utilizationAndCommission0.leftSlot());
+            utilizations = uint32(utilizationAndCommission0.rightSlot());
+            commissions = commissions.toRightSlot(utilizationAndCommission0.leftSlot());
             paidAmounts = paidAmounts.toRightSlot(paid0);
         }
         {
@@ -668,16 +664,16 @@ contract PanopticPool is Multicall {
                     owner,
                     longAmounts.leftSlot(),
                     shortAmounts.leftSlot(),
-                    _totalSwapped.leftSlot()
+                    totalSwapped.leftSlot()
                 );
-            commissions = uint32(utilizationAndCommission1.rightSlot() << 16);
-            utilizations = utilizations.toLeftSlot(utilizationAndCommission1.leftSlot());
+            utilizations += uint32(utilizationAndCommission1.rightSlot() << 16);
+            commissions = commissions.toLeftSlot(utilizationAndCommission1.leftSlot());
             paidAmounts = paidAmounts.toLeftSlot(paid1);
         }
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
         unchecked {
-            return (commissions, utilizations, paidAmounts);
+            return (utilizations, commissions, paidAmounts);
         }
     }
 

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -44,6 +44,9 @@ library Errors {
     /// @notice A mint or swap callback was attempted from an address that did not match the canonical Uniswap V3 pool with the claimed features
     error InvalidUniswapCallback();
 
+    /// @notice PanopticPool: The Net Liquidity is zero due to small positions and cannotbe used to compute the liquiditySpread
+    error NetLiquidityZero();
+
     /// @notice PanopticPool: None of the legs in a position are force-exercisable (they are all either short or ATM long)
     error NoLegsExercisable();
 

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -34,6 +34,9 @@ library Errors {
     /// @notice Tick is not between `MIN_TICK` and `MAX_TICK`
     error InvalidTick();
 
+    /// @notice Liquidity in a chunk is above 2**128
+    error LiquidityTooHigh();
+
     /// @notice The TokenId provided by the user is malformed or invalid
     /// @param parameterType poolId=0, ratio=1, tokenType=2, risk_partner=3, strike=4, width=5, two identical strike/width/tokenType chunks=6
     error InvalidTokenIdParameter(uint256 parameterType);
@@ -49,6 +52,9 @@ library Errors {
 
     /// @notice PanopticPool: There is not enough available liquidity in the chunk for one of the long legs to be created (or for one of the short legs to be closed)
     error NotEnoughLiquidity();
+
+    /// @notice CollateralTracker: The user does not own enough assets to open/close a position
+    error NotEnoughTokens(address tokenAddress, uint256 assetsRequested, uint256 assetBalance);
 
     /// @notice PanopticPool: Position is still solvent and cannot be liquidated
     error NotMarginCalled();
@@ -91,6 +97,9 @@ library Errors {
 
     /// @notice The Uniswap Pool has not been created, so it cannot be used in the SFPM or have a PanopticPool created for it by the factory
     error UniswapPoolNotInitialized();
+
+    /// @notice CollateralTracker: Mints/burns of a position returns no collateral requirement
+    error ZeroCollateralRequirement();
 
     /// @notice SFPM: Mints/burns of zero-liquidity chunks in Uniswap are not supported
     error ZeroLiquidity();

--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -283,6 +283,42 @@ library Math {
     /// @notice Calculates the amount of token0 received for a given LiquidityChunk.
     /// @param liquidityChunk A specification for a liquidity chunk in Uniswap containing `liquidity`, `tickLower`, and `tickUpper`
     /// @return The amount of token0 represented by `liquidityChunk` when `currentTick < tickLower`
+    function getAmount0ForLiquidityUp(
+        LiquidityChunk liquidityChunk
+    ) internal pure returns (uint256) {
+        uint160 lowPriceX96 = getSqrtRatioAtTick(liquidityChunk.tickLower());
+        uint160 highPriceX96 = getSqrtRatioAtTick(liquidityChunk.tickUpper());
+        unchecked {
+            return
+                mulDivRoundingUp(
+                    mulDivRoundingUp(
+                        uint256(liquidityChunk.liquidity()) << 96,
+                        highPriceX96 - lowPriceX96,
+                        highPriceX96
+                    ),
+                    1,
+                    lowPriceX96
+                );
+        }
+    }
+
+    /// @notice Calculates the amount of token1 received for a given LiquidityChunk.
+    /// @param liquidityChunk A specification for a liquidity chunk in Uniswap containing `liquidity`, `tickLower`, and `tickUpper`
+    /// @return The amount of token1 represented by `liquidityChunk` when `currentTick > tickUpper`
+    function getAmount1ForLiquidityUp(
+        LiquidityChunk liquidityChunk
+    ) internal pure returns (uint256) {
+        uint160 lowPriceX96 = getSqrtRatioAtTick(liquidityChunk.tickLower());
+        uint160 highPriceX96 = getSqrtRatioAtTick(liquidityChunk.tickUpper());
+
+        unchecked {
+            return mulDiv96RoundingUp(liquidityChunk.liquidity(), highPriceX96 - lowPriceX96);
+        }
+    }
+
+    /// @notice Calculates the amount of token0 received for a given LiquidityChunk.
+    /// @param liquidityChunk A specification for a liquidity chunk in Uniswap containing `liquidity`, `tickLower`, and `tickUpper`
+    /// @return The amount of token0 represented by `liquidityChunk` when `currentTick < tickLower`
     function getAmount0ForLiquidity(LiquidityChunk liquidityChunk) internal pure returns (uint256) {
         uint160 lowPriceX96 = getSqrtRatioAtTick(liquidityChunk.tickLower());
         uint160 highPriceX96 = getSqrtRatioAtTick(liquidityChunk.tickUpper());

--- a/contracts/libraries/Math.sol
+++ b/contracts/libraries/Math.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.24;
-
 // Libraries
 import {Errors} from "@libraries/Errors.sol";
 import {Constants} from "@libraries/Constants.sol";
@@ -373,22 +372,20 @@ library Math {
         int24 tickUpper,
         uint256 amount0
     ) internal pure returns (LiquidityChunk) {
-        uint160 lowPriceX96 = getSqrtRatioAtTick(tickLower);
-        uint160 highPriceX96 = getSqrtRatioAtTick(tickUpper);
-
         unchecked {
-            return
-                LiquidityChunkLibrary.createChunk(
-                    tickLower,
-                    tickUpper,
-                    toUint128(
-                        mulDiv(
-                            amount0,
-                            mulDiv96(highPriceX96, lowPriceX96),
-                            highPriceX96 - lowPriceX96
-                        )
-                    )
-                );
+            uint160 lowPriceX96 = getSqrtRatioAtTick(tickLower);
+            uint160 highPriceX96 = getSqrtRatioAtTick(tickUpper);
+
+            uint256 liquidity = mulDiv(
+                amount0,
+                mulDiv96(highPriceX96, lowPriceX96),
+                highPriceX96 - lowPriceX96
+            );
+
+            // This check guarantees the following uint128 cast is safe.
+            if (liquidity > type(uint128).max) revert Errors.LiquidityTooHigh();
+
+            return LiquidityChunkLibrary.createChunk(tickLower, tickUpper, uint128(liquidity));
         }
     }
 
@@ -402,16 +399,16 @@ library Math {
         int24 tickUpper,
         uint256 amount1
     ) internal pure returns (LiquidityChunk) {
-        uint160 lowPriceX96 = getSqrtRatioAtTick(tickLower);
-        uint160 highPriceX96 = getSqrtRatioAtTick(tickUpper);
-
         unchecked {
-            return
-                LiquidityChunkLibrary.createChunk(
-                    tickLower,
-                    tickUpper,
-                    toUint128(mulDiv(amount1, Constants.FP96, highPriceX96 - lowPriceX96))
-                );
+            uint160 lowPriceX96 = getSqrtRatioAtTick(tickLower);
+            uint160 highPriceX96 = getSqrtRatioAtTick(tickUpper);
+
+            uint256 liquidity = mulDiv(amount1, Constants.FP96, highPriceX96 - lowPriceX96);
+
+            // This check guarantees the following uint128 cast is safe.
+            if (liquidity > type(uint128).max) revert Errors.LiquidityTooHigh();
+
+            return LiquidityChunkLibrary.createChunk(tickLower, tickUpper, uint128(liquidity));
         }
     }
 

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -662,8 +662,14 @@ library PanopticMath {
 
         LiquidityChunk liquidityChunk = getLiquidityChunk(tokenId, legIndex, positionSize);
 
-        amount0 = uint128(Math.getAmount0ForLiquidity(liquidityChunk));
-        amount1 = uint128(Math.getAmount1ForLiquidity(liquidityChunk));
+        // Add branching here for isLong rounding Up/Down to match Uniswap's moved token amounts
+        if (tokenId.isLong(legIndex) == 0) {
+            amount0 = uint128(Math.getAmount0ForLiquidityUp(liquidityChunk));
+            amount1 = uint128(Math.getAmount1ForLiquidityUp(liquidityChunk));
+        } else {
+            amount0 = uint128(Math.getAmount0ForLiquidity(liquidityChunk));
+            amount1 = uint128(Math.getAmount1ForLiquidity(liquidityChunk));
+        }
 
         return LeftRightUnsigned.wrap(amount0).toLeftSlot(amount1);
     }

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -662,7 +662,8 @@ library PanopticMath {
 
         LiquidityChunk liquidityChunk = getLiquidityChunk(tokenId, legIndex, positionSize);
 
-        // Add branching here for isLong rounding Up/Down to match Uniswap's moved token amounts
+        // Shorts round UP to ensure user pays enough (conservative for protocol)
+        // Longs round DOWN to ensure user receives correct amount (conservative for protocol)
         if (tokenId.isLong(legIndex) == 0) {
             amount0 = uint128(Math.getAmount0ForLiquidityUp(liquidityChunk));
             amount1 = uint128(Math.getAmount1ForLiquidityUp(liquidityChunk));

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
-
 // Interfaces
 import {CollateralTracker} from "@contracts/CollateralTracker.sol";
 import {PanopticPool} from "@contracts/PanopticPool.sol";
@@ -661,22 +660,10 @@ library PanopticMath {
         uint128 amount0;
         uint128 amount1;
 
-        (int24 tickLower, int24 tickUpper) = tokenId.asTicks(legIndex);
+        LiquidityChunk liquidityChunk = getLiquidityChunk(tokenId, legIndex, positionSize);
 
-        // effective strike price of the option (avg. price over LP range)
-        // geometric mean of two numbers = √(x1 * x2) = √x1 * √x2
-        uint256 geometricMeanPriceX96 = Math.mulDiv96(
-            Math.getSqrtRatioAtTick(tickLower),
-            Math.getSqrtRatioAtTick(tickUpper)
-        );
-
-        if (tokenId.asset(legIndex) == 0) {
-            amount0 = positionSize * uint128(tokenId.optionRatio(legIndex));
-            amount1 = Math.mulDiv96RoundingUp(amount0, geometricMeanPriceX96).toUint128();
-        } else {
-            amount1 = positionSize * uint128(tokenId.optionRatio(legIndex));
-            amount0 = Math.mulDivRoundingUp(amount1, 2 ** 96, geometricMeanPriceX96).toUint128();
-        }
+        amount0 = uint128(Math.getAmount0ForLiquidity(liquidityChunk));
+        amount1 = uint128(Math.getAmount1ForLiquidity(liquidityChunk));
 
         return LeftRightUnsigned.wrap(amount0).toLeftSlot(amount1);
     }

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1435,7 +1435,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         mintOptions(
             panopticPool,
             positionIdList,
-            2,
+            1,
             0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -1435,7 +1435,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         mintOptions(
             panopticPool,
             positionIdList,
-            1,
+            2,
             0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
@@ -1628,36 +1628,46 @@ contract CollateralTrackerTest is Test, PositionUtils {
         _grantTokens(Alice);
         IERC20Partial(token0).approve(address(collateralToken0), assets);
         collateralToken0.deposit(assets, Alice);
+        uint128 aliceBorrowAmount;
+        {
+            uint128 aliceSize = 100 ether;
+            mintOptions(
+                panopticPool,
+                positionIdList,
+                aliceSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK,
+                true
+            );
+            vm.stopPrank();
+            LeftRightUnsigned _amountsMoved = PanopticMath.getAmountsMoved(tokenId, aliceSize, 0);
 
-        uint128 aliceBorrowAmount = 100 ether;
-        mintOptions(
-            panopticPool,
-            positionIdList,
-            aliceBorrowAmount,
-            0,
-            Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            true
-        );
-        vm.stopPrank();
-
+            aliceBorrowAmount = _amountsMoved.rightSlot();
+        }
         // Bob deposits and borrows 50 ether (half of Alice)
         vm.startPrank(Bob);
         _grantTokens(Bob);
         IERC20Partial(token0).approve(address(collateralToken0), assets);
         collateralToken0.deposit(assets, Bob);
 
-        uint128 bobBorrowAmount = 50 ether;
-        mintOptions(
-            panopticPool,
-            positionIdList,
-            bobBorrowAmount,
-            0,
-            Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            true
-        );
-        vm.stopPrank();
+        uint128 bobBorrowAmount;
+        {
+            uint128 bobSize = 50 ether;
+            mintOptions(
+                panopticPool,
+                positionIdList,
+                bobSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK,
+                true
+            );
+            vm.stopPrank();
+            LeftRightUnsigned _amountsMoved = PanopticMath.getAmountsMoved(tokenId, bobSize, 0);
+
+            bobBorrowAmount = _amountsMoved.rightSlot();
+        }
 
         // Charlie deposits and borrows 50 ether (half of Alice)
         vm.startPrank(Charlie);
@@ -1665,17 +1675,24 @@ contract CollateralTrackerTest is Test, PositionUtils {
         IERC20Partial(token0).approve(address(collateralToken0), assets);
         collateralToken0.deposit(assets, Charlie);
 
-        uint128 charlieBorrowAmount = 50 ether;
-        mintOptions(
-            panopticPool,
-            positionIdList,
-            charlieBorrowAmount,
-            0,
-            Constants.MAX_V3POOL_TICK,
-            Constants.MIN_V3POOL_TICK,
-            true
-        );
-        vm.stopPrank();
+        uint128 charlieBorrowAmount;
+        {
+            uint128 charlieSize = 50 ether;
+            mintOptions(
+                panopticPool,
+                positionIdList,
+                charlieSize,
+                0,
+                Constants.MAX_V3POOL_TICK,
+                Constants.MIN_V3POOL_TICK,
+                true
+            );
+            vm.stopPrank();
+            LeftRightUnsigned _amountsMoved = PanopticMath.getAmountsMoved(tokenId, charlieSize, 0);
+
+            charlieBorrowAmount = _amountsMoved.rightSlot();
+        }
+
         uint256 initialTotalSupply = collateralToken0.totalSupply();
 
         // Record initial balances
@@ -2307,17 +2324,22 @@ contract CollateralTrackerTest is Test, PositionUtils {
         width = 2;
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
+        uint128 size = 100 ether;
 
         // Bob borrows a significant amount
         mintOptions(
             panopticPool,
             positionIdList,
-            100 ether, // Borrow same amount as deposit
+            size, // Borrow same amount as deposit
             0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
+
+        LeftRightUnsigned _amountsMoved = PanopticMath.getAmountsMoved(tokenId, size, 0);
+
+        uint128 borrowAmount = _amountsMoved.rightSlot();
 
         // Reduce Bob's balance to make him insolvent when interest accrues
         collateralToken0.setBalance(Bob, 1 ether); // Set very low balance
@@ -2353,7 +2375,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Bob's base index should not have been updated (remains at old value)
         (int128 baseIndex, int128 netBorrows) = collateralToken0.interestState(Bob);
-        assertEq(netBorrows, 100 ether, "Net borrows should remain unchanged");
+        assertEq(netBorrows, int128(borrowAmount), "Net borrows should remain unchanged");
         assertLt(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
     }
 
@@ -2715,16 +2737,21 @@ contract CollateralTrackerTest is Test, PositionUtils {
         tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
         positionIdList.push(tokenId);
 
+        uint128 size = 100 ether;
+
         // Bob borrows a significant amount
         mintOptions(
             panopticPool,
             positionIdList,
-            100 ether, // Borrow same amount as deposit
+            size, // Borrow same amount as deposit
             0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
+        LeftRightUnsigned _amountsMoved = PanopticMath.getAmountsMoved(tokenId, size, 0);
+
+        uint128 borrowAmount = _amountsMoved.rightSlot();
 
         // Reduce Bob's balance to make him insolvent when interest accrues
         collateralToken0.burnShares(Bob, collateralToken0.previewDeposit(99 ether));
@@ -2787,10 +2814,15 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertApproxEqAbs(
             aliceAssetsAfter - aliceAssetsBefore,
             expectedBonus,
-            1,
+            10,
             "FAIL: wrong bonus"
         );
 
+        assertLe(
+            aliceAssetsAfter - aliceAssetsBefore,
+            expectedBonus,
+            "FAIL: bad rounding in bonus calculation"
+        );
         assertApproxEqAbs(
             charlieAssetsAfter - charlieAssetsBefore,
             bobAssetsBefore - expectedBonus,

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -2279,7 +2279,7 @@ contract Misctest is Test, PositionUtils {
 
         vm.startPrank(Bob);
 
-        vm.expectRevert(stdError.divisionError);
+        vm.expectRevert(Errors.NetLiquidityZero.selector);
         mintOptions(
             pp,
             $tempIdList,
@@ -3319,13 +3319,13 @@ contract Misctest is Test, PositionUtils {
             // the positive premium is from the dummy short chunk
             assertEq(
                 int256(ct0.convertToAssets(ct0.balanceOf(Buyers[i]))) - int256(assetsBefore0),
-                i == 0 ? int256(107) : int256(108),
+                i == 0 ? int256(104) : int256(105),
                 "Buyer paid premium twice"
             );
 
             assertEq(
                 ct1.convertToAssets(ct1.balanceOf(Buyers[i])) - assetsBefore1,
-                1085,
+                1083,
                 "Buyer paid premium twice"
             );
         }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -5132,6 +5132,8 @@ contract Misctest is Test, PositionUtils {
                             console2.log("LONG: ZeroCollateralRequirement at strike:", strike);
                         } else if (receivedSelector == Errors.ZeroLiquidity.selector) {
                             console2.log("LONG: ZeroLiquidity at strike:", strike);
+                        } else if (receivedSelector == Errors.NetLiquidityZero.selector) {
+                            console2.log("LONG: NetLiquidityZero at strike:", strike);
                         } else {
                             // Unexpected error
                             console2.logBytes4(receivedSelector);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -4890,13 +4890,24 @@ contract Misctest is Test, PositionUtils {
             TokenId
                 .wrap(0)
                 .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
-                .addLeg(0, 1, 0, 0, 1, 0, int24(-665450), 2)
+                .addLeg(0, 1, 0, 0, 1, 0, int24(-654470), 2)
         );
 
         vm.startPrank(Bob);
 
+        vm.expectRevert(Errors.ZeroLiquidity.selector);
         mintOptions(pp, $posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
 
+        $posIdList.pop();
+
+        $posIdList.push(
+            TokenId
+                .wrap(0)
+                .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
+                .addLeg(0, 1, 0, 0, 1, 0, int24(-654470 + uniPool.tickSpacing()), 2)
+        );
+
+        mintOptions(pp, $posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
         (, , uint256[2][] memory positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
             Bob,
             false,

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -181,6 +181,8 @@ contract Misctest is Test, PositionUtils {
     address[] Buyer;
     SwapperC swapperc;
 
+    TokenId $tokenIdShort;
+    TokenId $tokenIdLong;
     TokenId[] $setupIdList;
     TokenId[] $posIdList;
     TokenId[][] $posIdLists;
@@ -4897,7 +4899,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(medianData != medianDataStale, "oracle median data updated");
     }
 
-    function test_Fuzz_NotionalReverts(uint128 positionSizeSeed, uint8 x) public {
+    function test_Fuzz_NotionalReverts_shorts(uint128 positionSizeSeed, uint8 x) public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -4905,8 +4907,13 @@ contract Misctest is Test, PositionUtils {
         token0.approve(address(swapperc), type(uint128).max);
         token1.approve(address(swapperc), type(uint128).max);
         uint64 poolId = PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing());
-        (int24 minTick, int24 maxTick) = sfpm.getEnforcedTickLimits(poolId);
-        uint256 n = uint256(uint24(maxTick - minTick)) / uint24(1000 * uniPool.tickSpacing());
+        uint256 n;
+        int24 minTick;
+        {
+            int24 maxTick;
+            (minTick, maxTick) = sfpm.getEnforcedTickLimits(poolId);
+            n = uint256(uint24(maxTick - minTick)) / uint24(1000 * uniPool.tickSpacing());
+        }
         vm.startPrank(Bob);
         uint128 positionSize = uint128(_boundLog(positionSizeSeed, 0, 128));
 
@@ -4914,11 +4921,15 @@ contract Misctest is Test, PositionUtils {
             // mint OTM position
             int24 strike = int24(minTick + int256(i + 1) * 1000 * uniPool.tickSpacing());
 
-            $posIdList.push(
-                TokenId
-                    .wrap(0)
-                    .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
-                    .addLeg(0, ((x >> 2) % 127) + 1, x % 2, 0, (x >> 1) % 2, 0, strike, 2)
+            $tokenIdShort = TokenId.wrap(0).addPoolId(poolId).addLeg(
+                0,
+                1,
+                x % 2,
+                0,
+                (x >> 1) % 2,
+                0,
+                strike,
+                2
             );
             uint128[] memory sizeList = new uint128[](1);
             uint64[] memory spreadList = new uint64[](1);
@@ -4927,10 +4938,7 @@ contract Misctest is Test, PositionUtils {
 
             sizeList[0] = positionSize;
             spreadList[0] = 0;
-            mintList[0] = TokenId
-                .wrap(0)
-                .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
-                .addLeg(0, 1, 0, 0, 1, 0, strike, 2);
+            mintList[0] = $tokenIdShort;
             tickLimits[0][0] = int24(-887272);
             tickLimits[0][1] = int24(887272);
 
@@ -4978,8 +4986,172 @@ contract Misctest is Test, PositionUtils {
                         console2.log("ZeroLiquidity at strike:", strike);
                     } else if (receivedSelector == 0x08c379a0) {
                         console2.log("Uniswap constraint at strike:", strike);
-                    } else if (receivedSelector == Errors.CastingError.selector) {
-                        console2.log("CastingError at strike:", strike);
+                    } else if (receivedSelector == Errors.LiquidityTooHigh.selector) {
+                        console2.log("LiquidityTooHigh at strike:", strike);
+                    } else if (receivedSelector == Errors.AccountInsolvent.selector) {
+                        console2.log("AccountInsolvent at strike:", strike);
+                    } else if (receivedSelector == Errors.PositionTooLarge.selector) {
+                        console2.log("PositionTooLarge at strike:", strike);
+                        // Position size exceeds protocol limits
+                    } else {
+                        // Unexpected error
+                        console2.logBytes4(receivedSelector);
+                        console2.logBytes(reason);
+                        revert(string(abi.encodePacked("Unexpected error")));
+                    }
+                }
+            }
+        }
+    }
+
+    function test_Fuzz_NotionalReverts_longs(uint128 positionSizeSeed, uint8 x) public {
+        swapperc = new SwapperC();
+        vm.startPrank(Swapper);
+        token0.mint(Swapper, type(uint128).max);
+        token1.mint(Swapper, type(uint128).max);
+        token0.approve(address(swapperc), type(uint128).max);
+        token1.approve(address(swapperc), type(uint128).max);
+        uint64 poolId = PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing());
+        uint256 n;
+        int24 minTick;
+        {
+            int24 maxTick;
+            (minTick, maxTick) = sfpm.getEnforcedTickLimits(poolId);
+            n = uint256(uint24(maxTick - minTick)) / uint24(1000 * uniPool.tickSpacing());
+        }
+        vm.startPrank(Bob);
+        uint128 positionSize = uint128(_boundLog(positionSizeSeed, 0, 128));
+
+        for (uint256 i = 0; i < n; ++i) {
+            // mint OTM position
+            int24 strike = int24(minTick + int256(i + 1) * 1000 * uniPool.tickSpacing());
+
+            $tokenIdShort = TokenId.wrap(0).addPoolId(poolId).addLeg(
+                0,
+                10,
+                x % 2,
+                0,
+                (x >> 1) % 2,
+                0,
+                strike,
+                2
+            );
+            uint128[] memory sizeList = new uint128[](1);
+            uint64[] memory spreadList = new uint64[](1);
+            TokenId[] memory mintList = new TokenId[](1);
+            int24[2][] memory tickLimits = new int24[2][](1);
+
+            sizeList[0] = positionSize;
+            spreadList[0] = type(uint64).max;
+            mintList[0] = $tokenIdShort;
+            tickLimits[0][0] = int24(-887272);
+            tickLimits[0][1] = int24(887272);
+
+            // Try to mint and check if it reverts
+            try pp.dispatch(mintList, mintList, sizeList, spreadList, tickLimits, true) {
+                // SUCCESS CASE - mintOptions didn't revert
+
+                // Alice Buys
+                vm.startPrank(Alice);
+
+                {
+                    uint256 asset = x % 2;
+                    uint256 tokenType;
+                    uint64 _poolId = poolId;
+                    $tokenIdLong = TokenId.wrap(0).addPoolId(_poolId).addLeg(
+                        0,
+                        9,
+                        asset,
+                        1,
+                        tokenType,
+                        0,
+                        strike,
+                        2
+                    );
+                }
+                mintList[0] = $tokenIdLong;
+                try pp.dispatch(mintList, mintList, sizeList, spreadList, tickLimits, true) {
+                    console2.log("Found non-reverting strike:", strike);
+                    (, , uint256[2][] memory positionBalanceArray) = pp
+                        .getAccumulatedFeesAndPositionsData(Alice, false, mintList);
+
+                    (, currentTick, , , , , ) = uniPool.slot0();
+
+                    LeftRightUnsigned tokenData0 = ct0.getAccountMarginDetails(
+                        Alice,
+                        currentTick,
+                        positionBalanceArray,
+                        0,
+                        0
+                    );
+
+                    LeftRightUnsigned tokenData1 = ct1.getAccountMarginDetails(
+                        Alice,
+                        currentTick,
+                        positionBalanceArray,
+                        0,
+                        0
+                    );
+
+                    (uint256 balanceCross, uint256 requiredCross) = PanopticMath.getCrossBalances(
+                        tokenData0,
+                        tokenData1,
+                        Math.getSqrtRatioAtTick(currentTick)
+                    );
+
+                    assertTrue(requiredCross > 0, "zero collateral requirement");
+                    assertTrue(requiredCross <= balanceCross, "account is solvent");
+
+                    burnOptions(
+                        pp,
+                        mintList,
+                        new TokenId[](0),
+                        int24(-887272),
+                        int24(887272),
+                        true
+                    );
+                } catch (bytes memory reason) {
+                    if (reason.length >= 4) {
+                        bytes4 receivedSelector = bytes4(reason);
+                        if (receivedSelector == Errors.NotEnoughLiquidity.selector) {
+                            console2.log("LONG: NotEnoughLiquidity at strike:", strike);
+                        } else if (
+                            receivedSelector == Errors.EffectiveLiquidityAboveThreshold.selector
+                        ) {
+                            console2.log(
+                                "LONG: EffectiveLiquidityAboveThreshold at strike:",
+                                strike
+                            );
+                        } else if (receivedSelector == Errors.NotEnoughTokens.selector) {
+                            console2.log("LONG: NotEnoughTokens at strike:", strike);
+                        } else if (receivedSelector == Errors.ZeroCollateralRequirement.selector) {
+                            console2.log("LONG: ZeroCollateralRequirement at strike:", strike);
+                        } else if (receivedSelector == Errors.ZeroLiquidity.selector) {
+                            console2.log("LONG: ZeroLiquidity at strike:", strike);
+                        } else {
+                            // Unexpected error
+                            console2.logBytes4(receivedSelector);
+                            console2.logBytes(reason);
+                            revert(string(abi.encodePacked("Unexpected error")));
+                        }
+                    }
+                }
+
+                vm.startPrank(Bob);
+                mintList[0] = $tokenIdShort;
+                burnOptions(pp, mintList, new TokenId[](0), int24(-887272), int24(887272), true);
+            } catch (bytes memory reason) {
+                if (reason.length >= 4) {
+                    bytes4 receivedSelector = bytes4(reason);
+
+                    if (receivedSelector == Errors.ZeroLiquidity.selector) {
+                        console2.log("ZeroLiquidity at strike:", strike);
+                    } else if (receivedSelector == 0x08c379a0) {
+                        console2.log("Uniswap constraint at strike:", strike);
+                    } else if (receivedSelector == Errors.LiquidityTooHigh.selector) {
+                        console2.log("LiquidityTooHigh at strike:", strike);
+                    } else if (receivedSelector == Errors.NotEnoughLiquidity.selector) {
+                        console2.log("NotEnoughLiquidity at strike:", strike);
                     } else if (receivedSelector == Errors.AccountInsolvent.selector) {
                         console2.log("AccountInsolvent at strike:", strike);
                     } else if (receivedSelector == Errors.PositionTooLarge.selector) {

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -192,6 +192,25 @@ contract Misctest is Test, PositionUtils {
     TokenId[][] positionIdLists;
     TokenId[][] collateralIdLists;
 
+    function _boundLog(
+        uint256 x,
+        uint8 min,
+        uint8 max
+    ) internal pure virtual returns (uint256 result) {
+        require(min <= max, "StdUtils boundLog(uint256,uint8,uint8): Max is less than min.");
+
+        // If x is between min and max, DO NOT return x directly. This is to ensure that the sampling remains uniform in log space
+
+        // select an exponent between [min, max]
+        uint256 range = uint256(max) - uint256(min) + 1;
+        uint256 m0 = min + (x % range);
+
+        // randomize the input value, use it to generate a number between 2 ** m0 and 2 **(m0+1)-1
+        x = uint256(keccak256(abi.encode(x)));
+        uint256 m1 = x % 2 ** max;
+        result = 2 ** m0 + (m1 >> (max - m0));
+    }
+
     function setUp() public {
         vm.startPrank(Deployer);
 
@@ -4878,69 +4897,103 @@ contract Misctest is Test, PositionUtils {
         assertTrue(medianData != medianDataStale, "oracle median data updated");
     }
 
-    function test_success_NotionalRounding() public {
+    function test_Fuzz_NotionalReverts(uint128 positionSizeSeed, uint8 x) public {
         swapperc = new SwapperC();
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
         token1.mint(Swapper, type(uint128).max);
         token0.approve(address(swapperc), type(uint128).max);
         token1.approve(address(swapperc), type(uint128).max);
-        // mint OTM position
-        $posIdList.push(
-            TokenId
-                .wrap(0)
-                .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
-                .addLeg(0, 1, 0, 0, 1, 0, int24(-654470), 2)
-        );
-
+        uint64 poolId = PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing());
+        (int24 minTick, int24 maxTick) = sfpm.getEnforcedTickLimits(poolId);
+        uint256 n = uint256(uint24(maxTick - minTick)) / uint24(1000 * uniPool.tickSpacing());
         vm.startPrank(Bob);
+        uint128 positionSize = uint128(_boundLog(positionSizeSeed, 0, 128));
 
-        vm.expectRevert(Errors.ZeroLiquidity.selector);
-        mintOptions(pp, $posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
+        for (uint256 i = 0; i < n; ++i) {
+            // mint OTM position
+            int24 strike = int24(minTick + int256(i + 1) * 1000 * uniPool.tickSpacing());
 
-        $posIdList.pop();
+            $posIdList.push(
+                TokenId
+                    .wrap(0)
+                    .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
+                    .addLeg(0, ((x >> 2) % 127) + 1, x % 2, 0, (x >> 1) % 2, 0, strike, 2)
+            );
+            uint128[] memory sizeList = new uint128[](1);
+            uint64[] memory spreadList = new uint64[](1);
+            TokenId[] memory mintList = new TokenId[](1);
+            int24[2][] memory tickLimits = new int24[2][](1);
 
-        $posIdList.push(
-            TokenId
+            sizeList[0] = positionSize;
+            spreadList[0] = 0;
+            mintList[0] = TokenId
                 .wrap(0)
                 .addPoolId(PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing()))
-                .addLeg(0, 1, 0, 0, 1, 0, int24(-654470 + uniPool.tickSpacing()), 2)
-        );
+                .addLeg(0, 1, 0, 0, 1, 0, strike, 2);
+            tickLimits[0][0] = int24(-887272);
+            tickLimits[0][1] = int24(887272);
 
-        mintOptions(pp, $posIdList, 2 ** 95, 0, int24(887272), int24(-887272), true);
-        (, , uint256[2][] memory positionBalanceArray) = pp.getAccumulatedFeesAndPositionsData(
-            Bob,
-            false,
-            $posIdList
-        );
+            // Try to mint and check if it reverts
+            try pp.dispatch(mintList, mintList, sizeList, spreadList, tickLimits, true) {
+                // SUCCESS CASE - mintOptions didn't revert
+                console2.log("Found non-reverting strike:", strike);
 
-        (, currentTick, , , , , ) = uniPool.slot0();
+                (, , uint256[2][] memory positionBalanceArray) = pp
+                    .getAccumulatedFeesAndPositionsData(Bob, false, mintList);
 
-        LeftRightUnsigned tokenData0 = ct0.getAccountMarginDetails(
-            Bob,
-            currentTick,
-            positionBalanceArray,
-            0,
-            0
-        );
+                (, currentTick, , , , , ) = uniPool.slot0();
 
-        LeftRightUnsigned tokenData1 = ct1.getAccountMarginDetails(
-            Bob,
-            currentTick,
-            positionBalanceArray,
-            0,
-            0
-        );
-        (uint256 balanceCross, uint256 requiredCross) = PanopticMath.getCrossBalances(
-            tokenData0,
-            tokenData1,
-            Math.getSqrtRatioAtTick(currentTick)
-        );
+                LeftRightUnsigned tokenData0 = ct0.getAccountMarginDetails(
+                    Bob,
+                    currentTick,
+                    positionBalanceArray,
+                    0,
+                    0
+                );
 
-        assertTrue(requiredCross > 0, "zero collateral requirement");
-        assertTrue(requiredCross <= balanceCross, "account is solvent");
+                LeftRightUnsigned tokenData1 = ct1.getAccountMarginDetails(
+                    Bob,
+                    currentTick,
+                    positionBalanceArray,
+                    0,
+                    0
+                );
 
-        burnOptions(pp, $posIdList[0], new TokenId[](0), int24(887272), int24(-887272), true);
+                (uint256 balanceCross, uint256 requiredCross) = PanopticMath.getCrossBalances(
+                    tokenData0,
+                    tokenData1,
+                    Math.getSqrtRatioAtTick(currentTick)
+                );
+
+                assertTrue(requiredCross > 0, "zero collateral requirement");
+                assertTrue(requiredCross <= balanceCross, "account is solvent");
+
+                burnOptions(pp, mintList, new TokenId[](0), int24(-887272), int24(887272), true);
+            } catch (bytes memory reason) {
+                if (reason.length >= 4) {
+                    bytes4 receivedSelector = bytes4(reason);
+
+                    if (receivedSelector == Errors.ZeroLiquidity.selector) {
+                        console2.log("ZeroLiquidity at strike:", strike);
+                    } else if (receivedSelector == 0x08c379a0) {
+                        console2.log("Uniswap constraint at strike:", strike);
+                    } else if (receivedSelector == Errors.CastingError.selector) {
+                        console2.log("CastingError at strike:", strike);
+                    } else if (receivedSelector == Errors.AccountInsolvent.selector) {
+                        console2.log("AccountInsolvent at strike:", strike);
+                    } else if (receivedSelector == Errors.PositionTooLarge.selector) {
+                        console2.log("PositionTooLarge at strike:", strike);
+                        // Position size exceeds protocol limits
+                    } else {
+                        // Unexpected error
+                        console2.logBytes4(receivedSelector);
+                        console2.logBytes(reason);
+                        revert(string(abi.encodePacked("Unexpected error")));
+                    }
+                }
+            }
+        }
     }
 
     function test_success_PremiumRollover() public {

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -4907,13 +4907,15 @@ contract Misctest is Test, PositionUtils {
         token0.approve(address(swapperc), type(uint128).max);
         token1.approve(address(swapperc), type(uint128).max);
         uint64 poolId = PanopticMath.getPoolId(address(uniPool), uniPool.tickSpacing());
+
         uint256 n;
         int24 minTick;
         {
-            int24 maxTick;
-            (minTick, maxTick) = sfpm.getEnforcedTickLimits(poolId);
+            minTick = (-887272 / uniPool.tickSpacing() + 1) * uniPool.tickSpacing();
+            int24 maxTick = (887272 / uniPool.tickSpacing()) * uniPool.tickSpacing();
             n = uint256(uint24(maxTick - minTick)) / uint24(1000 * uniPool.tickSpacing());
         }
+
         vm.startPrank(Bob);
         uint128 positionSize = uint128(_boundLog(positionSizeSeed, 0, 128));
 
@@ -4984,6 +4986,8 @@ contract Misctest is Test, PositionUtils {
 
                     if (receivedSelector == Errors.ZeroLiquidity.selector) {
                         console2.log("ZeroLiquidity at strike:", strike);
+                    } else if (receivedSelector == Errors.InvalidTickBound.selector) {
+                        console2.log("InvalidTickBound at strike:", strike);
                     } else if (receivedSelector == 0x08c379a0) {
                         console2.log("Uniswap constraint at strike:", strike);
                     } else if (receivedSelector == Errors.LiquidityTooHigh.selector) {
@@ -5015,8 +5019,8 @@ contract Misctest is Test, PositionUtils {
         uint256 n;
         int24 minTick;
         {
-            int24 maxTick;
-            (minTick, maxTick) = sfpm.getEnforcedTickLimits(poolId);
+            minTick = (-887272 / uniPool.tickSpacing() + 1) * uniPool.tickSpacing();
+            int24 maxTick = (887272 / uniPool.tickSpacing()) * uniPool.tickSpacing();
             n = uint256(uint24(maxTick - minTick)) / uint24(1000 * uniPool.tickSpacing());
         }
         vm.startPrank(Bob);
@@ -5024,7 +5028,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < n; ++i) {
             // mint OTM position
-            int24 strike = int24(minTick + int256(i + 1) * 1000 * uniPool.tickSpacing());
+            int24 strike = int24(-887270 + int256(i + 1) * 1000 * uniPool.tickSpacing());
 
             $tokenIdShort = TokenId.wrap(0).addPoolId(poolId).addLeg(
                 0,
@@ -5146,6 +5150,8 @@ contract Misctest is Test, PositionUtils {
 
                     if (receivedSelector == Errors.ZeroLiquidity.selector) {
                         console2.log("ZeroLiquidity at strike:", strike);
+                    } else if (receivedSelector == Errors.InvalidTickBound.selector) {
+                        console2.log("InvalidTickBound at strike:", strike);
                     } else if (receivedSelector == 0x08c379a0) {
                         console2.log("Uniswap constraint at strike:", strike);
                     } else if (receivedSelector == Errors.LiquidityTooHigh.selector) {

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -154,6 +154,9 @@ contract PanopticPoolTest is PositionUtils {
     int256 rangesFromStrike;
     int256[2] exerciseFeeAmounts;
 
+    LeftRightSigned $longAmounts;
+    LeftRightSigned $shortAmounts;
+
     PanopticFactory factory;
     PanopticPoolHarness pp;
     CollateralTracker ct0;
@@ -6303,21 +6306,24 @@ contract PanopticPoolTest is PositionUtils {
         TokenId tokenId = TokenId.wrap(0).addPoolId(poolId);
 
         for (uint256 i = 0; i < numLegs; ++i) {
-            tokenId = tokenId.addLeg(i, 1, isWETH, 0, tokenTypes[i], i, strikes[i], widths[i]);
+            tokenId = tokenId.addLeg(i, 2, isWETH, 0, tokenTypes[i], i, strikes[i], widths[i]); // option ratio = 2
         }
 
         TokenId[] memory posIdList = new TokenId[](1);
         posIdList[0] = tokenId;
 
+        console2.log("mint Short option(s)");
         mintOptions(
             pp,
             posIdList,
-            positionSize * 2,
+            positionSize,
             0,
             Constants.MAX_V3POOL_TICK,
             Constants.MIN_V3POOL_TICK,
             true
         );
+
+        ($longAmounts, $shortAmounts) = PanopticMath.computeExercisedAmounts(tokenId, positionSize);
 
         // now we can mint the long option we are force exercising
         vm.startPrank(Alice);
@@ -6340,7 +6346,7 @@ contract PanopticPoolTest is PositionUtils {
 
         posIdList[0] = tokenId;
 
-        (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
+        (LeftRightSigned longAmountsAlice, LeftRightSigned shortAmountsAlice) = PanopticMath
             .computeExercisedAmounts(tokenId, positionSize);
 
         {
@@ -6352,6 +6358,7 @@ contract PanopticPoolTest is PositionUtils {
             int24[2][] memory tickLimits = new int24[2][](1);
             tickLimits[0][0] = Constants.MAX_V3POOL_TICK;
             tickLimits[0][1] = Constants.MIN_V3POOL_TICK;
+            console2.log("mint Long option(s)");
             try pp.dispatch(posIdList, posIdList, sizeList, spreadList, tickLimits, true) {} catch (
                 bytes memory reason
             ) {
@@ -6373,7 +6380,7 @@ contract PanopticPoolTest is PositionUtils {
         updatePositionDataVariable(numLegs, isLongs);
 
         updateITMAmountsBurn(numLegs, tokenTypes);
-        updateIntrinsicValueBurn(longAmounts, shortAmounts);
+        updateIntrinsicValueBurn(longAmountsAlice, shortAmountsAlice);
 
         ($shortPremia, $longPremia, ) = pp.getAccumulatedFeesAndPositionsData(
             Alice,
@@ -6439,9 +6446,10 @@ contract PanopticPoolTest is PositionUtils {
         // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
         int256 exerciseFee = int256(-1024) >> uint256(rangesFromStrike);
 
-        exerciseFeeAmounts[0] += (longAmounts.rightSlot() * (-exerciseFee)) / 10_000;
-        exerciseFeeAmounts[1] += (longAmounts.leftSlot() * (-exerciseFee)) / 10_000;
+        exerciseFeeAmounts[0] += (longAmountsAlice.rightSlot() * (-exerciseFee)) / 10_000;
+        exerciseFeeAmounts[1] += (longAmountsAlice.leftSlot() * (-exerciseFee)) / 10_000;
         vm.assume(Math.abs(TWAPtick - currentTick) < 513);
+        console2.log("force exercise option(s)");
         forceExercise(
             pp,
             Alice,
@@ -6470,20 +6478,14 @@ contract PanopticPoolTest is PositionUtils {
 
         {
             (, uint256 inAMM, ) = ct0.getPoolData();
-            assertApproxEqAbs(
-                inAMM,
-                uint128(longAmounts.rightSlot() + shortAmounts.rightSlot()) * 2,
-                10
-            );
+            uint128 tokenFlow0 = uint128($shortAmounts.rightSlot() - $longAmounts.rightSlot());
+            assertApproxEqAbs(inAMM, tokenFlow0, 10, "fail: inAMM0");
         }
 
         {
             (, uint256 inAMM, ) = ct1.getPoolData();
-            assertApproxEqAbs(
-                inAMM,
-                uint128(longAmounts.leftSlot() + shortAmounts.leftSlot()) * 2,
-                10
-            );
+            uint128 tokenFlow1 = uint128($shortAmounts.leftSlot() - $longAmounts.leftSlot());
+            assertApproxEqAbs(inAMM, tokenFlow1, 10, "fail: inAMM1");
         }
         {
             assertEq(pp.positionsHash(Alice), 0);
@@ -6524,7 +6526,11 @@ contract PanopticPoolTest is PositionUtils {
                     int256(lastCollateralBalance0[Alice]),
                 $balanceDelta0,
                 uint256(
-                    int256((longAmounts.rightSlot() + shortAmounts.rightSlot()) / 1_00_000 + 10)
+                    int256(
+                        (longAmountsAlice.rightSlot() + shortAmountsAlice.rightSlot()) /
+                            1_00_000 +
+                            10
+                    )
                 ),
                 "Incorrect balance delta for token0 (Force Exercisee)"
             );
@@ -6533,7 +6539,11 @@ contract PanopticPoolTest is PositionUtils {
                     int256(lastCollateralBalance1[Alice]),
                 $balanceDelta1,
                 uint256(
-                    int256((longAmounts.leftSlot() + shortAmounts.leftSlot()) / 1_000_000 + 10)
+                    int256(
+                        (longAmountsAlice.leftSlot() + shortAmountsAlice.leftSlot()) /
+                            1_000_000 +
+                            10
+                    )
                 ),
                 "Incorrect balance delta for token1 (Force Exercisee)"
             );

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -2597,6 +2597,142 @@ contract PanopticPoolTest is PositionUtils {
         }
     }
 
+    function test_Success_mintOptions_ITMShortPut_0(
+        uint256 x,
+        uint256 widthSeed,
+        int256 strikeSeed,
+        uint256 positionSizeSeed
+    ) public {
+        _initPool(x);
+
+        (int24 width, int24 strike) = PositionUtils.getITMSW(
+            widthSeed,
+            strikeSeed,
+            uint24(tickSpacing),
+            currentTick,
+            1
+        );
+
+        populatePositionData(width, strike, positionSizeSeed);
+
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0,
+            1,
+            isWETH,
+            0,
+            1,
+            0,
+            strike,
+            width
+        );
+
+        uint256 expectedSwap1;
+        {
+            int256 amount0Required = SqrtPriceMath.getAmount0Delta(
+                currentSqrtPriceX96 < sqrtLower ? sqrtLower : currentSqrtPriceX96,
+                sqrtUpper,
+                int128(expectedLiq)
+            );
+
+            console2.log("amount0R", amount0Required);
+            (, expectedSwap1) = PositionUtils.simulateSwap(
+                pool,
+                tickLower,
+                tickUpper,
+                expectedLiq,
+                router,
+                token0,
+                token1,
+                fee,
+                false,
+                -amount0Required
+            );
+            console2.log("expectedSwap1", expectedSwap1);
+            vm.startPrank(Alice);
+        }
+
+        console2.log("positionSize", positionSize);
+        {
+            TokenId[] memory posIdList = new TokenId[](1);
+            posIdList[0] = tokenId;
+
+            // reversing the tick limits here to make sure they get entered into the SFPM properly
+            // this test will fail if it does not (because no ITM swaps will occur)
+            mintOptions(pp, posIdList, positionSize, 0, TickMath.MAX_TICK, TickMath.MIN_TICK, true);
+        }
+
+        assertEq(sfpm.balanceOf(address(pp), TokenId.unwrap(tokenId)), positionSize);
+
+        console2.log("expectedLi", expectedLiq);
+        uint256 amount1 = LiquidityAmounts.getAmount1ForLiquidity(
+            sqrtLower,
+            sqrtUpper,
+            expectedLiq
+        );
+
+        {
+            (, uint256 inAMM, ) = ct0.getPoolData();
+            assertEq(inAMM, 0, "inAMM0");
+        }
+
+        {
+            (, uint256 inAMM, ) = ct1.getPoolData();
+            assertApproxEqAbs(inAMM, amount1, 10, "inAMM1");
+        }
+
+        {
+            assertEq(
+                pp.positionsHash(Alice),
+                uint248(uint256(keccak256(abi.encodePacked(tokenId))))
+            );
+
+            assertEq(pp.numberOfLegs(Alice), 1);
+
+            (uint128 balance, uint64 poolUtilization0, uint64 poolUtilization1) = ph
+                .optionPositionInfo(pp, Alice, tokenId);
+
+            assertEq(balance, positionSize, "balance");
+            assertEq(poolUtilization1, (amount1 * 10000) / ct1.totalSupply(), "utilization 1");
+            assertEq(poolUtilization0, 0, "utilization 0");
+        }
+
+        {
+            (, LeftRightSigned shortAmounts) = PanopticMath.computeExercisedAmounts(
+                tokenId,
+                positionSize
+            );
+
+            int256 amount1Moved = currentSqrtPriceX96 < sqrtLower
+                ? int256(0)
+                : SqrtPriceMath.getAmount1Delta(
+                    sqrtLower,
+                    currentSqrtPriceX96 > sqrtUpper ? sqrtUpper : currentSqrtPriceX96,
+                    int128(expectedLiq)
+                );
+
+            int256 notionalVal = int256(expectedSwap1) + amount1Moved - shortAmounts.leftSlot();
+
+            // set itm spread fee to 0
+            int256 ITMSpread = notionalVal > 0
+                ? (notionalVal * int24(2 * ((0 * fee) / 100))) / 10_000
+                : -(notionalVal * int24(2 * ((0 * fee) / 100))) / 10_000;
+
+            assertApproxEqAbs(
+                ct1.balanceOf(Alice),
+                uint256(
+                    int256(uint256(type(uint104).max)) -
+                        notionalVal -
+                        (shortAmounts.leftSlot() * 10) /
+                        10_000
+                ),
+                uint256(int256(shortAmounts.leftSlot()) / 1_000_000 + 10),
+                "alice balance 1"
+            );
+
+            assertEq(ct0.balanceOf(Alice), uint256(type(uint104).max), "alice balance 0");
+        }
+    }
+
     function test_Success_mintOptions_ITMShortCall(
         uint256 x,
         uint256 widthSeed,
@@ -2633,6 +2769,7 @@ contract PanopticPoolTest is PositionUtils {
                 sqrtUpper > currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtUpper,
                 int128(expectedLiq)
             );
+            console2.log("amount1R", amount1Required);
 
             (expectedSwap0, ) = PositionUtils.simulateSwap(
                 pool,
@@ -2647,6 +2784,7 @@ contract PanopticPoolTest is PositionUtils {
                 -amount1Required
             );
 
+            console2.log("expectedSwap0", expectedSwap0);
             vm.startPrank(Alice);
         }
 

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -6,6 +6,7 @@ import {stdMath} from "forge-std/StdMath.sol";
 import {Errors} from "@libraries/Errors.sol";
 import {Math} from "@libraries/Math.sol";
 import {PanopticMath} from "@libraries/PanopticMath.sol";
+import {LiquidityChunk} from "@types/LiquidityChunk.sol";
 import {CallbackLib} from "@libraries/CallbackLib.sol";
 import {TokenId} from "@types/TokenId.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
@@ -32,6 +33,10 @@ contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
 
     function addrToPoolId(address pool) public view returns (uint256) {
         return s_AddrToPoolIdData[pool];
+    }
+
+    function poolIdToPoolData(uint64 poolId) public view returns (PoolData memory) {
+        return s_poolIdToPoolData[poolId];
     }
 }
 
@@ -2666,6 +2671,205 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             int256(balance1Before) + amount1MovedsBurn[0] + amount1MovedsBurn[1],
             10
         );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         FUZZ: MINT/BURN AMOUNTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Fuzz_mint_burn_TokenizedPosition_amountsMoved(uint256 x) public {
+        _initPool(x);
+
+        SemiFungiblePositionManager.PoolData memory poolData;
+        poolData = sfpm.poolIdToPoolData(poolId);
+
+        int24 width = int24(uint24(((x >> 48) % 2047) + 1));
+        int24 strike = int24(
+            bound(
+                int256(x >> 64),
+                poolData.minEnforcedTick + (width * tickSpacing) / 2,
+                poolData.maxEnforcedTick - (width * tickSpacing) / 2
+            )
+        );
+        strike = (strike / tickSpacing) * tickSpacing + (tickSpacing / 2) * (width % 2);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        vm.assume(
+            (strike - (width * tickSpacing) / 2 > currentTick) ||
+                (strike + (width * tickSpacing) / 2) < currentTick
+        );
+
+        positionSize = uint128(x >> 128);
+
+        uint256 asset = (x >> 1) % 2;
+        uint128 ratio = uint128((x % 127) + 1); // ratio
+        uint256 tokenType = (x >> 2) % 2;
+        tickLower = int24(strike - (width * tickSpacing) / 2);
+        tickUpper = int24(strike + (width * tickSpacing) / 2);
+        sqrtLower = TickMath.getSqrtRatioAtTick(tickLower);
+        sqrtUpper = TickMath.getSqrtRatioAtTick(tickUpper);
+
+        //console2.log('dd', getContractsForAmountAtTick(currentTick, tickLower, tickUpper, asset, positionSize));
+
+        //positionSize = uint128(
+        //    getContractsForAmountAtTick(currentTick, tickLower, tickUpper, asset, positionSize)
+        //)/ratio;
+
+        positionSize = uint128(bound(positionSize, 1, type(uint128).max)) / ratio;
+        console2.log("ss", positionSize, ratio);
+        {
+            uint256 explicitLiq = asset == 0
+                ? Math.mulDiv(
+                    positionSize * ratio,
+                    Math.mulDiv(sqrtLower, sqrtUpper, 2 ** 96),
+                    sqrtUpper - sqrtLower
+                )
+                : Math.mulDiv(positionSize * ratio, 2 ** 96, sqrtUpper - sqrtLower);
+            console2.log("exp", explicitLiq);
+
+            expectedLiq = uint128(explicitLiq);
+        }
+        vm.assume(expectedLiq < pool.maxLiquidityPerTick());
+        vm.assume(expectedLiq > 0);
+
+        int256 amountMoved0 = SqrtPriceMath.getAmount0Delta(
+            sqrtLower < currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtLower,
+            sqrtUpper,
+            int128(expectedLiq * ratio)
+        );
+        int256 amountMoved1 = SqrtPriceMath.getAmount1Delta(
+            sqrtLower,
+            sqrtUpper > currentSqrtPriceX96 ? currentSqrtPriceX96 : sqrtUpper,
+            int128(expectedLiq * ratio)
+        );
+
+        vm.assume((amountMoved0 <= type(int128).max - 4) && (amountMoved1 < type(int128).max - 4));
+
+        console2.log("aM0", amountMoved0);
+        console2.log("aM1", amountMoved1);
+        /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
+        TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
+            0, // index
+            ratio, // ratio
+            asset, // asset
+            0, // isLong
+            tokenType, // tokenType
+            0, // riskPartnet
+            strike,
+            width
+        );
+
+        uint256 aliceBefore0 = IERC20Partial(token0).balanceOf(Alice);
+        uint256 aliceBefore1 = IERC20Partial(token1).balanceOf(Alice);
+
+        (LeftRightUnsigned[4] memory collectedByLeg, LeftRightSigned totalSwapped) = sfpm
+            .mintTokenizedPosition(
+                tokenId,
+                uint128(positionSize),
+                TickMath.MIN_TICK,
+                TickMath.MAX_TICK
+            );
+
+        LeftRightUnsigned _amountsMoved = PanopticMath.getAmountsMoved(tokenId, positionSize, 0);
+
+        assertEq(
+            totalSwapped.rightSlot(),
+            currentTick < tickLower ? int128(_amountsMoved.rightSlot()) : int256(0),
+            "amount moved 0"
+        );
+        assertEq(
+            totalSwapped.leftSlot(),
+            currentTick > tickUpper ? int128(_amountsMoved.leftSlot()) : int256(0),
+            "amount moved 1"
+        );
+
+        uint256 aliceAfter0 = IERC20Partial(token0).balanceOf(Alice);
+        uint256 aliceAfter1 = IERC20Partial(token1).balanceOf(Alice);
+
+        assertEq(
+            (aliceBefore0 - aliceAfter0),
+            currentTick < tickLower ? _amountsMoved.rightSlot() : 0,
+            "balance delta 0"
+        );
+        assertEq(
+            (aliceBefore1 - aliceAfter1),
+            currentTick > tickUpper ? _amountsMoved.leftSlot() : 0,
+            "balance delta 1"
+        );
+
+        assertEq(sfpm.balanceOf(Alice, TokenId.unwrap(tokenId)), positionSize, "pSize");
+
+        accountLiquidities = sfpm.getAccountLiquidity(
+            address(pool),
+            Alice,
+            tokenType,
+            tickLower,
+            tickUpper
+        );
+
+        assertEq(accountLiquidities.leftSlot(), 0, "account liquidities");
+        assertEq(accountLiquidities.rightSlot(), expectedLiq, "expectedLiq");
+
+        (uint256 realLiq, , , , ) = pool.positions(
+            keccak256(abi.encodePacked(address(sfpm), tickLower, tickUpper))
+        );
+
+        assertEq(realLiq, expectedLiq);
+
+        (collectedByLeg, totalSwapped) = sfpm.burnTokenizedPosition(
+            tokenId,
+            uint128(positionSize),
+            TickMath.MIN_TICK,
+            TickMath.MAX_TICK
+        );
+
+        _amountsMoved = PanopticMath.getAmountsMoved(tokenId.flipToBurnToken(), positionSize, 0);
+
+        assertEq(
+            totalSwapped.rightSlot(),
+            currentTick < tickLower ? -int128(_amountsMoved.rightSlot()) : int256(0),
+            "amount moved 0"
+        );
+        assertEq(
+            totalSwapped.leftSlot(),
+            currentTick > tickUpper ? -int128(_amountsMoved.leftSlot()) : int256(0),
+            "amount moved 1"
+        );
+
+        {
+            uint256 aliceAfterBurn0 = IERC20Partial(token0).balanceOf(Alice);
+            uint256 aliceAfterBurn1 = IERC20Partial(token1).balanceOf(Alice);
+            assertEq(
+                (aliceAfterBurn0 - aliceAfter0),
+                currentTick < tickLower ? _amountsMoved.rightSlot() : 0,
+                "balance delta 0"
+            );
+            assertEq(
+                (aliceAfterBurn1 - aliceAfter1),
+                currentTick > tickUpper ? _amountsMoved.leftSlot() : 0,
+                "balance delta 1"
+            );
+        }
+        assertEq(sfpm.balanceOf(Alice, TokenId.unwrap(tokenId)), 0, "pSize");
+
+        {
+            accountLiquidities = sfpm.getAccountLiquidity(
+                address(pool),
+                Alice,
+                tokenType,
+                tickLower,
+                tickUpper
+            );
+
+            assertEq(accountLiquidities.leftSlot(), 0, "account liquidities");
+            assertEq(accountLiquidities.rightSlot(), 0, "expectedLiq");
+        }
+        (realLiq, , , , ) = pool.positions(
+            keccak256(abi.encodePacked(address(sfpm), tickLower, tickUpper))
+        );
+
+        assertEq(realLiq, 0);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -1169,12 +1169,27 @@ contract PanopticMathTest is Test, PositionUtils {
             highPriceX96 - lowPriceX96
         );
 
-        amount0 =
-            Math.mulDiv(uint256(liquidity) << 96, highPriceX96 - lowPriceX96, highPriceX96) /
-            lowPriceX96;
+        if (isLong == 0) {
+            amount0 = Math.mulDivRoundingUp(
+                Math.mulDivRoundingUp(
+                    uint256(liquidity) << 96,
+                    highPriceX96 - lowPriceX96,
+                    highPriceX96
+                ),
+                1,
+                lowPriceX96
+            );
 
-        amount1 = Math.mulDiv96(liquidity, highPriceX96 - lowPriceX96);
+            amount1 = Math.mulDiv96RoundingUp(liquidity, highPriceX96 - lowPriceX96);
+        } else {
+            amount0 = Math.mulDiv(
+                Math.mulDiv(uint256(liquidity) << 96, highPriceX96 - lowPriceX96, highPriceX96),
+                1,
+                lowPriceX96
+            );
 
+            amount1 = Math.mulDiv96(liquidity, highPriceX96 - lowPriceX96);
+        }
         vm.assume(amount0 < type(uint128).max);
         vm.assume(amount1 < type(uint128).max);
         LeftRightUnsigned expectedContractsNotional = LeftRightUnsigned
@@ -1200,13 +1215,13 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         if (amount0 != contracts) {
-            assertGt(
+            assertGe(
                 legacyContractsNotional.rightSlot(),
                 returnedContractsNotional.rightSlot(),
                 "LEGACY: amount 0 not equal"
             );
             if (legacyContractsNotional.leftSlot() > 0) {
-                assertGt(
+                assertGe(
                     legacyContractsNotional.leftSlot(),
                     returnedContractsNotional.leftSlot(),
                     "LEGACY: amount 1 not equal"
@@ -1303,12 +1318,27 @@ contract PanopticMathTest is Test, PositionUtils {
         uint160 highPriceX96 = Math.getSqrtRatioAtTick(tickUpper);
 
         uint256 liquidity = Math.mulDiv(contracts, 2 ** 96, highPriceX96 - lowPriceX96);
+        if (isLong == 0) {
+            amount0 = Math.mulDivRoundingUp(
+                Math.mulDivRoundingUp(
+                    uint256(liquidity) << 96,
+                    highPriceX96 - lowPriceX96,
+                    highPriceX96
+                ),
+                1,
+                lowPriceX96
+            );
 
-        amount0 =
-            Math.mulDiv(uint256(liquidity) << 96, highPriceX96 - lowPriceX96, highPriceX96) /
-            lowPriceX96;
+            amount1 = Math.mulDiv96RoundingUp(liquidity, highPriceX96 - lowPriceX96);
+        } else {
+            amount0 = Math.mulDiv(
+                Math.mulDiv(uint256(liquidity) << 96, highPriceX96 - lowPriceX96, highPriceX96),
+                1,
+                lowPriceX96
+            );
 
-        amount1 = Math.mulDiv96(liquidity, highPriceX96 - lowPriceX96);
+            amount1 = Math.mulDiv96(liquidity, highPriceX96 - lowPriceX96);
+        }
 
         vm.assume(amount0 < type(uint128).max);
         vm.assume(amount1 < type(uint128).max);
@@ -1335,13 +1365,13 @@ contract PanopticMathTest is Test, PositionUtils {
         );
 
         if (amount1 != contracts) {
-            assertGt(
+            assertGe(
                 legacyContractsNotional.leftSlot(),
                 returnedContractsNotional.leftSlot(),
                 "LEGACY: amount 0 not equal"
             );
             if (legacyContractsNotional.rightSlot() > 0) {
-                assertGt(
+                assertGe(
                     legacyContractsNotional.rightSlot(),
                     returnedContractsNotional.rightSlot(),
                     "LEGACY: amount 1 not equal"

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -1086,20 +1086,19 @@ contract PanopticMathTest is Test, PositionUtils {
         );
     }
 
-    function test_Success_getAmountsMoved_asset0(
+    function test_Fuzz_getAmountsMoved0_legacy(
         uint256 optionRatioSeed,
         uint16 isLong,
         uint16 tokenType,
         int24 strike,
         int24 width,
-        uint64 positionSize
+        uint128 positionSize
     ) public {
-        vm.assume(positionSize != 0);
         TokenId tokenId;
 
         // contruct a tokenId
         {
-            uint256 optionRatio = bound(optionRatioSeed, 1, 1);
+            uint256 optionRatio = bound(optionRatioSeed, 1, 127);
 
             // the following are all 1 bit so mask them:
             uint8 MASK = 0x1; // takes first 1 bit of the uint16
@@ -1117,28 +1116,30 @@ contract PanopticMathTest is Test, PositionUtils {
             (rangeDown, rangeUp) = PanopticMath.getRangesFromStrike(width, int24(tickSpacing));
 
             (, currentTick, , , , , ) = selectedPool.slot0();
-            (strikeOffset, minTick, maxTick) = PositionUtils.getContextFull(
-                uint256(uint24(tickSpacing)),
-                currentTick,
-                width
-            );
 
-            lowerBound = int24(minTick + rangeDown - strikeOffset);
-            upperBound = int24(maxTick - rangeUp - strikeOffset);
+            lowerBound = int24(-887272 + rangeDown);
+            upperBound = int24(887272 - rangeUp);
 
             // bound strike
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
-            strike = int24(strike * tickSpacing + strikeOffset);
+            strike = int24(strike * tickSpacing);
 
             tokenId = TokenId.wrap(uint256(uint24(tickSpacing)) << 48);
             tokenId = tokenId.addLeg(0, optionRatio, 0, isLong, tokenType, 0, strike, width);
+            console2.log("strike", strike);
         }
+        tokenId.validate();
 
         // get the tick range for this leg in order to get the strike price (the underlying price)
         (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0);
 
-        // set amount 0
-        uint128 amount0 = positionSize * uint128(tokenId.optionRatio(0));
+        positionSize = uint128(
+            bound(positionSize, 0, positionSize / uint128(tokenId.optionRatio(0)))
+        );
+        vm.assume(positionSize != 0);
+
+        // set amount 0 - LEGACY
+        uint256 amount0 = positionSize * uint128(tokenId.optionRatio(0));
 
         uint256 amount1 = Math.mulDivRoundingUp(
             uint256(amount0),
@@ -1149,41 +1150,84 @@ contract PanopticMathTest is Test, PositionUtils {
             ),
             2 ** 96
         );
+        vm.assume(amount0 < type(uint128).max);
+        vm.assume(amount1 < type(uint128).max);
+        LeftRightUnsigned legacyContractsNotional = LeftRightUnsigned
+            .wrap(0)
+            .toRightSlot(amount0.toUint128())
+            .toLeftSlot(amount1.toUint128());
 
-        vm.assume(amount1 < 2 ** 128);
+        // set amount0 - UNISWAP MATH
+        uint256 contracts = positionSize * tokenId.optionRatio(0);
 
+        uint160 lowPriceX96 = Math.getSqrtRatioAtTick(tickLower);
+        uint160 highPriceX96 = Math.getSqrtRatioAtTick(tickUpper);
+
+        uint256 liquidity = Math.mulDiv(
+            contracts,
+            Math.mulDiv96(highPriceX96, lowPriceX96),
+            highPriceX96 - lowPriceX96
+        );
+
+        amount0 =
+            Math.mulDiv(uint256(liquidity) << 96, highPriceX96 - lowPriceX96, highPriceX96) /
+            lowPriceX96;
+
+        amount1 = Math.mulDiv96(liquidity, highPriceX96 - lowPriceX96);
+
+        vm.assume(amount0 < type(uint128).max);
+        vm.assume(amount1 < type(uint128).max);
         LeftRightUnsigned expectedContractsNotional = LeftRightUnsigned
             .wrap(0)
-            .toRightSlot(amount0)
-            .toLeftSlot(uint128(amount1));
+            .toRightSlot(amount0.toUint128())
+            .toLeftSlot(amount1.toUint128());
 
+        // set amount0 - PANOPTIC MATH
         LeftRightUnsigned returnedContractsNotional = harness.getAmountsMoved(
             tokenId,
             positionSize,
             0
         );
         assertEq(
-            LeftRightUnsigned.unwrap(expectedContractsNotional),
-            LeftRightUnsigned.unwrap(returnedContractsNotional)
+            expectedContractsNotional.rightSlot(),
+            returnedContractsNotional.rightSlot(),
+            "CORRECT: amount 0 not equal"
         );
+        assertEq(
+            expectedContractsNotional.leftSlot(),
+            returnedContractsNotional.leftSlot(),
+            "CORRECT: amount 1 not equal"
+        );
+
+        if (amount0 != contracts) {
+            assertGt(
+                legacyContractsNotional.rightSlot(),
+                returnedContractsNotional.rightSlot(),
+                "LEGACY: amount 0 not equal"
+            );
+            if (legacyContractsNotional.leftSlot() > 0) {
+                assertGt(
+                    legacyContractsNotional.leftSlot(),
+                    returnedContractsNotional.leftSlot(),
+                    "LEGACY: amount 1 not equal"
+                );
+            }
+        }
     }
 
-    function test_Success_getAmountsMoved_asset1(
-        uint256 optionRatio,
+    function test_Fuzz_getAmountsMoved1_legacy(
+        uint256 optionRatioSeed,
         uint16 isLong,
         uint16 tokenType,
         int24 strike,
         int24 width,
-        uint64 positionSize
+        uint128 positionSize
     ) public {
-        vm.assume(positionSize != 0);
         TokenId tokenId;
 
         // contruct a tokenId
         {
-            selectedPool = pools[bound(optionRatio, 0, 2)]; // reuse optionRatio as seed
-
-            optionRatio = bound(optionRatio, 1, 127);
+            uint256 optionRatio = bound(optionRatioSeed, 1, 127);
 
             // the following are all 1 bit so mask them:
             uint8 MASK = 0x1; // takes first 1 bit of the uint16
@@ -1191,6 +1235,7 @@ contract PanopticMathTest is Test, PositionUtils {
             tokenType = tokenType & MASK;
 
             // bound fuzzed tick
+            selectedPool = pools[bound(optionRatio, 0, 2)]; // reuse optionRatio as seed
             tickSpacing = selectedPool.tickSpacing();
 
             width = int24(bound(width, 1, 2048));
@@ -1200,32 +1245,40 @@ contract PanopticMathTest is Test, PositionUtils {
             (rangeDown, rangeUp) = PanopticMath.getRangesFromStrike(width, int24(tickSpacing));
 
             (, currentTick, , , , , ) = selectedPool.slot0();
-            (strikeOffset, minTick, maxTick) = PositionUtils.getContextFull(
-                uint256(uint24(tickSpacing)),
-                currentTick,
-                width
-            );
 
-            lowerBound = int24(minTick + rangeDown - strikeOffset);
-            upperBound = int24(maxTick - rangeUp - strikeOffset);
-
-            // Set current tick and pool price
-            currentTick = int24(bound(currentTick, minTick, maxTick));
+            lowerBound = int24(-887272 + rangeDown);
+            upperBound = int24(887272 - rangeUp);
 
             // bound strike
             strike = int24(bound(strike, lowerBound / tickSpacing, upperBound / tickSpacing));
-            strike = int24(strike * tickSpacing + strikeOffset);
+            strike = int24(strike * tickSpacing);
 
             tokenId = TokenId.wrap(uint256(uint24(tickSpacing)) << 48);
             tokenId = tokenId.addLeg(0, optionRatio, 1, isLong, tokenType, 0, strike, width);
+            console2.log("strike", strike);
         }
+        tokenId.validate();
 
         // get the tick range for this leg in order to get the strike price (the underlying price)
         (int24 tickLower, int24 tickUpper) = tokenId.asTicks(0);
 
-        // set amount 1
-        uint128 amount1 = positionSize * uint128(tokenId.optionRatio(0));
+        positionSize = uint128(
+            bound(positionSize, 0, positionSize / uint128(tokenId.optionRatio(0)))
+        );
+        vm.assume(positionSize != 0);
 
+        // set amount 1 - LEGACY
+        uint256 amount1 = positionSize * uint128(tokenId.optionRatio(0));
+        console2.log("tL", Math.getSqrtRatioAtTick(tickLower));
+        console2.log("tU", Math.getSqrtRatioAtTick(tickUpper));
+
+        vm.assume(
+            Math.mulDiv(
+                Math.getSqrtRatioAtTick(tickLower),
+                Math.getSqrtRatioAtTick(tickUpper),
+                2 ** 96
+            ) > 0
+        );
         uint256 amount0 = Math.mulDivRoundingUp(
             uint256(amount1),
             2 ** 96,
@@ -1235,22 +1288,66 @@ contract PanopticMathTest is Test, PositionUtils {
                 2 ** 96
             )
         );
-        vm.assume(amount0 < 2 ** 128);
 
+        vm.assume(amount0 < type(uint128).max);
+        vm.assume(amount1 < type(uint128).max);
+        LeftRightUnsigned legacyContractsNotional = LeftRightUnsigned
+            .wrap(0)
+            .toRightSlot(amount0.toUint128())
+            .toLeftSlot(amount1.toUint128());
+
+        // set amount0 - UNISWAP MATH
+        uint256 contracts = positionSize * tokenId.optionRatio(0);
+
+        uint160 lowPriceX96 = Math.getSqrtRatioAtTick(tickLower);
+        uint160 highPriceX96 = Math.getSqrtRatioAtTick(tickUpper);
+
+        uint256 liquidity = Math.mulDiv(contracts, 2 ** 96, highPriceX96 - lowPriceX96);
+
+        amount0 =
+            Math.mulDiv(uint256(liquidity) << 96, highPriceX96 - lowPriceX96, highPriceX96) /
+            lowPriceX96;
+
+        amount1 = Math.mulDiv96(liquidity, highPriceX96 - lowPriceX96);
+
+        vm.assume(amount0 < type(uint128).max);
+        vm.assume(amount1 < type(uint128).max);
         LeftRightUnsigned expectedContractsNotional = LeftRightUnsigned
             .wrap(0)
-            .toRightSlot(uint128(amount0))
-            .toLeftSlot(amount1);
+            .toRightSlot(amount0.toUint128())
+            .toLeftSlot(amount1.toUint128());
 
+        // set amount0 - PANOPTIC MATH
         LeftRightUnsigned returnedContractsNotional = harness.getAmountsMoved(
             tokenId,
             positionSize,
             0
         );
         assertEq(
-            LeftRightUnsigned.unwrap(expectedContractsNotional),
-            LeftRightUnsigned.unwrap(returnedContractsNotional)
+            expectedContractsNotional.rightSlot(),
+            returnedContractsNotional.rightSlot(),
+            "CORRECT: amount 0 not equal"
         );
+        assertEq(
+            expectedContractsNotional.leftSlot(),
+            returnedContractsNotional.leftSlot(),
+            "CORRECT: amount 1 not equal"
+        );
+
+        if (amount1 != contracts) {
+            assertGt(
+                legacyContractsNotional.leftSlot(),
+                returnedContractsNotional.leftSlot(),
+                "LEGACY: amount 0 not equal"
+            );
+            if (legacyContractsNotional.rightSlot() > 0) {
+                assertGt(
+                    legacyContractsNotional.rightSlot(),
+                    returnedContractsNotional.rightSlot(),
+                    "LEGACY: amount 1 not equal"
+                );
+            }
+        }
     }
 
     // // _calculateIOAmounts


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in `PanopticMath.getAmountsMoved()` where token amounts were calculated using a geometric mean price approximation instead of Uniswap V3's actual liquidity formulas. This discrepancy caused the protocol to overestimate notional amounts, leading to incorrect collateral requirements and potential insolvency issues.

## Problem

The previous implementation used a geometric mean price to estimate token amounts:
```solidity
// Old (incorrect) approach
uint256 geometricMeanPriceX96 = Math.mulDiv96(
    Math.getSqrtRatioAtTick(tickLower),
    Math.getSqrtRatioAtTick(tickUpper)
);
amount0 = positionSize * optionRatio;
amount1 = Math.mulDiv96RoundingUp(amount0, geometricMeanPriceX96);
```

This approximation **does not match** the actual amounts that Uniswap V3 moves when minting/burning liquidity positions, causing accounting mismatches between Panoptic and Uniswap.

## Solution

### 1. New Math Functions
Added `getAmount0ForLiquidityUp()` and `getAmount1ForLiquidityUp()` in `Math.sol` that use Uniswap's exact formulas with proper rounding:
- Round UP for shorts (conservative for protocol - user pays more)
- Round DOWN for longs (conservative for protocol - user receives less)

### 2. Fixed `getAmountsMoved()`
Now calculates amounts using actual Uniswap liquidity math:
```solidity
LiquidityChunk liquidityChunk = getLiquidityChunk(tokenId, legIndex, positionSize);

// Shorts round UP, longs round DOWN (conservative for protocol)
if (tokenId.isLong(legIndex) == 0) {
    amount0 = uint128(Math.getAmount0ForLiquidityUp(liquidityChunk));
    amount1 = uint128(Math.getAmount1ForLiquidityUp(liquidityChunk));
} else {
    amount0 = uint128(Math.getAmount0ForLiquidity(liquidityChunk));
    amount1 = uint128(Math.getAmount1ForLiquidity(liquidityChunk));
}
```

### 3. Additional Safety Checks
- Added `ZeroLiquidity` revert in `CollateralTracker.sol` if position moves no tokens

## Impact

- **Accounting Accuracy**: Notional calculations now precisely match Uniswap's token movements
- **Security**: Prevents overestimation of amounts that could lead to insolvency
- **Correctness**: Proper rounding direction ensures protocol remains conservative

## Testing

- Added fuzzing tests demonstrating the legacy calculation consistently overestimated amounts
- Updated existing tests to use corrected `getAmountsMoved()` for borrow amount calculations
- Verified new calculations match Uniswap's actual behavior across various scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces protocol-wide interest accrual with per-user tracking and read-only previews.
  - Accounts for unrealized interest in balances, withdrawals, and utilization.
  - Enables using accumulated premia as collateral in solvency checks and withdrawals.
  - Improves ERC1155 compatibility for token receipts.
- Refactor
  - Streamlines mint/burn and settlement flows; unifies commission/settlement handling.
  - Replaces legacy exercise/refund logic with clearer refund semantics.
- Tests
  - Adds extensive fuzz tests and math harness coverage (WAD math, amounts moved).
- Chores
  - Updates deployment constructor parameters and CI optimizer settings.
  - Renames stale price check to a generalized oracle error; adds minimum redemption error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->