### PR TITLE
refactor: Rename LeftRight slot functions for clarity

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -215,7 +215,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         s_poolFee = fee;
 
         // store the initial block and initialize the borrowIndex
-        s_interestRateAccumulator = LeftRightUnsigned.wrap(0).toRightSlot(
+        s_interestRateAccumulator = LeftRightUnsigned.wrap(0).addToRightSlot(
             uint128((block.timestamp << 96) + uint96(WAD))
         );
 
@@ -717,13 +717,13 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             s_interestState[owner] = LeftRightSigned
                 .wrap(0)
-                .toRightSlot(userBorrowIndex)
-                .toLeftSlot(netBorrows);
+                .addToRightSlot(userBorrowIndex)
+                .addToLeftSlot(netBorrows);
 
             s_interestRateAccumulator = LeftRightUnsigned
                 .wrap(0)
-                .toLeftSlot(_unrealizedGlobalInterest)
-                .toRightSlot(uint128((currentTime << 96) + uint96(currentBorrowIndex)));
+                .addToLeftSlot(_unrealizedGlobalInterest)
+                .addToRightSlot(uint128((currentTime << 96) + uint96(currentBorrowIndex)));
         }
     }
 
@@ -1055,7 +1055,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
             {
                 address _optionOwner = optionOwner;
-                s_interestState[_optionOwner] = s_interestState[_optionOwner].toLeftSlot(
+                // add new netBorrows to the left slot
+                s_interestState[_optionOwner] = s_interestState[_optionOwner].addToLeftSlot(
                     netBorrows
                 );
             }
@@ -1086,7 +1087,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             0 // realizedPremium not used
         );
         return (
-            LeftRightUnsigned.wrap(0).toRightSlot(utilization).toLeftSlot(commission),
+            LeftRightUnsigned.wrap(0).addToRightSlot(utilization).addToLeftSlot(commission),
             tokenPaid
         );
     }
@@ -1116,5 +1117,4 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         );
         return tokenPaid;
     }
-
 }

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -675,8 +675,8 @@ contract PanopticPool is Multicall {
                     totalSwapped.rightSlot()
                 );
             utilizations = uint32(utilizationAndCommission0.rightSlot());
-            commissions = commissions.toRightSlot(utilizationAndCommission0.leftSlot());
-            paidAmounts = paidAmounts.toRightSlot(paid0);
+            commissions = commissions.addToRightSlot(utilizationAndCommission0.leftSlot());
+            paidAmounts = paidAmounts.addToRightSlot(paid0);
         }
         {
             (LeftRightUnsigned utilizationAndCommission1, int128 paid1) = s_collateralToken1
@@ -687,8 +687,8 @@ contract PanopticPool is Multicall {
                     totalSwapped.leftSlot()
                 );
             utilizations += uint32(utilizationAndCommission1.rightSlot() << 16);
-            commissions = commissions.toLeftSlot(utilizationAndCommission1.leftSlot());
-            paidAmounts = paidAmounts.toLeftSlot(paid1);
+            commissions = commissions.addToLeftSlot(utilizationAndCommission1.leftSlot());
+            paidAmounts = paidAmounts.addToLeftSlot(paid1);
         }
 
         // return pool utilizations as two uint16 (pool Utilization is always <= 10000)
@@ -778,7 +778,7 @@ contract PanopticPool is Multicall {
                 totalSwapped.rightSlot(),
                 realizedPremia.rightSlot()
             );
-            paidAmounts = paidAmounts.toRightSlot(paid0);
+            paidAmounts = paidAmounts.addToRightSlot(paid0);
         }
 
         {
@@ -789,7 +789,7 @@ contract PanopticPool is Multicall {
                 totalSwapped.leftSlot(),
                 realizedPremia.leftSlot()
             );
-            paidAmounts = paidAmounts.toLeftSlot(paid1);
+            paidAmounts = paidAmounts.addToLeftSlot(paid1);
         }
 
         emit OptionBurnt(owner, positionSize, tokenId, premiaByLeg);
@@ -1231,9 +1231,9 @@ contract PanopticPool is Multicall {
                                 _currentTick,
                                 1
                             );
-                        accumulatedPremium = LeftRightUnsigned.wrap(premiumAccumulator0).toLeftSlot(
-                            premiumAccumulator1
-                        );
+                        accumulatedPremium = LeftRightUnsigned
+                            .wrap(premiumAccumulator0)
+                            .addToLeftSlot(premiumAccumulator1);
                     }
                     {
                         // update the premium accumulator for the long position to the latest value
@@ -1252,10 +1252,10 @@ contract PanopticPool is Multicall {
                     // update the realized premia
                     realizedPremia = LeftRightSigned
                         .wrap(0)
-                        .toRightSlot(
+                        .addToRightSlot(
                             int128(int256((accumulatedPremium.rightSlot() * liquidity) / 2 ** 64))
                         )
-                        .toLeftSlot(
+                        .addToLeftSlot(
                             int128(int256((accumulatedPremium.leftSlot() * liquidity) / 2 ** 64))
                         );
                 }
@@ -1636,7 +1636,7 @@ contract PanopticPool is Multicall {
 
                     premiaByLeg[leg] = LeftRightSigned
                         .wrap(0)
-                        .toRightSlot(
+                        .addToRightSlot(
                             int128(
                                 int256(
                                     ((premiumAccumulatorsByLeg[leg][0] -
@@ -1645,7 +1645,7 @@ contract PanopticPool is Multicall {
                                 )
                             )
                         )
-                        .toLeftSlot(
+                        .addToLeftSlot(
                             int128(
                                 int256(
                                     ((premiumAccumulatorsByLeg[leg][1] -
@@ -1722,7 +1722,7 @@ contract PanopticPool is Multicall {
 
                 s_options[owner][tokenId][leg] = LeftRightUnsigned
                     .wrap(uint128(grossCurrent0))
-                    .toLeftSlot(uint128(grossCurrent1));
+                    .addToLeftSlot(uint128(grossCurrent1));
             }
 
             // if position is long, ensure that removed liquidity does not deplete strike beyond min(MAX_SPREAD, user-provided effectiveLiquidityLimit)
@@ -1769,7 +1769,7 @@ contract PanopticPool is Multicall {
                                     totalLiquidityBefore) / totalLiquidity
                             )
                         )
-                        .toLeftSlot(
+                        .addToLeftSlot(
                             uint128(
                                 (grossCurrent1 *
                                     positionLiquidity +
@@ -1822,7 +1822,7 @@ contract PanopticPool is Multicall {
                             )
                         )
                     )
-                    .toLeftSlot(
+                    .addToLeftSlot(
                         uint128(
                             Math.min(
                                 (uint256(premiumOwed.leftSlot()) * settledTokens.leftSlot()) /
@@ -2001,7 +2001,7 @@ contract PanopticPool is Multicall {
                                     ) / totalLiquidity
                                 )
                             )
-                            .toLeftSlot(
+                            .addToLeftSlot(
                                 uint128(
                                     uint256(
                                         Math.max(
@@ -2019,7 +2019,7 @@ contract PanopticPool is Multicall {
                             )
                         : LeftRightUnsigned
                             .wrap(uint128(premiumAccumulatorsByLeg[_leg][0]))
-                            .toLeftSlot(uint128(premiumAccumulatorsByLeg[_leg][1]));
+                            .addToLeftSlot(uint128(premiumAccumulatorsByLeg[_leg][1]));
                 }
             }
             // update settled tokens in storage with all local deltas

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -123,7 +123,7 @@ contract RiskEngine {
                 return
                     LeftRightSigned
                         .wrap(0)
-                        .toRightSlot(
+                        .addToRightSlot(
                             int128(
                                 fees.rightSlot() -
                                     int256(
@@ -135,7 +135,7 @@ contract RiskEngine {
                                     )
                             )
                         )
-                        .toLeftSlot(
+                        .addToLeftSlot(
                             int128(
                                 int256(
                                     PanopticMath.convert0to1RoundingUp(
@@ -155,7 +155,7 @@ contract RiskEngine {
                 return
                     LeftRightSigned
                         .wrap(0)
-                        .toRightSlot(
+                        .addToRightSlot(
                             int128(
                                 int256(
                                     PanopticMath.convert1to0RoundingUp(
@@ -165,7 +165,7 @@ contract RiskEngine {
                                 ) + fees.rightSlot()
                             )
                         )
-                        .toLeftSlot(
+                        .addToLeftSlot(
                             int128(
                                 fees.leftSlot() -
                                     int256(
@@ -265,8 +265,12 @@ contract RiskEngine {
                 exerciseFees = exerciseFees.sub(
                     LeftRightSigned
                         .wrap(0)
-                        .toRightSlot(int128(uint128(currentValue0)) - int128(uint128(oracleValue0)))
-                        .toLeftSlot(int128(uint128(currentValue1)) - int128(uint128(oracleValue1)))
+                        .addToRightSlot(
+                            int128(uint128(currentValue0)) - int128(uint128(oracleValue0))
+                        )
+                        .addToLeftSlot(
+                            int128(uint128(currentValue1)) - int128(uint128(oracleValue1))
+                        )
                 );
             }
 
@@ -278,8 +282,8 @@ contract RiskEngine {
 
             // store the exercise fees in the exerciseFees variable
             exerciseFees = exerciseFees
-                .toRightSlot(int128((longAmounts.rightSlot() * fee) / int256(DECIMALS)))
-                .toLeftSlot(int128((longAmounts.leftSlot() * fee) / int256(DECIMALS)));
+                .addToRightSlot(int128((longAmounts.rightSlot() * fee) / int256(DECIMALS)))
+                .addToLeftSlot(int128((longAmounts.leftSlot() * fee) / int256(DECIMALS)));
         }
     }
 
@@ -405,8 +409,10 @@ contract RiskEngine {
             paid0 = bonus0 + int256(netPaid.rightSlot());
             paid1 = bonus1 + int256(netPaid.leftSlot());
             return (
-                LeftRightSigned.wrap(0).toRightSlot(int128(bonus0)).toLeftSlot(int128(bonus1)),
-                LeftRightSigned.wrap(0).toRightSlot(int128(balance0 - paid0)).toLeftSlot(
+                LeftRightSigned.wrap(0).addToRightSlot(int128(bonus0)).addToLeftSlot(
+                    int128(bonus1)
+                ),
+                LeftRightSigned.wrap(0).addToRightSlot(int128(balance0 - paid0)).addToLeftSlot(
                     int128(balance1 - paid1)
                 )
             );
@@ -447,7 +453,7 @@ contract RiskEngine {
                     longPremia.rightSlot() +
                     owedInterest0).toUint128()
                 : 0;
-            tokenData0 = LeftRightUnsigned.wrap(balance0.toUint128()).toLeftSlot(
+            tokenData0 = LeftRightUnsigned.wrap(balance0.toUint128()).addToLeftSlot(
                 requirement0.toUint128()
             );
         }
@@ -459,7 +465,7 @@ contract RiskEngine {
                     longPremia.leftSlot() +
                     owedInterest1).toUint128()
                 : 0;
-            tokenData1 = LeftRightUnsigned.wrap(balance1.toUint128()).toLeftSlot(
+            tokenData1 = LeftRightUnsigned.wrap(balance1.toUint128()).addToLeftSlot(
                 requirement1.toUint128()
             );
         }

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -822,7 +822,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
             );
 
             // Add amounts swapped to totalSwapped variable
-            totalSwapped = LeftRightSigned.wrap(0).toRightSlot(swap0.toInt128()).toLeftSlot(
+            totalSwapped = LeftRightSigned.wrap(0).addToRightSlot(swap0.toInt128()).addToLeftSlot(
                 swap1.toInt128()
             );
         }
@@ -903,8 +903,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
             // if tokenType is 0, and we transacted some token1: then this leg is ITM
             itmAmounts = itmAmounts.add(
                 tokenId.tokenType(leg) == 0
-                    ? LeftRightSigned.wrap(0).toLeftSlot(movedLeg.leftSlot())
-                    : LeftRightSigned.wrap(0).toRightSlot(movedLeg.rightSlot())
+                    ? LeftRightSigned.wrap(0).addToLeftSlot(movedLeg.leftSlot())
+                    : LeftRightSigned.wrap(0).addToRightSlot(movedLeg.rightSlot())
             );
 
             unchecked {
@@ -1019,9 +1019,9 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
             }
 
             // update the starting liquidity for this position for next time around
-            s_accountLiquidity[positionKey] = LeftRightUnsigned.wrap(updatedLiquidity).toLeftSlot(
-                removedLiquidity
-            );
+            s_accountLiquidity[positionKey] = LeftRightUnsigned
+                .wrap(updatedLiquidity)
+                .addToLeftSlot(removedLiquidity);
         }
 
         // track how much liquidity we need to collect from uniswap
@@ -1131,16 +1131,16 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         feesBase = roundUp
             ? LeftRightSigned
                 .wrap(0)
-                .toRightSlot(
+                .addToRightSlot(
                     int128(int256(Math.mulDiv128RoundingUp(feeGrowthInside0LastX128, liquidity)))
                 )
-                .toLeftSlot(
+                .addToLeftSlot(
                     int128(int256(Math.mulDiv128RoundingUp(feeGrowthInside1LastX128, liquidity)))
                 )
             : LeftRightSigned
                 .wrap(0)
-                .toRightSlot(int128(int256(Math.mulDiv128(feeGrowthInside0LastX128, liquidity))))
-                .toLeftSlot(int128(int256(Math.mulDiv128(feeGrowthInside1LastX128, liquidity))));
+                .addToRightSlot(int128(int256(Math.mulDiv128(feeGrowthInside0LastX128, liquidity))))
+                .addToLeftSlot(int128(int256(Math.mulDiv128(feeGrowthInside1LastX128, liquidity))));
     }
 
     /// @notice Mint a chunk of liquidity (`liquidityChunk`) in the Uniswap V3 pool; return the amount moved.
@@ -1176,9 +1176,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         // amount0 The amount of token0 that was paid to mint the given amount of liquidity
         // amount1 The amount of token1 that was paid to mint the given amount of liquidity
         // no need to safecast to int from uint here as the max position size is int128
-        movedAmounts = LeftRightSigned.wrap(0).toRightSlot(int128(int256(amount0))).toLeftSlot(
-            int128(int256(amount1))
-        );
+        movedAmounts = LeftRightSigned
+            .wrap(0)
+            .addToRightSlot(int128(int256(amount0)))
+            .addToLeftSlot(int128(int256(amount1)));
     }
 
     /// @notice Burn a chunk of liquidity (`liquidityChunk`) in the Uniswap V3 pool and send to msg.sender; return the amount moved.
@@ -1202,9 +1203,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         // no need to safecast to int from uint here as the max position size is int128
         // decrement the amountsOut with burnt amounts. amountsOut = notional value of tokens moved
         unchecked {
-            movedAmounts = LeftRightSigned.wrap(0).toRightSlot(-int128(int256(amount0))).toLeftSlot(
-                -int128(int256(amount1))
-            );
+            movedAmounts = LeftRightSigned
+                .wrap(0)
+                .addToRightSlot(-int128(int256(amount0)))
+                .addToLeftSlot(-int128(int256(amount1)));
         }
     }
 
@@ -1273,7 +1275,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
 
             // CollectedOut is the amount of fees accumulated+collected (received - burnt)
             // That's because receivedAmount contains the burnt tokens and whatever amount of fees collected
-            collectedChunk = LeftRightUnsigned.wrap(collected0).toLeftSlot(collected1);
+            collectedChunk = LeftRightUnsigned.wrap(collected0).addToLeftSlot(collected1);
 
             // record the collected amounts in the s_accountPremiumOwed and s_accountPremiumGross accumulators
             _updateStoredPremia(positionKey, currentLiquidity, collectedChunk);
@@ -1341,7 +1343,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                         .mulDiv(premium1X64_base, numerator, totalLiquidity)
                         .toUint128Capped();
 
-                    deltaPremiumOwed = LeftRightUnsigned.wrap(premium0X64_owed).toLeftSlot(
+                    deltaPremiumOwed = LeftRightUnsigned.wrap(premium0X64_owed).addToLeftSlot(
                         premium1X64_owed
                     );
                 }
@@ -1364,7 +1366,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                         .mulDiv(premium1X64_base, numerator, totalLiquidity ** 2)
                         .toUint128Capped();
 
-                    deltaPremiumGross = LeftRightUnsigned.wrap(premium0X64_gross).toLeftSlot(
+                    deltaPremiumGross = LeftRightUnsigned.wrap(premium0X64_gross).addToLeftSlot(
                         premium1X64_gross
                     );
                 }

--- a/contracts/libraries/FeesCalc.sol
+++ b/contracts/libraries/FeesCalc.sol
@@ -48,7 +48,7 @@ library FeesCalc {
         int24 tickLower,
         int24 tickUpper,
         uint128 liquidity
-    ) public view returns (LeftRightSigned) {
+    ) external view returns (LeftRightSigned) {
         // extract the amount of AMM fees collected within the liquidity chunk
         // NOTE: the fee variables are *per unit of liquidity*; so more "rate" variables
         (
@@ -62,8 +62,8 @@ library FeesCalc {
         return
             LeftRightSigned
                 .wrap(0)
-                .toRightSlot(int128(int256(Math.mulDiv128(ammFeesPerLiqToken0X128, liquidity))))
-                .toLeftSlot(int128(int256(Math.mulDiv128(ammFeesPerLiqToken1X128, liquidity))));
+                .addToRightSlot(int128(int256(Math.mulDiv128(ammFeesPerLiqToken0X128, liquidity))))
+                .addToLeftSlot(int128(int256(Math.mulDiv128(ammFeesPerLiqToken1X128, liquidity))));
     }
 
     /// @notice Calculates the fee growth that has occurred (per unit of liquidity) in the AMM/Uniswap for an

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -798,7 +798,7 @@ library PanopticMath {
             amount1 = uint128(Math.getAmount1ForLiquidity(liquidityChunk));
         }
 
-        return LeftRightUnsigned.wrap(amount0).toLeftSlot(amount1);
+        return LeftRightUnsigned.wrap(amount0).addToLeftSlot(amount1);
     }
 
     /// @notice Compute the amount of funds that are moved to or removed from the Panoptic Pool when `tokenId` is created.
@@ -819,22 +819,26 @@ library PanopticMath {
         if (tokenId.tokenType(legIndex) == 0) {
             if (isShort) {
                 // if option is short, increment shorts by contracts
-                shorts = LeftRightSigned.wrap(0).toRightSlot(
+                shorts = LeftRightSigned.wrap(0).addToRightSlot(
                     Math.toInt128(amountsMoved.rightSlot())
                 );
             } else {
                 // is option is long, increment longs by contracts
-                longs = LeftRightSigned.wrap(0).toRightSlot(
+                longs = LeftRightSigned.wrap(0).addToRightSlot(
                     Math.toInt128(amountsMoved.rightSlot())
                 );
             }
         } else {
             if (isShort) {
                 // if option is short, increment shorts by notional
-                shorts = LeftRightSigned.wrap(0).toLeftSlot(Math.toInt128(amountsMoved.leftSlot()));
+                shorts = LeftRightSigned.wrap(0).addToLeftSlot(
+                    Math.toInt128(amountsMoved.leftSlot())
+                );
             } else {
                 // if option is long, increment longs by notional
-                longs = LeftRightSigned.wrap(0).toLeftSlot(Math.toInt128(amountsMoved.leftSlot()));
+                longs = LeftRightSigned.wrap(0).addToLeftSlot(
+                    Math.toInt128(amountsMoved.leftSlot())
+                );
             }
         }
     }
@@ -907,7 +911,7 @@ library PanopticMath {
 
                 // It is assumed the sum of `protocolLoss1` and `collateralDelta1` does not exceed `2^127 - 1` given practical constraints
                 // on token supplies and deposit limits
-                haircutBase = LeftRightSigned.wrap(longPremium.rightSlot()).toLeftSlot(
+                haircutBase = LeftRightSigned.wrap(longPremium.rightSlot()).addToLeftSlot(
                     int128(protocolLoss1 + collateralDelta1)
                 );
             } else if (
@@ -936,13 +940,13 @@ library PanopticMath {
                 // on token supplies and deposit limits
                 haircutBase = LeftRightSigned
                     .wrap(int128(protocolLoss0 + collateralDelta0))
-                    .toLeftSlot(longPremium.leftSlot());
+                    .addToLeftSlot(longPremium.leftSlot());
             } else {
                 // for each token, haircut until the protocol loss is mitigated or the premium paid is exhausted
                 // the size of `collateralDelta0/1` and `longPremium.rightSlot()/leftSlot()` is limited to `2^127 - 1` given that they originate from LeftRightSigned types
                 haircutBase = LeftRightSigned
                     .wrap(int128(Math.min(collateralDelta0, longPremium.rightSlot())))
-                    .toLeftSlot(int128(Math.min(collateralDelta1, longPremium.leftSlot())));
+                    .addToLeftSlot(int128(Math.min(collateralDelta1, longPremium.leftSlot())));
 
                 collateralDelta0 = 0;
                 collateralDelta1 = 0;
@@ -976,7 +980,7 @@ library PanopticMath {
                                     )
                                 )
                             )
-                            .toLeftSlot(
+                            .addToLeftSlot(
                                 int128(
                                     uint128(
                                         Math.unsafeDivRoundingUp(
@@ -1024,7 +1028,7 @@ library PanopticMath {
                 collateral1.settleBurn(_liquidatee, 0, 0, 0, int128(haircutTotal.leftSlot()));
 
             return
-                LeftRightSigned.wrap(0).toRightSlot(int128(collateralDelta0)).toLeftSlot(
+                LeftRightSigned.wrap(0).addToRightSlot(int128(collateralDelta0)).addToLeftSlot(
                     int128(collateralDelta1)
                 );
         }

--- a/contracts/types/LeftRight.sol
+++ b/contracts/types/LeftRight.sol
@@ -46,7 +46,7 @@ library LeftRightLibrary {
         return int128(LeftRightSigned.unwrap(self));
     }
 
-    // All toRightSlot functions add bits to the right slot without clearing it first
+    // All addToRightSlot functions add bits to the right slot without clearing it first
     // Typically, the slot is already clear when writing to it, but if it is not, the bits will be added to the existing bits
     // Therefore, the assumption must not be made that the bits will be cleared while using these helpers
     // Note that the values *within* the slots are allowed to overflow, but overflows are contained and will not leak into the other slot
@@ -55,7 +55,7 @@ library LeftRightLibrary {
     /// @param self The 256-bit pattern to be written to
     /// @param right The value to be added to the right slot
     /// @return `self` with `right` added (not overwritten, but added) to the value in its right 128 bits
-    function toRightSlot(
+    function addToRightSlot(
         LeftRightUnsigned self,
         uint128 right
     ) internal pure returns (LeftRightUnsigned) {
@@ -74,7 +74,7 @@ library LeftRightLibrary {
     /// @param self The 256-bit pattern to be written to
     /// @param right The value to be added to the right slot
     /// @return `self` with `right` added (not overwritten, but added) to the value in its right 128 bits
-    function toRightSlot(
+    function addToRightSlot(
         LeftRightSigned self,
         int128 right
     ) internal pure returns (LeftRightSigned) {
@@ -108,7 +108,7 @@ library LeftRightLibrary {
         return int128(LeftRightSigned.unwrap(self) >> 128);
     }
 
-    /// All toLeftSlot functions add bits to the left slot without clearing it first
+    /// All addToLeftSlot functions add bits to the left slot without clearing it first
     // Typically, the slot is already clear when writing to it, but if it is not, the bits will be added to the existing bits
     // Therefore, the assumption must not be made that the bits will be cleared while using these helpers
     // Note that the values *within* the slots are allowed to overflow, but overflows are contained and will not leak into the other slot
@@ -117,7 +117,7 @@ library LeftRightLibrary {
     /// @param self The 256-bit pattern to be written to
     /// @param left The value to be added to the left slot
     /// @return `self` with `left` added (not overwritten, but added) to the value in its left 128 bits
-    function toLeftSlot(
+    function addToLeftSlot(
         LeftRightUnsigned self,
         uint128 left
     ) internal pure returns (LeftRightUnsigned) {
@@ -130,7 +130,10 @@ library LeftRightLibrary {
     /// @param self The 256-bit pattern to be written to
     /// @param left The value to be added to the left slot
     /// @return `self` with `left` added (not overwritten, but added) to the value in its left 128 bits
-    function toLeftSlot(LeftRightSigned self, int128 left) internal pure returns (LeftRightSigned) {
+    function addToLeftSlot(
+        LeftRightSigned self,
+        int128 left
+    ) internal pure returns (LeftRightSigned) {
         unchecked {
             return LeftRightSigned.wrap(LeftRightSigned.unwrap(self) + (int256(left) << 128));
         }
@@ -202,7 +205,7 @@ library LeftRightLibrary {
 
             if (right128 != right) revert Errors.UnderOverFlow();
 
-            return z.toRightSlot(right128).toLeftSlot(left128);
+            return z.addToRightSlot(right128).addToLeftSlot(left128);
         }
     }
 
@@ -220,7 +223,7 @@ library LeftRightLibrary {
 
             if (left128 != left256 || right128 != right256) revert Errors.UnderOverFlow();
 
-            return z.toRightSlot(right128).toLeftSlot(left128);
+            return z.addToRightSlot(right128).addToLeftSlot(left128);
         }
     }
 
@@ -238,7 +241,7 @@ library LeftRightLibrary {
 
             if (left128 != left256 || right128 != right256) revert Errors.UnderOverFlow();
 
-            return z.toRightSlot(right128).toLeftSlot(left128);
+            return z.addToRightSlot(right128).addToLeftSlot(left128);
         }
     }
 
@@ -261,7 +264,7 @@ library LeftRightLibrary {
             if (left128 != left256 || right128 != right256) revert Errors.UnderOverFlow();
 
             return
-                z.toRightSlot(uint128(uint256((Math.max(right128, 0))))).toLeftSlot(
+                z.addToRightSlot(uint128(uint256((Math.max(right128, 0))))).addToLeftSlot(
                     uint128(uint256((Math.max(left128, 0))))
                 );
         }
@@ -290,10 +293,10 @@ library LeftRightLibrary {
         bool l_Enabled = !(z_xL == type(uint128).max || z_yL == type(uint128).max);
 
         return (
-            LeftRightUnsigned.wrap(r_Enabled ? z_xR : x.rightSlot()).toLeftSlot(
+            LeftRightUnsigned.wrap(r_Enabled ? z_xR : x.rightSlot()).addToLeftSlot(
                 l_Enabled ? z_xL : x.leftSlot()
             ),
-            LeftRightUnsigned.wrap(r_Enabled ? z_yR : y.rightSlot()).toLeftSlot(
+            LeftRightUnsigned.wrap(r_Enabled ? z_yR : y.rightSlot()).addToLeftSlot(
                 l_Enabled ? z_yL : y.leftSlot()
             )
         );

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -551,7 +551,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             liquidatee,
             positionIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToRightSlot(1).addToLeftSlot(1)
         );
     }
 
@@ -573,7 +573,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             exercisee,
             targetList,
             exerciseeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToRightSlot(1).addToLeftSlot(1)
         );
     }
 
@@ -595,7 +595,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             exercisee,
             targetList,
             settleeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToRightSlot(1).addToLeftSlot(1)
         );
     }
 
@@ -10032,7 +10032,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         );
 
         // store bonus amounts as actual amounts by dividing by DECIMALS_128
-        bonusAmounts = bonusAmounts.toRightSlot(bonus0 / int128(DECIMALS)).toLeftSlot(
+        bonusAmounts = bonusAmounts.addToRightSlot(bonus0 / int128(DECIMALS)).addToLeftSlot(
             bonus1 / int128(DECIMALS)
         );
     }

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -472,7 +472,7 @@ contract Misctest is Test, PositionUtils {
             liquidatee,
             positionIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToRightSlot(1).addToLeftSlot(1)
         );
     }
 
@@ -520,7 +520,7 @@ contract Misctest is Test, PositionUtils {
             exercisee,
             settleeList,
             settleeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(premiaAsCollateral ? 1 : 0).toLeftSlot(
+            LeftRightUnsigned.wrap(0).addToRightSlot(premiaAsCollateral ? 1 : 0).addToLeftSlot(
                 premiaAsCollateral ? 1 : 0
             )
         );
@@ -1814,7 +1814,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(0)
         );
     }
 
@@ -1961,7 +1961,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             $tempIdList,
-            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
@@ -1971,7 +1971,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             $tempIdList,
-            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(1)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
@@ -1981,7 +1981,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             $tempIdList,
-            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(0)
         );
 
         snap = vm.snapshotState();
@@ -2001,7 +2001,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
@@ -2011,7 +2011,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(1)
         );
 
         uint256 snap2 = vm.snapshotState();
@@ -2022,7 +2022,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(0)
         );
 
         vm.revertToState(snap2);
@@ -2033,7 +2033,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             $tempIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
 
         vm.revertToState(snap);
@@ -2059,7 +2059,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             $tempIdList,
-            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(0)
         );
 
         vm.expectRevert(Errors.AccountInsolvent.selector);
@@ -2069,7 +2069,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             $tempIdList,
-            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(0)
         );
 
         snap2 = vm.snapshotState();
@@ -2080,7 +2080,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             $tempIdList,
-            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(1)
         );
 
         vm.revertToState(snap2);
@@ -2093,7 +2093,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             $tempIdList,
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
 
         vm.revertToState(snap2);
@@ -2114,7 +2114,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toLeftSlot(0)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(0)
         );
 
         vm.revertToState(snap2);
@@ -2127,7 +2127,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToLeftSlot(1)
         );
 
         vm.revertToState(snap2);
@@ -2139,7 +2139,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(0)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(0)
         );
 
         vm.revertToState(snap2);
@@ -2152,7 +2152,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[1],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 
@@ -2238,7 +2238,7 @@ contract Misctest is Test, PositionUtils {
             $posIdList[0],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -404,7 +404,7 @@ contract PanopticPoolTest is PositionUtils {
             liquidatee,
             positionIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToRightSlot(1).addToLeftSlot(1)
         );
     }
 
@@ -430,7 +430,7 @@ contract PanopticPoolTest is PositionUtils {
             exercisee,
             exerciseeListInitial,
             exerciseeListFinal,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToRightSlot(1).addToLeftSlot(1)
         );
     }
 
@@ -450,7 +450,7 @@ contract PanopticPoolTest is PositionUtils {
             exercisee,
             settleeList,
             settleeList,
-            LeftRightUnsigned.wrap(0).toRightSlot(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(0).addToRightSlot(1).addToLeftSlot(1)
         );
     }
 
@@ -1867,14 +1867,14 @@ contract PanopticPoolTest is PositionUtils {
         LeftRightSigned poolUtilizationsAtMint;
         {
             (, , uint256 currentPoolUtilization) = ct0.getPoolData();
-            poolUtilizationsAtMint = LeftRightSigned.wrap(0).toRightSlot(
+            poolUtilizationsAtMint = LeftRightSigned.wrap(0).addToRightSlot(
                 int128(int256(currentPoolUtilization))
             );
         }
 
         {
             (, , uint256 currentPoolUtilization) = ct1.getPoolData();
-            poolUtilizationsAtMint = poolUtilizationsAtMint.toLeftSlot(
+            poolUtilizationsAtMint = poolUtilizationsAtMint.addToLeftSlot(
                 int128(int256(currentPoolUtilization))
             );
         }
@@ -6552,7 +6552,7 @@ contract PanopticPoolTest is PositionUtils {
             posIdList[0],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
 
         assertApproxEqAbs(
@@ -6679,7 +6679,9 @@ contract PanopticPoolTest is PositionUtils {
 
             LeftRightSigned refundAmounts = re.getRefundAmounts(
                 Charlie,
-                LeftRightSigned.wrap(0).toRightSlot(int128(refund0)).toLeftSlot(int128(refund1)),
+                LeftRightSigned.wrap(0).addToRightSlot(int128(refund0)).addToLeftSlot(
+                    int128(refund1)
+                ),
                 int24(atTick),
                 ct0,
                 ct1
@@ -6904,7 +6906,7 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[2][0],
                 $posIdLists[3],
                 $posIdLists[0],
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+                LeftRightUnsigned.wrap(1).addToLeftSlot(1)
             );
 
             int256 balanceDelta0 = int256(ct0.balanceOf(Alice)) -
@@ -6977,7 +6979,7 @@ contract PanopticPoolTest is PositionUtils {
             $posIdLists[2][0],
             $posIdLists[3],
             $posIdLists[0],
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 
@@ -7132,7 +7134,7 @@ contract PanopticPoolTest is PositionUtils {
                 $posIdLists[2][0],
                 $posIdLists[3],
                 new TokenId[](0),
-                LeftRightUnsigned.wrap(1).toLeftSlot(1)
+                LeftRightUnsigned.wrap(1).addToLeftSlot(1)
             );
 
             int256 balanceDelta0 = int256(ct0.balanceOf(Alice)) -
@@ -7205,7 +7207,7 @@ contract PanopticPoolTest is PositionUtils {
             $posIdLists[2][0],
             $posIdLists[3],
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 
@@ -7342,7 +7344,7 @@ contract PanopticPoolTest is PositionUtils {
             $posIdLists[1][0],
             $posIdLists[0],
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 
@@ -7435,7 +7437,7 @@ contract PanopticPoolTest is PositionUtils {
             tokenId2,
             new TokenId[](0),
             posIdList,
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 
@@ -7484,7 +7486,7 @@ contract PanopticPoolTest is PositionUtils {
             touchedIds[0],
             new TokenId[](0),
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 
@@ -9552,7 +9554,7 @@ contract PanopticPoolTest is PositionUtils {
             Alice,
             posIdList,
             posIdList,
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 
@@ -9641,7 +9643,7 @@ contract PanopticPoolTest is PositionUtils {
             Alice,
             posIdList,
             new TokenId[](0),
-            LeftRightUnsigned.wrap(1).toLeftSlot(1)
+            LeftRightUnsigned.wrap(1).addToLeftSlot(1)
         );
     }
 }

--- a/test/foundry/libraries/FeesCalc.t.sol
+++ b/test/foundry/libraries/FeesCalc.t.sol
@@ -92,8 +92,12 @@ contract FeesCalcTest is Test, PositionUtils {
 
         LeftRightSigned expectedFeesEachToken;
         expectedFeesEachToken = expectedFeesEachToken
-            .toRightSlot(int128(int256(Math.mulDiv128(ammFeesPerLiqToken0X128, startingLiquidity))))
-            .toLeftSlot(int128(int256(Math.mulDiv128(ammFeesPerLiqToken1X128, startingLiquidity))));
+            .addToRightSlot(
+                int128(int256(Math.mulDiv128(ammFeesPerLiqToken0X128, startingLiquidity)))
+            )
+            .addToLeftSlot(
+                int128(int256(Math.mulDiv128(ammFeesPerLiqToken1X128, startingLiquidity)))
+            );
 
         LeftRightSigned returnedFeesEachToken = harness.calculateAMMSwapFees(
             selectedPool,

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -1154,8 +1154,8 @@ contract PanopticMathTest is Test, PositionUtils {
         vm.assume(amount1 < type(uint128).max);
         LeftRightUnsigned legacyContractsNotional = LeftRightUnsigned
             .wrap(0)
-            .toRightSlot(amount0.toUint128())
-            .toLeftSlot(amount1.toUint128());
+            .addToRightSlot(amount0.toUint128())
+            .addToLeftSlot(amount1.toUint128());
 
         // set amount0 - UNISWAP MATH
         uint256 contracts = positionSize * tokenId.optionRatio(0);
@@ -1194,8 +1194,8 @@ contract PanopticMathTest is Test, PositionUtils {
         vm.assume(amount1 < type(uint128).max);
         LeftRightUnsigned expectedContractsNotional = LeftRightUnsigned
             .wrap(0)
-            .toRightSlot(amount0.toUint128())
-            .toLeftSlot(amount1.toUint128());
+            .addToRightSlot(amount0.toUint128())
+            .addToLeftSlot(amount1.toUint128());
 
         // set amount0 - PANOPTIC MATH
         LeftRightUnsigned returnedContractsNotional = harness.getAmountsMoved(
@@ -1308,8 +1308,8 @@ contract PanopticMathTest is Test, PositionUtils {
         vm.assume(amount1 < type(uint128).max);
         LeftRightUnsigned legacyContractsNotional = LeftRightUnsigned
             .wrap(0)
-            .toRightSlot(amount0.toUint128())
-            .toLeftSlot(amount1.toUint128());
+            .addToRightSlot(amount0.toUint128())
+            .addToLeftSlot(amount1.toUint128());
 
         // set amount0 - UNISWAP MATH
         uint256 contracts = positionSize * tokenId.optionRatio(0);
@@ -1344,8 +1344,8 @@ contract PanopticMathTest is Test, PositionUtils {
         vm.assume(amount1 < type(uint128).max);
         LeftRightUnsigned expectedContractsNotional = LeftRightUnsigned
             .wrap(0)
-            .toRightSlot(amount0.toUint128())
-            .toLeftSlot(amount1.toUint128());
+            .addToRightSlot(amount0.toUint128())
+            .addToLeftSlot(amount1.toUint128());
 
         // set amount0 - PANOPTIC MATH
         LeftRightUnsigned returnedContractsNotional = harness.getAmountsMoved(
@@ -1430,7 +1430,7 @@ contract PanopticMathTest is Test, PositionUtils {
         LeftRightUnsigned contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
         vm.assume(int256(uint256(contractsNotional.rightSlot())) < type(int128).max);
 
-        LeftRightSigned expectedShorts = LeftRightSigned.wrap(0).toRightSlot(
+        LeftRightSigned expectedShorts = LeftRightSigned.wrap(0).addToRightSlot(
             Math.toInt128(contractsNotional.rightSlot())
         );
         (LeftRightSigned returnedLongs, LeftRightSigned returnedShorts) = harness
@@ -1501,7 +1501,7 @@ contract PanopticMathTest is Test, PositionUtils {
         LeftRightUnsigned contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
         vm.assume(int256(uint256(contractsNotional.rightSlot())) < type(int128).max);
 
-        LeftRightSigned expectedLongs = LeftRightSigned.wrap(0).toRightSlot(
+        LeftRightSigned expectedLongs = LeftRightSigned.wrap(0).addToRightSlot(
             Math.toInt128(contractsNotional.rightSlot())
         );
         (LeftRightSigned returnedLongs, LeftRightSigned returnedShorts) = harness
@@ -1557,7 +1557,7 @@ contract PanopticMathTest is Test, PositionUtils {
         LeftRightUnsigned contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
         vm.assume(int256(uint256(contractsNotional.leftSlot())) < type(int128).max);
 
-        LeftRightSigned expectedShorts = LeftRightSigned.wrap(0).toLeftSlot(
+        LeftRightSigned expectedShorts = LeftRightSigned.wrap(0).addToLeftSlot(
             Math.toInt128(contractsNotional.leftSlot())
         );
         (LeftRightSigned returnedLongs, LeftRightSigned returnedShorts) = harness
@@ -1616,7 +1616,7 @@ contract PanopticMathTest is Test, PositionUtils {
         LeftRightUnsigned contractsNotional = harness.getAmountsMoved(tokenId, positionSize, 0);
 
         vm.assume(int256(uint256(contractsNotional.leftSlot())) < type(int128).max);
-        LeftRightSigned expectedLongs = LeftRightSigned.wrap(0).toLeftSlot(
+        LeftRightSigned expectedLongs = LeftRightSigned.wrap(0).addToLeftSlot(
             Math.toInt128(contractsNotional.leftSlot())
         );
 

--- a/test/foundry/libraries/harnesses/FeesCalcHarness.sol
+++ b/test/foundry/libraries/harnesses/FeesCalcHarness.sol
@@ -44,6 +44,6 @@ contract FeesCalcHarness {
     }
 
     function addBalance(TokenId tokenId, uint128 balance) public {
-        userBalance[tokenId] = LeftRightUnsigned.wrap(0).toRightSlot(balance);
+        userBalance[tokenId] = LeftRightUnsigned.wrap(0).addToRightSlot(balance);
     }
 }

--- a/test/foundry/types/LeftRight.t.sol
+++ b/test/foundry/types/LeftRight.t.sol
@@ -25,7 +25,7 @@ contract LeftRightTest is Test {
     // RIGHT SLOT
     function test_Success_RightSlot_Uint128_In_Uint256(uint128 y) public view {
         LeftRightUnsigned x = LeftRightUnsigned.wrap(0);
-        x = harness.toRightSlot(x, y);
+        x = harness.addToRightSlot(x, y);
         assertEq(uint128(harness.leftSlot(x)), 0);
         assertEq(uint128(harness.rightSlot(x)), y);
     }
@@ -35,13 +35,13 @@ contract LeftRightTest is Test {
         uint128 y
     ) public view {
         uint128 originalLeft = harness.leftSlot(x);
-        x = harness.toRightSlot(x, y);
+        x = harness.addToRightSlot(x, y);
         assertEq(harness.leftSlot(x), originalLeft, "Right slot input overflowed into left slot");
     }
 
     function test_Success_RightSlot_Int128_In_Int256(int128 y) public view {
         LeftRightSigned x = LeftRightSigned.wrap(0);
-        x = harness.toRightSlot(x, y);
+        x = harness.addToRightSlot(x, y);
         assertEq(int128(harness.leftSlot(x)), 0);
         assertEq(int128(harness.rightSlot(x)), y);
     }
@@ -51,7 +51,7 @@ contract LeftRightTest is Test {
         int128 y
     ) public view {
         int128 originalLeft = harness.leftSlot(x);
-        x = harness.toRightSlot(x, y);
+        x = harness.addToRightSlot(x, y);
         assertEq(
             int128(harness.leftSlot(x)),
             originalLeft,
@@ -62,14 +62,14 @@ contract LeftRightTest is Test {
     // LEFT SLOT
     function test_Success_LeftSlot_Uint128_In_Uint256(uint128 y) public view {
         LeftRightUnsigned x = LeftRightUnsigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
+        x = harness.addToLeftSlot(x, y);
         assertEq(uint128(harness.leftSlot(x)), y);
         assertEq(uint128(harness.rightSlot(x)), 0);
     }
 
     function test_Success_LeftSlot_Int128_In_Int256(int128 y) public view {
         LeftRightSigned x = LeftRightSigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
+        x = harness.addToLeftSlot(x, y);
         assertEq(int128(harness.leftSlot(x)), y);
         assertEq(int128(harness.rightSlot(x)), 0);
     }
@@ -77,8 +77,8 @@ contract LeftRightTest is Test {
     // BOTH
     function test_Success_BothSlots_uint256(uint128 y, uint128 z) public view {
         LeftRightUnsigned x = LeftRightUnsigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
 
         assertEq(uint128(harness.leftSlot(x)), y);
         assertEq(uint128(harness.rightSlot(x)), z);
@@ -86,8 +86,8 @@ contract LeftRightTest is Test {
 
     function test_Success_BothSlots_int256(int128 y, int128 z) public view {
         LeftRightSigned x = LeftRightSigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
 
         assertEq(int128(harness.leftSlot(x)), y);
         assertEq(int128(harness.rightSlot(x)), z);
@@ -96,27 +96,27 @@ contract LeftRightTest is Test {
     // MATH
     function test_Success_AddUints(uint128 y, uint128 z, uint128 u, uint128 v) public {
         LeftRightUnsigned x = LeftRightUnsigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
         assertEq(uint128(harness.leftSlot(x)), y);
         assertEq(uint128(harness.rightSlot(x)), z);
 
         // try swapping order
         x = LeftRightUnsigned.wrap(0);
-        x = harness.toRightSlot(x, y);
-        x = harness.toLeftSlot(x, z);
+        x = harness.addToRightSlot(x, y);
+        x = harness.addToLeftSlot(x, z);
         assertEq(uint128(harness.leftSlot(x)), z);
         assertEq(uint128(harness.rightSlot(x)), y);
 
         x = LeftRightUnsigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
         assertEq(uint128(harness.leftSlot(x)), y);
         assertEq(uint128(harness.rightSlot(x)), z);
 
         LeftRightUnsigned xx = LeftRightUnsigned.wrap(0);
-        xx = harness.toLeftSlot(xx, u);
-        xx = harness.toRightSlot(xx, v);
+        xx = harness.addToLeftSlot(xx, u);
+        xx = harness.addToRightSlot(xx, v);
 
         // now test add
         if (uint128(uint256(y) + uint256(u)) < y) {
@@ -137,14 +137,14 @@ contract LeftRightTest is Test {
 
     function test_Success_AddUintInt(uint128 y, uint128 z, int128 u, int128 v) public {
         LeftRightUnsigned x = LeftRightUnsigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
         assertEq(uint128(harness.leftSlot(x)), y);
         assertEq(uint128(harness.rightSlot(x)), z);
 
         LeftRightSigned xx = LeftRightSigned.wrap(0);
-        xx = harness.toLeftSlot(xx, u);
-        xx = harness.toRightSlot(xx, v);
+        xx = harness.addToLeftSlot(xx, u);
+        xx = harness.addToRightSlot(xx, v);
 
         // now test add
         unchecked {
@@ -180,15 +180,15 @@ contract LeftRightTest is Test {
 
     function test_Success_SubUints(uint128 y, uint128 z, uint128 u, uint128 v) public {
         LeftRightUnsigned x = LeftRightUnsigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
 
         assertEq(uint128(harness.leftSlot(x)), y);
         assertEq(uint128(harness.rightSlot(x)), z);
 
         LeftRightUnsigned xx = LeftRightUnsigned.wrap(0);
-        xx = harness.toRightSlot(xx, v);
-        xx = harness.toLeftSlot(xx, u);
+        xx = harness.addToRightSlot(xx, v);
+        xx = harness.addToLeftSlot(xx, u);
 
         assertEq(uint128(harness.leftSlot(xx)), u);
         assertEq(uint128(harness.rightSlot(xx)), v);
@@ -216,27 +216,27 @@ contract LeftRightTest is Test {
     // MATH for ints
     function test_Success_AddInts(int128 y, int128 z, int128 u, int128 v) public {
         LeftRightSigned x = LeftRightSigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
         assertEq(int128(harness.leftSlot(x)), y);
         assertEq(int128(harness.rightSlot(x)), z);
 
         // try swapping order
         x = LeftRightSigned.wrap(0);
-        x = harness.toRightSlot(x, y);
-        x = harness.toLeftSlot(x, z);
+        x = harness.addToRightSlot(x, y);
+        x = harness.addToLeftSlot(x, z);
         assertEq(int128(harness.leftSlot(x)), z);
         assertEq(int128(harness.rightSlot(x)), y);
 
         x = LeftRightSigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
         assertEq(int128(harness.leftSlot(x)), y);
         assertEq(int128(harness.rightSlot(x)), z);
 
         LeftRightSigned xx = LeftRightSigned.wrap(0);
-        xx = harness.toLeftSlot(xx, u);
-        xx = harness.toRightSlot(xx, v);
+        xx = harness.addToLeftSlot(xx, u);
+        xx = harness.addToRightSlot(xx, v);
 
         // now test add
         unchecked {
@@ -259,27 +259,27 @@ contract LeftRightTest is Test {
 
     function test_Success_SubInts(int128 y, int128 z, int128 u, int128 v) public {
         LeftRightSigned x = LeftRightSigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
         assertEq(int128(harness.leftSlot(x)), y);
         assertEq(int128(harness.rightSlot(x)), z);
 
         // try swapping order
         x = LeftRightSigned.wrap(0);
-        x = harness.toRightSlot(x, y);
-        x = harness.toLeftSlot(x, z);
+        x = harness.addToRightSlot(x, y);
+        x = harness.addToLeftSlot(x, z);
         assertEq(int128(harness.leftSlot(x)), z);
         assertEq(int128(harness.rightSlot(x)), y);
 
         x = LeftRightSigned.wrap(0);
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
         assertEq(int128(harness.leftSlot(x)), y);
         assertEq(int128(harness.rightSlot(x)), z);
 
         LeftRightSigned xx = LeftRightSigned.wrap(0);
-        xx = harness.toLeftSlot(xx, u);
-        xx = harness.toRightSlot(xx, v);
+        xx = harness.addToLeftSlot(xx, u);
+        xx = harness.addToRightSlot(xx, v);
 
         // now test add
         unchecked {
@@ -303,12 +303,12 @@ contract LeftRightTest is Test {
     function test_Success_SubRectInts(int128 y, int128 z, int128 u, int128 v) public {
         LeftRightSigned x = LeftRightSigned.wrap(0);
 
-        x = harness.toLeftSlot(x, y);
-        x = harness.toRightSlot(x, z);
+        x = harness.addToLeftSlot(x, y);
+        x = harness.addToRightSlot(x, z);
 
         LeftRightSigned xx = LeftRightSigned.wrap(0);
-        xx = harness.toLeftSlot(xx, u);
-        xx = harness.toRightSlot(xx, v);
+        xx = harness.addToLeftSlot(xx, u);
+        xx = harness.addToRightSlot(xx, v);
 
         // now test add
         unchecked {

--- a/test/foundry/types/harnesses/LeftRightHarness.sol
+++ b/test/foundry/types/harnesses/LeftRightHarness.sol
@@ -31,7 +31,7 @@ contract LeftRightHarness {
         return r;
     }
 
-    /// @dev All toRightSlot functions add bits to the right slot without clearing it first
+    /// @dev All addToRightSlot functions add bits to the right slot without clearing it first
     /// @dev Typically, the slot is already clear when writing to it, but if it is not, the bits will be added to the existing bits
     /// @dev Therefore, the assumption must not be made that the bits will be cleared while using these helpers
 
@@ -41,11 +41,11 @@ contract LeftRightHarness {
      * @param right the bit pattern to write into the full pattern in the right half.
      * @return self with incoming right added (not overwritten, but added) to its right 128 bits.
      */
-    function toRightSlot(
+    function addToRightSlot(
         LeftRightUnsigned self,
         uint128 right
     ) public pure returns (LeftRightUnsigned) {
-        LeftRightUnsigned r = LeftRightLibrary.toRightSlot(self, right);
+        LeftRightUnsigned r = LeftRightLibrary.addToRightSlot(self, right);
         return r;
     }
 
@@ -55,8 +55,11 @@ contract LeftRightHarness {
      * @param right the bit pattern to write into the full pattern in the right half.
      * @return self with right added to its right 128 bits.
      */
-    function toRightSlot(LeftRightSigned self, int128 right) public pure returns (LeftRightSigned) {
-        LeftRightSigned r = LeftRightLibrary.toRightSlot(self, right);
+    function addToRightSlot(
+        LeftRightSigned self,
+        int128 right
+    ) public pure returns (LeftRightSigned) {
+        LeftRightSigned r = LeftRightLibrary.addToRightSlot(self, right);
         return r;
     }
 
@@ -84,7 +87,7 @@ contract LeftRightHarness {
         return r;
     }
 
-    /// @dev All toLeftSlot functions add bits to the left slot without clearing it first
+    /// @dev All addToLeftSlot functions add bits to the left slot without clearing it first
     /// @dev Typically, the slot is already clear when writing to it, but if it is not, the bits will be added to the existing bits
     /// @dev Therefore, the assumption must not be made that the bits will be cleared while using these helpers
 
@@ -94,11 +97,11 @@ contract LeftRightHarness {
      * @param left the bit pattern to write into the full pattern in the right half.
      * @return self with left added to its left 128 bits.
      */
-    function toLeftSlot(
+    function addToLeftSlot(
         LeftRightUnsigned self,
         uint128 left
     ) public pure returns (LeftRightUnsigned) {
-        LeftRightUnsigned r = LeftRightLibrary.toLeftSlot(self, left);
+        LeftRightUnsigned r = LeftRightLibrary.addToLeftSlot(self, left);
         return r;
     }
 
@@ -108,8 +111,11 @@ contract LeftRightHarness {
      * @param left the bit pattern to write into the full pattern in the right half.
      * @return self with left added to its left 128 bits.
      */
-    function toLeftSlot(LeftRightSigned self, int128 left) public pure returns (LeftRightSigned) {
-        LeftRightSigned r = LeftRightLibrary.toLeftSlot(self, left);
+    function addToLeftSlot(
+        LeftRightSigned self,
+        int128 left
+    ) public pure returns (LeftRightSigned) {
+        LeftRightSigned r = LeftRightLibrary.addToLeftSlot(self, left);
         return r;
     }
 


### PR DESCRIPTION
### Summary

This PR improves the clarity and descriptiveness of the `LeftRight` library by renaming the slot manipulation functions. The previous names, `toLeftSlot` and `toRightSlot`, were ambiguous and could imply that they overwrite the value in a slot.

However, their actual implementation performs an **addition**. To make the code easier to understand and prevent potential developer confusion, the functions have been renamed to **`addToLeftSlot`** and **`addToRightSlot`**.

### Changes

* **`LeftRight.sol`**: Renamed `toLeftSlot` and `toRightSlot` to `addToLeftSlot` and `addToRightSlot` and updated the corresponding documentation.
* **Affected Contracts**: Updated all calls to these functions across the following contracts:
    * `CollateralTracker.sol`
    * `PanopticPool.sol`
    * `RiskEngine.sol`
    * `SemiFungiblePositionManager.sol`
    * `FeesCalc.sol`
    * `PanopticMath.sol`
    * All related test files.
* **Minor Optimization**: Changed function visibility from `public` to `external` in `FeesCalc.sol` for a minor gas optimization.

This is purely a refactoring effort to enhance code quality and maintainability. **No logical changes** have been made to the contract behavior.