### PR TITLE
feat: Simplify force exercise fee

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -966,7 +966,7 @@ contract PanopticPool is Multicall {
                         );
                     } else if (toLength == (finalLength + 1)) {
                         // final is one element shorter, that's a force exercise
-                        tokenId.validateIsExercisable(twapTick);
+                        if (tokenId.countLongs() == 0) revert Errors.NoLegsExercisable();
                         exchangedAmounts = _forceExercise(
                             account,
                             tokenId,

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -116,6 +116,9 @@ contract PanopticPool is Multicall {
     /// @notice Flag that signals to add a new position to the user's positions hash (as opposed to removing an existing position).
     bool internal constant ADD = true;
 
+    /// @notice Flag that signals to an account is solvent.
+    bool internal constant IS_SOLVENT = true;
+
     /// @notice The minimum window (in seconds) used to calculate the TWAP price for solvency checks during liquidations.
     uint32 internal constant TWAP_WINDOW = 600;
 
@@ -940,10 +943,10 @@ contract PanopticPool is Multicall {
         }
         LeftRightSigned exchangedAmounts;
         {
+            uint256 toLength = positionIdListTo.length;
+            uint256 finalLength = positionIdListToFinal.length;
             // if account is solvent at all ticks, this is a force exercise or a settleLongPremium.
             if (solvent == numberOfTicks) {
-                uint256 toLength = positionIdListTo.length;
-                uint256 finalLength = positionIdListToFinal.length;
                 unchecked {
                     tokenId = positionIdListTo[toLength - 1];
                     if (toLength == finalLength) {
@@ -964,7 +967,13 @@ contract PanopticPool is Multicall {
                     } else if (toLength == (finalLength + 1)) {
                         // final is one element shorter, that's a force exercise
                         tokenId.validateIsExercisable(twapTick);
-                        exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
+                        exchangedAmounts = _forceExercise(
+                            account,
+                            tokenId,
+                            twapTick,
+                            currentTick,
+                            IS_SOLVENT
+                        );
                     } else if (finalLength == 0) {
                         // if final length was zero, this was intended to be liquidation, but revert because not margin called and solvent at some of the tested ticks
                         revert Errors.NotMarginCalled();
@@ -985,9 +994,19 @@ contract PanopticPool is Multicall {
                 // if account is insolvent at all ticks, this is a liquidation
 
                 // if the positions lengths are the same, this was intended as a settleLongPremia, but revert because account is insolvent
-                if (positionIdListToFinal.length == positionIdListTo.length)
-                    revert Errors.AccountInsolvent(solvent, 4);
+                if (toLength == finalLength) revert Errors.AccountInsolvent(solvent, 4);
 
+                if (toLength == (finalLength + 1)) {
+                    // final is one element shorter, that's a forces closed through a force exercise
+                    tokenId = positionIdListTo[toLength - 1];
+                    exchangedAmounts = _forceExercise(
+                        account,
+                        tokenId,
+                        twapTick,
+                        currentTick,
+                        !IS_SOLVENT
+                    );
+                }
                 // if the final position list has a non-zero length, this can't be a complete liquidation, revert
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
                 exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
@@ -1111,7 +1130,8 @@ contract PanopticPool is Multicall {
         address account,
         TokenId tokenId,
         int24 twapTick,
-        int24 currentTick
+        int24 currentTick,
+        bool solvent
     ) internal returns (LeftRightSigned refundAmounts) {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
@@ -1119,14 +1139,11 @@ contract PanopticPool is Multicall {
         LeftRightSigned exerciseFees;
         uint128 positionSize;
         {
-            positionSize = s_positionBalance[account][tokenId].positionSize();
+            PositionBalance positionBalance = s_positionBalance[account][tokenId];
+
+            positionSize = positionBalance.positionSize();
 
             if (positionSize == 0) revert Errors.PositionNotOwned();
-
-            (LeftRightSigned longAmounts, ) = PanopticMath.computeExercisedAmounts(
-                tokenId,
-                positionSize
-            );
 
             // Compute the exerciseFee, this will decrease the further away the price is from the exercised position
             // Include any deltas in long legs between the current and oracle tick in the exercise fee
@@ -1134,8 +1151,8 @@ contract PanopticPool is Multicall {
                 currentTick,
                 twapTick,
                 tokenId,
-                positionSize,
-                longAmounts
+                positionBalance,
+                solvent
             );
         }
 

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -997,7 +997,7 @@ contract PanopticPool is Multicall {
                 if (toLength == finalLength) revert Errors.AccountInsolvent(solvent, 4);
 
                 if (toLength == (finalLength + 1)) {
-                    // final is one element shorter, that's a forces closed through a force exercise
+                    // final is one element shorter, that's a liquidation through a force exercise
                     tokenId = positionIdListTo[toLength - 1];
                     exchangedAmounts = _forceExercise(
                         account,
@@ -1159,11 +1159,12 @@ contract PanopticPool is Multicall {
         // The protocol delegates some virtual shares to ensure the burn can be settled.
         ct0.delegate(account);
         ct1.delegate(account);
+        LeftRightSigned netPaid;
 
         {
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
-            _burnOptions(
+            (netPaid, ) = _burnOptions(
                 tokenId,
                 positionSize,
                 MIN_SWAP_TICK,
@@ -1171,6 +1172,8 @@ contract PanopticPool is Multicall {
                 account,
                 COMMIT_LONG_SETTLED
             );
+
+            issueReceipt(tokenId, positionSize, account, netPaid);
         }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
         refundAmounts = s_riskEngine.getRefundAmounts(account, exerciseFees, twapTick, ct0, ct1);
@@ -1184,6 +1187,34 @@ contract PanopticPool is Multicall {
         ct1.revoke(account);
 
         emit ForcedExercised(msg.sender, account, tokenId, exerciseFees);
+    }
+
+    function issueReceipt(
+        TokenId tokenId,
+        uint128 positionSize,
+        address account,
+        LeftRightSigned netPaid
+    ) internal {
+        uint256 asset = tokenId.asset(0);
+        // add poolId information
+        TokenId tokenIdBase = TokenId.wrap(tokenId.poolId());
+
+        // add the tokenType=0 leg: a loan if the amount paid is negative, a credit if it is positive
+        tokenIdBase = tokenIdBase.addLeg(0, 1, asset, netPaid.rightSlot() < 0 ? 0 : 1, 0, 1, 0, 0);
+
+        // add the tokenType=1 leg: a loan if the amount paid is negative, a credit if it is positive
+        tokenIdBase = tokenIdBase.addLeg(1, 1, asset, netPaid.leftSlot() < 0 ? 0 : 1, 1, 0, 0, 0);
+
+        // issue the tokenId receipt to the user
+        _mintOptions(
+            tokenIdBase,
+            positionSize,
+            type(uint64).max,
+            account,
+            MIN_SWAP_TICK,
+            MAX_SWAP_TICK,
+            0
+        );
     }
 
     /// @notice Settle unpaid premium for one `legIndex` on a position owned by `owner`.

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -116,9 +116,6 @@ contract PanopticPool is Multicall {
     /// @notice Flag that signals to add a new position to the user's positions hash (as opposed to removing an existing position).
     bool internal constant ADD = true;
 
-    /// @notice Flag that signals to an account is solvent.
-    bool internal constant IS_SOLVENT = true;
-
     /// @notice The minimum window (in seconds) used to calculate the TWAP price for solvency checks during liquidations.
     uint32 internal constant TWAP_WINDOW = 600;
 
@@ -958,16 +955,11 @@ contract PanopticPool is Multicall {
                                 revert Errors.InputListFail();
                             }
                         }
-                        exchangedAmounts = _settleLongPremium(
-                            account,
-                            tokenId,
-                            twapTick,
-                            currentTick
-                        );
+                        _settleLongPremium(account, tokenId, twapTick, currentTick);
                     } else if (toLength == (finalLength + 1)) {
                         // final is one element shorter, that's a force exercise
                         if (tokenId.countLongs() == 0) revert Errors.NoLegsExercisable();
-                        exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
+                        _forceExercise(account, tokenId, twapTick, currentTick);
                     } else if (finalLength == 0) {
                         // if final length was zero, this was intended to be liquidation, but revert because not margin called and solvent at some of the tested ticks
                         revert Errors.NotMarginCalled();
@@ -1114,12 +1106,13 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         int24 twapTick,
         int24 currentTick
-    ) internal returns (LeftRightSigned refundAmounts) {
+    ) internal {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
-        LeftRightSigned exerciseFees;
         uint128 positionSize;
+
+        LeftRightSigned exerciseFees;
         {
             PositionBalance positionBalance = s_positionBalance[account][tokenId];
 
@@ -1140,11 +1133,10 @@ contract PanopticPool is Multicall {
         // The protocol delegates some virtual shares to ensure the burn can be settled.
         ct0.delegate(account);
         ct1.delegate(account);
-        LeftRightSigned netPaid;
         {
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
-            (netPaid, ) = _burnOptions(
+            _burnOptions(
                 tokenId,
                 positionSize,
                 MIN_SWAP_TICK,
@@ -1152,11 +1144,15 @@ contract PanopticPool is Multicall {
                 account,
                 COMMIT_LONG_SETTLED
             );
-
-            issueReceipt(tokenId, positionSize, account, netPaid);
         }
         // redistribute token composition of refund amounts if user doesn't have enough of one token to pay
-        refundAmounts = s_riskEngine.getRefundAmounts(account, exerciseFees, twapTick, ct0, ct1);
+        LeftRightSigned refundAmounts = s_riskEngine.getRefundAmounts(
+            account,
+            exerciseFees,
+            twapTick,
+            ct0,
+            ct1
+        );
 
         // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
         ct0.refund(account, msg.sender, refundAmounts.rightSlot());
@@ -1166,47 +1162,6 @@ contract PanopticPool is Multicall {
         ct1.revoke(account);
 
         emit ForcedExercised(msg.sender, account, tokenId, exerciseFees);
-    }
-
-    function issueReceipt(
-        TokenId tokenId,
-        uint128 positionSize,
-        address account,
-        LeftRightSigned netPaid
-    ) internal {
-        // add poolId information
-        /*
-       
-
-        // TODO use Uniswap's getTickAtSqrtPrice to extract an effective strike  
-        TokenId tokenIdBase0 = TokenId.wrap(tokenId.poolId());
-        // add the tokenType=0 leg: a loan if the amount paid is negative, a credit if it is positive
-        tokenIdBase0 = tokenIdBase0.addLeg(0, 1, 0, netPaid.rightSlot() < 0 ? 1 : 0, 0, 0, 0, 0);
-        
-        TokenId tokenIdBase1 = TokenId.wrap(tokenId.poolId());
-        // add the tokenType=1 leg: a loan if the amount paid is negative, a credit if it is positive
-        tokenIdBase1 = tokenIdBase1.addLeg(0, 1,1, netPaid.leftSlot() < 0 ? 1 : 0, 1, 0, 0, 0);
-        // issue the tokenId receipt to the user
-        _mintOptions(
-            tokenIdBase0,
-            uint128(uint256(Math.abs(netPaid.rightSlot()))),
-            type(uint64).max,
-            account,
-            MIN_SWAP_TICK,
-            MAX_SWAP_TICK,
-            0
-        );
-                
-        _mintOptions(
-            tokenIdBase1,
-            uint128(uint256(Math.abs(netPaid.leftSlot()))),
-            type(uint64).max,
-            account,
-            MIN_SWAP_TICK,
-            MAX_SWAP_TICK,
-            0
-        );
-        */
     }
 
     /// @notice Settle unpaid premium for one `legIndex` on a position owned by `owner`.
@@ -1219,7 +1174,7 @@ contract PanopticPool is Multicall {
         TokenId tokenId,
         int24 twapTick,
         int24 currentTick
-    ) internal returns (LeftRightSigned refundAmounts) {
+    ) internal {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
 
@@ -1231,6 +1186,7 @@ contract PanopticPool is Multicall {
 
         if (positionSize == 0) revert Errors.PositionNotOwned();
 
+        LeftRightSigned refundAmounts;
         for (uint256 leg = 0; leg < tokenId.countLegs(); ) {
             if (tokenId.width(leg) != 0 && tokenId.isLong(leg) != 0) {
                 LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -967,13 +967,7 @@ contract PanopticPool is Multicall {
                     } else if (toLength == (finalLength + 1)) {
                         // final is one element shorter, that's a force exercise
                         if (tokenId.countLongs() == 0) revert Errors.NoLegsExercisable();
-                        exchangedAmounts = _forceExercise(
-                            account,
-                            tokenId,
-                            twapTick,
-                            currentTick,
-                            IS_SOLVENT
-                        );
+                        exchangedAmounts = _forceExercise(account, tokenId, twapTick, currentTick);
                     } else if (finalLength == 0) {
                         // if final length was zero, this was intended to be liquidation, but revert because not margin called and solvent at some of the tested ticks
                         revert Errors.NotMarginCalled();
@@ -996,19 +990,8 @@ contract PanopticPool is Multicall {
                 // if the positions lengths are the same, this was intended as a settleLongPremia, but revert because account is insolvent
                 if (toLength == finalLength) revert Errors.AccountInsolvent(solvent, 4);
 
-                if (toLength == (finalLength + 1)) {
-                    // final is one element shorter, that's a liquidation through a force exercise
-                    tokenId = positionIdListTo[toLength - 1];
-                    exchangedAmounts = _forceExercise(
-                        account,
-                        tokenId,
-                        twapTick,
-                        currentTick,
-                        !IS_SOLVENT
-                    );
-                }
-                // if the final position list has a non-zero length, this can't be a complete liquidation, revert
                 if (positionIdListToFinal.length != 0) revert Errors.InputListFail();
+                // if the final position list has a non-zero length, this can't be a complete liquidation, revert
                 exchangedAmounts = _liquidate(account, positionIdListTo, twapTick, currentTick);
             } else {
                 // otherwise, revert because the account is not fully margin called
@@ -1130,8 +1113,7 @@ contract PanopticPool is Multicall {
         address account,
         TokenId tokenId,
         int24 twapTick,
-        int24 currentTick,
-        bool solvent
+        int24 currentTick
     ) internal returns (LeftRightSigned refundAmounts) {
         CollateralTracker ct0 = s_collateralToken0;
         CollateralTracker ct1 = s_collateralToken1;
@@ -1151,8 +1133,7 @@ contract PanopticPool is Multicall {
                 currentTick,
                 twapTick,
                 tokenId,
-                positionBalance,
-                solvent
+                positionBalance
             );
         }
 
@@ -1160,7 +1141,6 @@ contract PanopticPool is Multicall {
         ct0.delegate(account);
         ct1.delegate(account);
         LeftRightSigned netPaid;
-
         {
             // Exercise the option
             // Turn off ITM swapping to prevent swap at potentially unfavorable price
@@ -1181,7 +1161,6 @@ contract PanopticPool is Multicall {
         // settle difference between delegated amounts (from the protocol) and exercise fees/substituted tokens
         ct0.refund(account, msg.sender, refundAmounts.rightSlot());
         ct1.refund(account, msg.sender, refundAmounts.leftSlot());
-
         // revoke the virtual shares that were delegated after settling the difference with the exercisor
         ct0.revoke(account);
         ct1.revoke(account);
@@ -1195,26 +1174,39 @@ contract PanopticPool is Multicall {
         address account,
         LeftRightSigned netPaid
     ) internal {
-        uint256 asset = tokenId.asset(0);
         // add poolId information
-        TokenId tokenIdBase = TokenId.wrap(tokenId.poolId());
+        /*
+       
 
+        // TODO use Uniswap's getTickAtSqrtPrice to extract an effective strike  
+        TokenId tokenIdBase0 = TokenId.wrap(tokenId.poolId());
         // add the tokenType=0 leg: a loan if the amount paid is negative, a credit if it is positive
-        tokenIdBase = tokenIdBase.addLeg(0, 1, asset, netPaid.rightSlot() < 0 ? 0 : 1, 0, 1, 0, 0);
-
+        tokenIdBase0 = tokenIdBase0.addLeg(0, 1, 0, netPaid.rightSlot() < 0 ? 1 : 0, 0, 0, 0, 0);
+        
+        TokenId tokenIdBase1 = TokenId.wrap(tokenId.poolId());
         // add the tokenType=1 leg: a loan if the amount paid is negative, a credit if it is positive
-        tokenIdBase = tokenIdBase.addLeg(1, 1, asset, netPaid.leftSlot() < 0 ? 0 : 1, 1, 0, 0, 0);
-
+        tokenIdBase1 = tokenIdBase1.addLeg(0, 1,1, netPaid.leftSlot() < 0 ? 1 : 0, 1, 0, 0, 0);
         // issue the tokenId receipt to the user
         _mintOptions(
-            tokenIdBase,
-            positionSize,
+            tokenIdBase0,
+            uint128(uint256(Math.abs(netPaid.rightSlot()))),
             type(uint64).max,
             account,
             MIN_SWAP_TICK,
             MAX_SWAP_TICK,
             0
         );
+                
+        _mintOptions(
+            tokenIdBase1,
+            uint128(uint256(Math.abs(netPaid.leftSlot()))),
+            type(uint64).max,
+            account,
+            MIN_SWAP_TICK,
+            MAX_SWAP_TICK,
+            0
+        );
+        */
     }
 
     /// @notice Settle unpaid premium for one `legIndex` on a position owned by `owner`.

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -257,120 +257,86 @@ contract RiskEngine {
     /// @param oracleTick The price oracle tick
     /// @param tokenId The position to be exercised
     /// @param positionBalance The position data of the position to be exercised
-    /// @param solvent whether the account is solvent (positive cost = expense) or insolvent (negative cost = bonus)
     /// @return exerciseFees The fees for exercising the option position
     function exerciseCost(
         int24 currentTick,
         int24 oracleTick,
         TokenId tokenId,
-        PositionBalance positionBalance,
-        bool solvent
+        PositionBalance positionBalance
     ) external view returns (LeftRightSigned exerciseFees) {
         (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
             .computeExercisedAmounts(tokenId, positionBalance.positionSize());
         unchecked {
-            if (solvent) {
-                // we find whether the price is within any leg; any in-range leg will have a cost. Otherwise, the force-exercise fee is 1bps
-                bool hasLegsInRange;
+            // we find whether the price is within any leg; any in-range leg will have a cost. Otherwise, the force-exercise fee is 1bps
+            bool hasLegsInRange;
 
-                for (uint256 leg = 0; leg < tokenId.countLegs(); ++leg) {
-                    // short legs are not counted - exercise is intended to be based on long legs
-                    if (tokenId.isLong(leg) == 0) continue;
+            for (uint256 leg = 0; leg < tokenId.countLegs(); ++leg) {
+                // short legs are not counted - exercise is intended to be based on long legs
+                if (tokenId.isLong(leg) == 0) continue;
 
-                    {
-                        int24 range = int24(
-                            int256(
-                                Math.unsafeDivRoundingUp(
-                                    uint24(tokenId.width(leg) * tokenId.tickSpacing()),
-                                    2
-                                )
+                {
+                    int24 range = int24(
+                        int256(
+                            Math.unsafeDivRoundingUp(
+                                uint24(tokenId.width(leg) * tokenId.tickSpacing()),
+                                2
                             )
-                        );
-                        if (Math.abs(currentTick - tokenId.strike(leg)) < range)
-                            hasLegsInRange = true;
-                    }
+                        )
+                    );
+                    if (Math.abs(currentTick - tokenId.strike(leg)) < range) hasLegsInRange = true;
+                }
 
-                    uint256 currentValue0;
-                    uint256 currentValue1;
-                    uint256 oracleValue0;
-                    uint256 oracleValue1;
+                uint256 currentValue0;
+                uint256 currentValue1;
+                uint256 oracleValue0;
+                uint256 oracleValue1;
 
-                    {
-                        LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-                            tokenId,
-                            leg,
-                            positionBalance.positionSize()
-                        );
+                {
+                    LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                        tokenId,
+                        leg,
+                        positionBalance.positionSize()
+                    );
 
-                        (currentValue0, currentValue1) = Math.getAmountsForLiquidity(
-                            currentTick,
-                            liquidityChunk
-                        );
+                    (currentValue0, currentValue1) = Math.getAmountsForLiquidity(
+                        currentTick,
+                        liquidityChunk
+                    );
 
-                        (oracleValue0, oracleValue1) = Math.getAmountsForLiquidity(
-                            oracleTick,
-                            liquidityChunk
-                        );
-                    }
-
-                    // reverse any token deltas between the current and oracle prices for the chunk the exercisee had to mint in Uniswap
-                    // the outcome of current price crossing a long chunk will always be less favorable than the status quo, i.e.,
-                    // if the current price is moved downward such that some part of the chunk is between the current and market prices,
-                    // the chunk composition will swap token1 for token0 at a price (token0/token1) more favorable than market (token1/token0),
-                    // forcing the exercisee to provide more value in token0 than they would have provided in token1 at market, and vice versa.
-                    // (the excess value provided by the exercisee could then be captured in a return swap across their newly added liquidity)
-                    exerciseFees = exerciseFees.sub(
-                        LeftRightSigned
-                            .wrap(0)
-                            .addToRightSlot(
-                                int128(uint128(currentValue0)) - int128(uint128(oracleValue0))
-                            )
-                            .addToLeftSlot(
-                                int128(uint128(currentValue1)) - int128(uint128(oracleValue1))
-                            )
+                    (oracleValue0, oracleValue1) = Math.getAmountsForLiquidity(
+                        oracleTick,
+                        liquidityChunk
                     );
                 }
 
-                // NOTE: we HAVE to start with a negative number as the base exercise cost because when shifting a negative number right by n bits,
-                // the result is rounded DOWN and NOT toward zero
-                // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
-                // subtract 1 from max half ranges from strike so fee starts at FORCE_EXERCISE_COST when moving OTM
-                int256 fee = hasLegsInRange ? -int256(FORCE_EXERCISE_COST) : -1024;
-
-                // store the exercise fees in the exerciseFees variable
-                exerciseFees = exerciseFees
-                    .addToRightSlot(int128((longAmounts.rightSlot() * fee) / int256(DECIMALS)))
-                    .addToLeftSlot(int128((longAmounts.leftSlot() * fee) / int256(DECIMALS)));
-            } else {
-                int16 utilization0 = int16(positionBalance.utilization0());
-                int16 utilization1 = int16(positionBalance.utilization1());
-
-                uint128 positionSize = positionBalance.positionSize();
-                uint256 _tokenRequired0 = _getRequiredCollateralAtTickSinglePosition(
-                    tokenId,
-                    positionSize,
-                    currentTick,
-                    utilization0,
-                    true
+                // reverse any token deltas between the current and oracle prices for the chunk the exercisee had to mint in Uniswap
+                // the outcome of current price crossing a long chunk will always be less favorable than the status quo, i.e.,
+                // if the current price is moved downward such that some part of the chunk is between the current and market prices,
+                // the chunk composition will swap token1 for token0 at a price (token0/token1) more favorable than market (token1/token0),
+                // forcing the exercisee to provide more value in token0 than they would have provided in token1 at market, and vice versa.
+                // (the excess value provided by the exercisee could then be captured in a return swap across their newly added liquidity)
+                exerciseFees = exerciseFees.sub(
+                    LeftRightSigned
+                        .wrap(0)
+                        .addToRightSlot(
+                            int128(uint128(currentValue0)) - int128(uint128(oracleValue0))
+                        )
+                        .addToLeftSlot(
+                            int128(uint128(currentValue1)) - int128(uint128(oracleValue1))
+                        )
                 );
-
-                uint256 _tokenRequired1 = _getRequiredCollateralAtTickSinglePosition(
-                    tokenId,
-                    positionSize,
-                    currentTick,
-                    utilization1,
-                    false
-                );
-
-                // store the exercise fees in the exerciseFees variable, taken as 5x the required tokens times the FORCE_EXERCISE_COST (6.4% of fixed bonus is it is 1.28%)
-                exerciseFees = exerciseFees
-                    .addToRightSlot(
-                        int128(uint128((_tokenRequired0 * 5 * FORCE_EXERCISE_COST) / DECIMALS))
-                    )
-                    .addToLeftSlot(
-                        int128(uint128((_tokenRequired1 * 5 * FORCE_EXERCISE_COST) / DECIMALS))
-                    );
             }
+
+            // NOTE: we HAVE to start with a negative number as the base exercise cost because when shifting a negative number right by n bits,
+            // the result is rounded DOWN and NOT toward zero
+            // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
+            // subtract 1 from max half ranges from strike so fee starts at FORCE_EXERCISE_COST when moving OTM
+            int256 fee = hasLegsInRange ? -int256(FORCE_EXERCISE_COST) : -1024;
+
+            // store the exercise fees in the exerciseFees variable
+            exerciseFees = exerciseFees
+                .addToRightSlot(int128((longAmounts.rightSlot() * fee) / int256(DECIMALS)))
+                .addToLeftSlot(int128((longAmounts.leftSlot() * fee) / int256(DECIMALS)));
         }
     }
 

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -270,9 +270,8 @@ contract RiskEngine {
             .computeExercisedAmounts(tokenId, positionBalance.positionSize());
         unchecked {
             if (solvent) {
-                // find the leg furthest to the strike price `currentTick`; this will have the lowest exercise cost
-                // we don't need the leg information itself, really just "the number of half ranges" from the strike price:
-                uint256 maxNumRangesFromStrike = 1; // technically "maxNum(Half)RangesFromStrike" but the name is long
+                // we find whether the price is within any leg; any in-range leg will have a cost. Otherwise, the force-exercise fee is 1bps
+                bool hasLegsInRange;
 
                 for (uint256 leg = 0; leg < tokenId.countLegs(); ++leg) {
                     // short legs are not counted - exercise is intended to be based on long legs
@@ -287,10 +286,8 @@ contract RiskEngine {
                                 )
                             )
                         );
-                        maxNumRangesFromStrike = Math.max(
-                            maxNumRangesFromStrike,
-                            uint256(Math.abs(currentTick - tokenId.strike(leg)) / range)
-                        );
+                        if (Math.abs(currentTick - tokenId.strike(leg)) < range)
+                            hasLegsInRange = true;
                     }
 
                     uint256 currentValue0;
@@ -338,7 +335,7 @@ contract RiskEngine {
                 // the result is rounded DOWN and NOT toward zero
                 // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
                 // subtract 1 from max half ranges from strike so fee starts at FORCE_EXERCISE_COST when moving OTM
-                int256 fee = int256(-int256(FORCE_EXERCISE_COST) >> (maxNumRangesFromStrike - 1)); // exponential decay of fee based on number of half ranges away from the price
+                int256 fee = hasLegsInRange ? -int256(FORCE_EXERCISE_COST) : -1;
 
                 // store the exercise fees in the exerciseFees variable
                 exerciseFees = exerciseFees

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -255,92 +255,125 @@ contract RiskEngine {
     /// - 2.5% if between (850, 900) or (1150, 1200)
     /// @param currentTick The current price tick
     /// @param oracleTick The price oracle tick
-    /// @param positionId The position to be exercised
-    /// @param positionSize The size of the position to be exercised
-    /// @param longAmounts The amount of longs in the position
+    /// @param tokenId The position to be exercised
+    /// @param positionBalance The position data of the position to be exercised
+    /// @param solvent whether the account is solvent (positive cost = expense) or insolvent (negative cost = bonus)
     /// @return exerciseFees The fees for exercising the option position
     function exerciseCost(
         int24 currentTick,
         int24 oracleTick,
-        TokenId positionId,
-        uint128 positionSize,
-        LeftRightSigned longAmounts
+        TokenId tokenId,
+        PositionBalance positionBalance,
+        bool solvent
     ) external view returns (LeftRightSigned exerciseFees) {
-        // find the leg furthest to the strike price `currentTick`; this will have the lowest exercise cost
-        // we don't need the leg information itself, really just "the number of half ranges" from the strike price:
-        uint256 maxNumRangesFromStrike = 1; // technically "maxNum(Half)RangesFromStrike" but the name is long
-
+        (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
+            .computeExercisedAmounts(tokenId, positionBalance.positionSize());
         unchecked {
-            for (uint256 leg = 0; leg < positionId.countLegs(); ++leg) {
-                // short legs are not counted - exercise is intended to be based on long legs
-                if (positionId.isLong(leg) == 0) continue;
+            if (solvent) {
+                // find the leg furthest to the strike price `currentTick`; this will have the lowest exercise cost
+                // we don't need the leg information itself, really just "the number of half ranges" from the strike price:
+                uint256 maxNumRangesFromStrike = 1; // technically "maxNum(Half)RangesFromStrike" but the name is long
 
-                {
-                    int24 range = int24(
-                        int256(
-                            Math.unsafeDivRoundingUp(
-                                uint24(positionId.width(leg) * positionId.tickSpacing()),
-                                2
+                for (uint256 leg = 0; leg < tokenId.countLegs(); ++leg) {
+                    // short legs are not counted - exercise is intended to be based on long legs
+                    if (tokenId.isLong(leg) == 0) continue;
+
+                    {
+                        int24 range = int24(
+                            int256(
+                                Math.unsafeDivRoundingUp(
+                                    uint24(tokenId.width(leg) * tokenId.tickSpacing()),
+                                    2
+                                )
                             )
-                        )
-                    );
-                    maxNumRangesFromStrike = Math.max(
-                        maxNumRangesFromStrike,
-                        uint256(Math.abs(currentTick - positionId.strike(leg)) / range)
+                        );
+                        maxNumRangesFromStrike = Math.max(
+                            maxNumRangesFromStrike,
+                            uint256(Math.abs(currentTick - tokenId.strike(leg)) / range)
+                        );
+                    }
+
+                    uint256 currentValue0;
+                    uint256 currentValue1;
+                    uint256 oracleValue0;
+                    uint256 oracleValue1;
+
+                    {
+                        LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                            tokenId,
+                            leg,
+                            positionBalance.positionSize()
+                        );
+
+                        (currentValue0, currentValue1) = Math.getAmountsForLiquidity(
+                            currentTick,
+                            liquidityChunk
+                        );
+
+                        (oracleValue0, oracleValue1) = Math.getAmountsForLiquidity(
+                            oracleTick,
+                            liquidityChunk
+                        );
+                    }
+
+                    // reverse any token deltas between the current and oracle prices for the chunk the exercisee had to mint in Uniswap
+                    // the outcome of current price crossing a long chunk will always be less favorable than the status quo, i.e.,
+                    // if the current price is moved downward such that some part of the chunk is between the current and market prices,
+                    // the chunk composition will swap token1 for token0 at a price (token0/token1) more favorable than market (token1/token0),
+                    // forcing the exercisee to provide more value in token0 than they would have provided in token1 at market, and vice versa.
+                    // (the excess value provided by the exercisee could then be captured in a return swap across their newly added liquidity)
+                    exerciseFees = exerciseFees.sub(
+                        LeftRightSigned
+                            .wrap(0)
+                            .addToRightSlot(
+                                int128(uint128(currentValue0)) - int128(uint128(oracleValue0))
+                            )
+                            .addToLeftSlot(
+                                int128(uint128(currentValue1)) - int128(uint128(oracleValue1))
+                            )
                     );
                 }
 
-                uint256 currentValue0;
-                uint256 currentValue1;
-                uint256 oracleValue0;
-                uint256 oracleValue1;
+                // NOTE: we HAVE to start with a negative number as the base exercise cost because when shifting a negative number right by n bits,
+                // the result is rounded DOWN and NOT toward zero
+                // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
+                // subtract 1 from max half ranges from strike so fee starts at FORCE_EXERCISE_COST when moving OTM
+                int256 fee = int256(-int256(FORCE_EXERCISE_COST) >> (maxNumRangesFromStrike - 1)); // exponential decay of fee based on number of half ranges away from the price
 
-                {
-                    LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-                        positionId,
-                        leg,
-                        positionSize
-                    );
+                // store the exercise fees in the exerciseFees variable
+                exerciseFees = exerciseFees
+                    .addToRightSlot(int128((longAmounts.rightSlot() * fee) / int256(DECIMALS)))
+                    .addToLeftSlot(int128((longAmounts.leftSlot() * fee) / int256(DECIMALS)));
+            } else {
+                int16 utilization0 = int16(positionBalance.utilization0());
+                int16 utilization1 = int16(positionBalance.utilization1());
 
-                    (currentValue0, currentValue1) = Math.getAmountsForLiquidity(
-                        currentTick,
-                        liquidityChunk
-                    );
-
-                    (oracleValue0, oracleValue1) = Math.getAmountsForLiquidity(
-                        oracleTick,
-                        liquidityChunk
-                    );
-                }
-
-                // reverse any token deltas between the current and oracle prices for the chunk the exercisee had to mint in Uniswap
-                // the outcome of current price crossing a long chunk will always be less favorable than the status quo, i.e.,
-                // if the current price is moved downward such that some part of the chunk is between the current and market prices,
-                // the chunk composition will swap token1 for token0 at a price (token0/token1) more favorable than market (token1/token0),
-                // forcing the exercisee to provide more value in token0 than they would have provided in token1 at market, and vice versa.
-                // (the excess value provided by the exercisee could then be captured in a return swap across their newly added liquidity)
-                exerciseFees = exerciseFees.sub(
-                    LeftRightSigned
-                        .wrap(0)
-                        .addToRightSlot(
-                            int128(uint128(currentValue0)) - int128(uint128(oracleValue0))
-                        )
-                        .addToLeftSlot(
-                            int128(uint128(currentValue1)) - int128(uint128(oracleValue1))
-                        )
+                uint128 positionSize = positionBalance.positionSize();
+                uint256 _tokenRequired0 = _getRequiredCollateralAtTickSinglePosition(
+                    tokenId,
+                    positionSize,
+                    currentTick,
+                    utilization0,
+                    true
                 );
+
+                uint256 _tokenRequired1 = _getRequiredCollateralAtTickSinglePosition(
+                    tokenId,
+                    positionSize,
+                    currentTick,
+                    utilization1,
+                    false
+                );
+
+                // store the exercise fees in the exerciseFees variable, taken as 10x the required tokens times the FORCE_EXERCISE_COST
+                exerciseFees = exerciseFees
+                    .addToRightSlot(
+                        int128(uint128((_tokenRequired0 * 10 * FORCE_EXERCISE_COST) / DECIMALS))
+                    )
+                    .addToLeftSlot(
+                        int128(uint128((_tokenRequired1 * 10 * FORCE_EXERCISE_COST) / DECIMALS))
+                    );
             }
-
-            // NOTE: we HAVE to start with a negative number as the base exercise cost because when shifting a negative number right by n bits,
-            // the result is rounded DOWN and NOT toward zero
-            // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
-            // subtract 1 from max half ranges from strike so fee starts at FORCE_EXERCISE_COST when moving OTM
-            int256 fee = int256(-int256(FORCE_EXERCISE_COST) >> (maxNumRangesFromStrike - 1)); // exponential decay of fee based on number of half ranges away from the price
-
-            // store the exercise fees in the exerciseFees variable
-            exerciseFees = exerciseFees
-                .addToRightSlot(int128((longAmounts.rightSlot() * fee) / int256(DECIMALS)))
-                .addToLeftSlot(int128((longAmounts.leftSlot() * fee) / int256(DECIMALS)));
         }
     }
 

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -335,7 +335,7 @@ contract RiskEngine {
                 // the result is rounded DOWN and NOT toward zero
                 // this divergence is observed when n (the number of half ranges) is > 10 (ensuring the floor is not zero, but -1 = 1bps at that point)
                 // subtract 1 from max half ranges from strike so fee starts at FORCE_EXERCISE_COST when moving OTM
-                int256 fee = hasLegsInRange ? -int256(FORCE_EXERCISE_COST) : -1;
+                int256 fee = hasLegsInRange ? -int256(FORCE_EXERCISE_COST) : -1024;
 
                 // store the exercise fees in the exerciseFees variable
                 exerciseFees = exerciseFees
@@ -362,13 +362,13 @@ contract RiskEngine {
                     false
                 );
 
-                // store the exercise fees in the exerciseFees variable, taken as 10x the required tokens times the FORCE_EXERCISE_COST
+                // store the exercise fees in the exerciseFees variable, taken as 5x the required tokens times the FORCE_EXERCISE_COST (6.4% of fixed bonus is it is 1.28%)
                 exerciseFees = exerciseFees
                     .addToRightSlot(
-                        int128(uint128((_tokenRequired0 * 10 * FORCE_EXERCISE_COST) / DECIMALS))
+                        int128(uint128((_tokenRequired0 * 5 * FORCE_EXERCISE_COST) / DECIMALS))
                     )
                     .addToLeftSlot(
-                        int128(uint128((_tokenRequired1 * 10 * FORCE_EXERCISE_COST) / DECIMALS))
+                        int128(uint128((_tokenRequired1 * 5 * FORCE_EXERCISE_COST) / DECIMALS))
                     );
             }
         }

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -17,7 +17,7 @@ import {Errors} from "@libraries/Errors.sol";
 import {LeftRightUnsigned, LeftRightSigned} from "@types/LeftRight.sol";
 import {TokenId} from "@types/TokenId.sol";
 import {LiquidityChunk} from "@types/LiquidityChunk.sol";
-import {PositionBalance} from "@types/PositionBalance.sol";
+import {PositionBalance, PositionBalanceLibrary} from "@types/PositionBalance.sol";
 import {Constants} from "@libraries/Constants.sol";
 // Panoptic Interfaces
 import {IERC20Partial} from "@tokens/interfaces/IERC20Partial.sol";
@@ -10074,8 +10074,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 atTick,
                 atTick, // use the fuzzed tick as the median tick for testing purposes
                 tokenId1,
-                positionSize0 / 4,
-                longAmounts
+                PositionBalanceLibrary.storeBalanceData((positionSize0 / 4), 0, 0)
             );
 
             assertEq(exerciseFees.rightSlot(), exerciseFee0);
@@ -10215,8 +10214,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 atTick,
                 atTick, // use the fuzzed tick as the median tick for testing purposes
                 tokenId1,
-                positionSize0 / 4,
-                longAmounts
+                PositionBalanceLibrary.storeBalanceData(positionSize0 / 4, 0, 0)
             );
 
             assertEq(exerciseFees.rightSlot(), exerciseFee0);
@@ -10356,8 +10354,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 atTick,
                 atTick, // use the fuzzed tick as the median tick for testing purposes
                 tokenId1,
-                positionSize0 / 4,
-                longAmounts
+                PositionBalanceLibrary.storeBalanceData(positionSize0 / 4, 0, 0)
             );
 
             assertEq(exerciseFees.rightSlot(), exerciseFee0);
@@ -10497,8 +10494,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 atTick,
                 atTick, // use the fuzzed tick as the median tick for testing purposes
                 tokenId1,
-                positionSize0 / 4,
-                longAmounts
+                PositionBalanceLibrary.storeBalanceData(positionSize0 / 4, 0, 0)
             );
 
             assertEq(exerciseFees.rightSlot(), exerciseFee0);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -1789,15 +1789,20 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 600);
         vm.roll(block.number + 1);
 
-        swapperc.swapTo(uniPool, 10 * 2 ** 96);
-
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(512));
+        pp.pokeOracle();
         vm.warp(block.timestamp + 600);
         vm.roll(block.number + 1);
 
         swapperc.mint(uniPool, -10, 10, 10 ** 18);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
 
-        PanopticMath.twapFilter(uniPool, 600);
+        (currentTick, fastOracleTick, slowOracleTick, lastObservedTick, oraclePack) = pp
+            .getOracleTicks();
+        twapTick = re.twapEMA(oraclePack);
+        console2.log("cur", currentTick);
+        console2.log("twapTick", twapTick);
+        vm.assume(Math.abs(currentTick - twapTick) < 513);
 
         vm.startPrank(Bob);
         forceExercise(
@@ -2242,15 +2247,21 @@ contract Misctest is Test, PositionUtils {
         vm.warp(block.timestamp + 600);
         vm.roll(block.number + 1);
 
-        swapperc.swapTo(uniPool, 10 * 2 ** 96);
+        swapperc.swapTo(uniPool, Math.getSqrtRatioAtTick(512));
 
+        pp.pokeOracle();
         vm.warp(block.timestamp + 600);
         vm.roll(block.number + 1);
 
         swapperc.mint(uniPool, -10, 10, 10 ** 18);
         swapperc.burn(uniPool, -10, 10, 10 ** 18);
 
-        twapTick = PanopticMath.twapFilter(uniPool, 600);
+        (currentTick, fastOracleTick, slowOracleTick, lastObservedTick, oraclePack) = pp
+            .getOracleTicks();
+        twapTick = re.twapEMA(oraclePack);
+        console2.log("cur", currentTick);
+        console2.log("twapTick", twapTick);
+        vm.assume(Math.abs(currentTick - twapTick) < 513);
 
         vm.startPrank(Bob);
         forceExercise(


### PR DESCRIPTION
## Description

~~This PR introduces the ability for liquidators to perform **partial liquidations** by targeting a single, risky position from an insolvent account, rather than being forced to liquidate the account's entire portfolio.~~

I removed the partial liquidation because it was exposing the protocol to liquidation-based attacks because it did not go through the haircutPremia logic, etc of the regular liquidation flow.

This PR refactors the `exerciseCost` function in `RiskEngine.sol` to **significantly simplify its fee logic.**

The previous complex, exponentially-decaying fee calculation (based on `maxNumRangesFromStrike`) has been **removed**. It is replaced with a much simpler binary check:

* If any long leg of the position is in range (`hasLegsInRange` is true), the fee is set to `FORCE_EXERCISE_COST`.
* Otherwise, the fee is a flat, currently at `-1024` (1bps) but could be hardcoded to be lower.

This core change also allowed for a simplification of the `exerciseCost` function signature, which in turn required updating the `PanopticPool.sol` contract where it's called.

**Key Changes:**

#### `RiskEngine.sol`
* **Simplified `exerciseCost` Signature:**
    * The function no longer accepts `positionId`, `positionSize`, and `longAmounts` as separate arguments.
    * It now takes `tokenId` and the complete `PositionBalance` struct.
* **Internal Calculation:** `exerciseCost` now calculates `longAmounts` and `shortAmounts` internally by calling `PanopticMath.computeExercisedAmounts` with the provided `positionBalance`.
* **Simplified Fee Logic:**
    * The previous complex fee calculation, which involved finding the `maxNumRangesFromStrike` for an exponential decay, has been removed.
    * The new logic is a binary check: if any long leg is in range (`hasLegsInRange`), the fee is set to `FORCE_EXERCISE_COST`. Otherwise, it's a flat fee of `-1024` (1bps).
