### PR TITLE
Feat: Factor Net Liquidation Value (NLV) into liquidation bonus

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1013,6 +1013,7 @@ contract PanopticPool is Multicall {
         LeftRightUnsigned tokenData0;
         LeftRightUnsigned tokenData1;
         LeftRightUnsigned shortPremium;
+        LeftRightSigned netLiq;
         {
             uint256[] memory positionBalanceArray = new uint256[](positionIdList.length);
             LeftRightUnsigned longPremium;
@@ -1022,6 +1023,13 @@ contract PanopticPool is Multicall {
                 COMPUTE_PREMIA_AS_COLLATERAL,
                 ONLY_AVAILABLE_PREMIUM,
                 currentTick
+            );
+            netLiq = s_riskEngine.getNetLiquidationValue(
+                positionIdList,
+                positionBalanceArray,
+                twapTick,
+                shortPremium,
+                longPremium
             );
             (tokenData0, tokenData1) = s_riskEngine.getMargin(
                 liquidatee,
@@ -1060,6 +1068,7 @@ contract PanopticPool is Multicall {
             (bonusAmounts, collateralRemaining) = s_riskEngine.getLiquidationBonus(
                 tokenData0,
                 tokenData1,
+                netLiq,
                 Math.getSqrtRatioAtTick(twapTick),
                 netPaid,
                 shortPremium

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -386,6 +386,11 @@ contract RiskEngine {
                     } else {
                         bonusCross = balanceCross / 2;
                     }
+                    // ensure the bonus is at least 1bps of the total balance
+                    bonusCross = Math.max(
+                        bonusCross,
+                        Math.mulDivRoundingUp(balanceCross, 1_000, DECIMALS)
+                    );
                 }
                 // `bonusCross` and `thresholdCross` are returned in terms of the lowest-priced token
                 if (atSqrtPriceX96 < Constants.FP96) {

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -351,6 +351,7 @@ contract RiskEngine {
     function getLiquidationBonus(
         LeftRightUnsigned tokenData0,
         LeftRightUnsigned tokenData1,
+        LeftRightSigned netLiq,
         uint160 atSqrtPriceX96,
         LeftRightSigned netPaid,
         LeftRightUnsigned shortPremium
@@ -360,16 +361,32 @@ contract RiskEngine {
         unchecked {
             // compute bonus as min(collateralBalance/2, required-collateralBalance)
             {
-                // compute the ratio of token0 to total collateral requirements
-                // evaluate at TWAP price to maintain consistency with solvency calculations
-                (uint256 balanceCross, uint256 thresholdCross) = PanopticMath.getCrossBalances(
-                    tokenData0,
-                    tokenData1,
-                    atSqrtPriceX96
-                );
-
-                uint256 bonusCross = Math.min(balanceCross / 2, thresholdCross - balanceCross);
-
+                uint256 thresholdCross;
+                uint256 bonusCross;
+                {
+                    uint256 balanceCross;
+                    // compute the ratio of token0 to total collateral requirements
+                    // evaluate at TWAP price to maintain consistency with solvency calculations
+                    (balanceCross, thresholdCross) = PanopticMath.getCrossBalances(
+                        tokenData0,
+                        tokenData1,
+                        atSqrtPriceX96
+                    );
+                    int256 netLiqCross = PanopticMath.getCrossBalances(netLiq, atSqrtPriceX96);
+                    if (thresholdCross < balanceCross + uint256(Math.max(0, netLiqCross))) {
+                        bonusCross = 0;
+                    } else if (
+                        thresholdCross - balanceCross - uint256(Math.max(0, netLiqCross)) <
+                        balanceCross / 2
+                    ) {
+                        bonusCross =
+                            thresholdCross -
+                            balanceCross -
+                            uint256(Math.max(0, netLiqCross));
+                    } else {
+                        bonusCross = balanceCross / 2;
+                    }
+                }
                 // `bonusCross` and `thresholdCross` are returned in terms of the lowest-priced token
                 if (atSqrtPriceX96 < Constants.FP96) {
                     // required0 / (required0 + token0(required1))
@@ -593,6 +610,81 @@ contract RiskEngine {
         }
 
         return atTicks;
+    }
+
+    /// @notice Calculate approximate NLV of user's option portfolio (token delta after closing `positionIdList`) at a given tick.
+    /// @param atTick The tick to calculate the value at
+    /// @param positionIdList A list of all positions the user holds on that pool
+    /// @param positionBalanceArray The list of all open positions held by the `optionOwner`, stored as `[balance/poolUtilizationAtMint, ...]`
+    /// @param shortPremia The total amount of premium (prorated by available settled tokens) owed to the short legs of `user`
+    /// @param longPremia The total amount of premium owed by the long legs of `user`
+    /// @return netLiq The NLV of token0 (right) and token1 (left) for `positionIdList` positions owned by `account` at the price `atTick`
+    function getNetLiquidationValue(
+        TokenId[] calldata positionIdList,
+        uint256[] calldata positionBalanceArray,
+        int24 atTick,
+        LeftRightUnsigned shortPremia,
+        LeftRightUnsigned longPremia
+    ) external view returns (LeftRightSigned netLiq) {
+        // Compute premia for all options (includes short+long premium)
+
+        int256 value0;
+        int256 value1;
+
+        for (uint256 k = 0; k < positionIdList.length; ) {
+            TokenId tokenId = positionIdList[k];
+            uint128 positionSize = PositionBalance.wrap(positionBalanceArray[k]).positionSize();
+            for (uint256 leg = 0; leg < tokenId.countLegs(); ) {
+                uint256 amount0;
+                uint256 amount1;
+                {
+                    LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                        tokenId,
+                        leg,
+                        positionSize
+                    );
+
+                    (amount0, amount1) = Math.getAmountsForLiquidity(atTick, liquidityChunk);
+                }
+                if (tokenId.isLong(leg) == 0) {
+                    unchecked {
+                        value0 += int256(amount0);
+                        value1 += int256(amount1);
+                    }
+                } else {
+                    unchecked {
+                        value0 -= int256(amount0);
+                        value1 -= int256(amount1);
+                    }
+                }
+
+                unchecked {
+                    ++leg;
+                }
+            }
+
+            (LeftRightSigned longAmounts, LeftRightSigned shortAmounts) = PanopticMath
+                .computeExercisedAmounts(tokenId, positionSize);
+
+            value0 += int256(longAmounts.rightSlot()) - int256(shortAmounts.rightSlot());
+            value1 += int256(longAmounts.leftSlot()) - int256(shortAmounts.leftSlot());
+
+            unchecked {
+                ++k;
+            }
+        }
+
+        unchecked {
+            value0 +=
+                int256(uint256(shortPremia.rightSlot())) -
+                int256(uint256(longPremia.rightSlot()));
+            value1 +=
+                int256(uint256(shortPremia.leftSlot())) -
+                int256(uint256(longPremia.leftSlot()));
+        }
+        netLiq = LeftRightSigned.wrap(0).addToRightSlot(int128(value0)).addToLeftSlot(
+            int128(value1)
+        );
     }
 
     /// @notice Get the collateral status/margin details of an account/user.

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -638,13 +638,26 @@ contract RiskEngine {
                 uint256 amount0;
                 uint256 amount1;
                 {
-                    LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-                        tokenId,
-                        leg,
-                        positionSize
-                    );
+                    if (tokenId.width(leg) != 0) {
+                        LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
+                            tokenId,
+                            leg,
+                            positionSize
+                        );
 
-                    (amount0, amount1) = Math.getAmountsForLiquidity(atTick, liquidityChunk);
+                        (amount0, amount1) = Math.getAmountsForLiquidity(atTick, liquidityChunk);
+                    } else {
+                        LeftRightUnsigned amountsMoved = PanopticMath.getAmountsMoved(
+                            tokenId,
+                            positionSize,
+                            leg
+                        );
+                        if (tokenId.tokenType(leg) == 0) {
+                            amount0 = amountsMoved.rightSlot();
+                        } else {
+                            amount1 = amountsMoved.leftSlot();
+                        }
+                    }
                 }
                 if (tokenId.isLong(leg) == 0) {
                     unchecked {

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -934,6 +934,22 @@ library PanopticMath {
         }
     }
 
+    /// @notice Get a single balance in terms of the lowest-priced token for a given set of (token0/token1) balances.
+    /// @param netLiq LeftRight encoded word with balance of token0 in the right slot, and balance of token1 in left slot
+    /// @param sqrtPriceX96 The price at which to compute the collateral value and requirements
+    /// @return The combined balances of netLiq in terms of (token0 if `price(token1/token0) < 1` and vice versa)
+    function getCrossBalances(
+        LeftRightSigned netLiq,
+        uint160 sqrtPriceX96
+    ) internal pure returns (int256) {
+        // convert values to the highest precision (lowest price) of the two tokens (token0 if price token1/token0 < 1 and vice versa)
+        if (sqrtPriceX96 < Constants.FP96) {
+            return netLiq.rightSlot() + PanopticMath.convert1to0(netLiq.leftSlot(), sqrtPriceX96);
+        }
+
+        return PanopticMath.convert0to1(netLiq.rightSlot(), sqrtPriceX96) + netLiq.leftSlot();
+    }
+
     /// @notice Get a single collateral balance and requirement in terms of the lowest-priced token for a given set of (token0/token1) collateral balances and requirements.
     /// @param tokenData0 LeftRight encoded word with balance of token0 in the right slot, and required balance in left slot
     /// @param tokenData1 LeftRight encoded word with balance of token1 in the right slot, and required balance in left slot


### PR DESCRIPTION
### Summary

This PR refines the liquidation bonus calculation to make it more accurate and fair.

Previously, the liquidation bonus was calculated based on the user's collateral deficit (`required_collateral - available_collateral`) alone. This approach did not account for the intrinsic value of the user's option portfolio itself. As a result, a liquidator could be overpaid if they were liquidating a user who was undercollateralized but held a portfolio with a positive Net Liquidation Value (NLV) (e.g., long in-the-money options).

This change introduces the portfolio's NLV into the bonus calculation. The bonus is now based on the user's *net* deficit, effectively calculated as:

`Deficit = required_collateral - (available_collateral + max(0, NLV))`

This ensures that any positive value in the user's option book is used to offset their collateral requirement *before* a bonus is calculated, leading to smaller, more appropriate bonuses. That bonus could be zero for some accounts (eg. with deep ITM long options).

### Changes

1.  **`RiskEngine.sol`:**
    * Adds a new `public view` function `getNetLiquidationValue`. This function iterates through a user's `positionIdList` to calculate the portfolio's total intrinsic value (NLV) in token0 and token1 at a given `atTick`.
    * Updates `getLiquidationBonus` to accept a new `LeftRightSigned netLiq` parameter.
    * The core bonus logic is modified to use this `netLiq`. It calculates a `netLiqCross` (the price-adjusted NLV) and subtracts it from the collateral deficit. If the user is net solvent (`collateral + NLV >= required`), the bonus is correctly set to `0`.

2.  **`PanopticPool.sol`:**
    * In the `_liquidate` function, the pool now calls `s_riskEngine.getNetLiquidationValue` to get the portfolio's NLV *before* calculating the bonus.
    * This `netLiq` is then passed into the `s_riskEngine.getLiquidationBonus` function.

3.  **`PanopticMath.sol`:**
    * Adds an overloaded `getCrossBalances` function that accepts a `LeftRightSigned` struct. This is a helper function needed to convert the two-token `netLiq` (which can be positive or negative) into a single, price-adjusted `int256` value for the bonus calculation.

---

### ⚠️ To-Do (WIP)

This PR contains the core logic but is still a work-in-progress. The following are required before it's ready for merge:

* [ ] Add new unit tests for `RiskEngine.getNetLiquidationValue`.
* [ ] Update existing tests for `RiskEngine.getLiquidationBonus` to cover new scenarios with positive, negative, and zero NLV.
* [ ] Update integration/fork tests for `PanopticPool._liquidate` to ensure the end-to-end flow is correct.