### PR TITLE
Feat: Implement builder fee-sharing mechanism and protocol fee

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -62,6 +62,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
         uint256 shares
     );
 
+    event CommissionPaid(address indexed payer, address indexed recipient, uint256 commission);
+
     /*//////////////////////////////////////////////////////////////
                                CONSTANTS
     //////////////////////////////////////////////////////////////*/
@@ -1073,23 +1075,60 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     ) internal returns (uint32, uint128, int128) {
         _accrueInterest(optionOwner);
         unchecked {
-            int256 tokenToPay;
-            uint128 commission;
-
             // current available assets belonging to PLPs (updated after settlement) excluding any premium paid
             int256 updatedAssets = int256(uint256(s_poolAssets)) - swappedAmount;
 
+            uint256 _totalSupply = totalSupply;
+            uint256 _totalAssets = totalAssets();
+            int256 tokenToPay;
+
             if (isCreation) {
                 {
-                    int256 intrinsicValue = int256(swappedAmount) - (shortAmount - longAmount);
+                    tokenToPay = int256(swappedAmount) - (shortAmount - longAmount);
                     // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
-                    commission = uint128(
+                    uint128 commission = uint128(
                         Math.unsafeDivRoundingUp(
                             uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
                             DECIMALS
                         )
                     );
-                    tokenToPay = intrinsicValue + int128(commission);
+                    uint256 commissionShares = Math.mulDivRoundingUp(
+                        commission,
+                        _totalSupply,
+                        _totalAssets
+                    );
+                    uint256 builderCode;
+                    {
+                        bytes32 slot = Constants.BUILDER_CODE_TRANSIENT_SLOT;
+                        assembly {
+                            builderCode := tload(slot)
+                        }
+                    }
+                    if (builderCode != 0) {
+                        _transferFrom(
+                            optionOwner,
+                            address(uint160(builderCode)),
+                            commissionShares / 10
+                        );
+                        emit CommissionPaid(
+                            optionOwner,
+                            address(uint160(builderCode)),
+                            commission / 10
+                        );
+                        _transferFrom(
+                            optionOwner,
+                            address(s_riskEngine),
+                            (4 * commissionShares) / 5
+                        );
+                        emit CommissionPaid(
+                            optionOwner,
+                            address(s_riskEngine),
+                            (4 * commission) / 5
+                        );
+                    } else {
+                        _transferFrom(optionOwner, address(s_riskEngine), commissionShares);
+                        emit CommissionPaid(optionOwner, address(s_riskEngine), commission);
+                    }
                 }
             } else {
                 // add premium and token deltas not covered by swap to be paid/collected on position close
@@ -1100,8 +1139,8 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             if (tokenToPay > 0) {
                 uint256 sharesToBurn = Math.mulDivRoundingUp(
                     uint256(tokenToPay),
-                    totalSupply,
-                    totalAssets()
+                    _totalSupply,
+                    _totalAssets
                 );
                 address _optionOwner = optionOwner;
                 if (balanceOf[_optionOwner] < sharesToBurn)
@@ -1113,7 +1152,11 @@ contract CollateralTracker is ERC20Minimal, Multicall {
 
                 _burn(optionOwner, sharesToBurn);
             } else if (tokenToPay < 0) {
-                uint256 sharesToMint = convertToShares(uint256(-tokenToPay));
+                uint256 sharesToMint = Math.mulDiv(
+                    uint256(-tokenToPay),
+                    _totalSupply,
+                    _totalAssets
+                );
                 _mint(optionOwner, sharesToMint);
             }
 
@@ -1140,7 +1183,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
                 );
             }
             uint32 utilization = isCreation ? uint32(_poolUtilization()) : 0;
-            return (utilization, commission, int128(tokenToPay));
+            return (utilization, 0, int128(tokenToPay));
         }
     }
 

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1083,58 +1083,43 @@ contract CollateralTracker is ERC20Minimal, Multicall {
             int256 tokenToPay;
 
             if (isCreation) {
+                tokenToPay = int256(swappedAmount) - (shortAmount - longAmount);
+            } else {
+                // add premium and token deltas not covered by swap to be paid/collected on position close
+                tokenToPay = int256(swappedAmount) - (longAmount - shortAmount) - realizedPremium;
+            }
+            // commissions, to be paid for all transactions.
+            {
+                uint128 commission = uint128(
+                    Math.unsafeDivRoundingUp(
+                        uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
+                        DECIMALS
+                    )
+                );
+                address builderCodeRecipient;
                 {
-                    tokenToPay = int256(swappedAmount) - (shortAmount - longAmount);
-                    // the swap commission is paid on the intrinsic value (if a swap occurred; users who mint covered options with their own collateral do not pay this fee)
-                    uint128 commission = uint128(
-                        Math.unsafeDivRoundingUp(
-                            uint256(uint128(shortAmount + longAmount)) * COMMISSION_FEE,
-                            DECIMALS
-                        )
-                    );
+                    bytes32 slot = Constants.BUILDER_CODE_TRANSIENT_SLOT;
+                    assembly {
+                        builderCodeRecipient := tload(slot)
+                    }
+                }
+                if (builderCodeRecipient != address(0)) {
                     uint256 commissionShares = Math.mulDivRoundingUp(
                         commission,
                         _totalSupply,
                         _totalAssets
                     );
-                    uint256 builderCode;
-                    {
-                        bytes32 slot = Constants.BUILDER_CODE_TRANSIENT_SLOT;
-                        assembly {
-                            builderCode := tload(slot)
-                        }
-                    }
-                    if (builderCode != 0) {
-                        _transferFrom(
-                            optionOwner,
-                            address(uint160(builderCode)),
-                            commissionShares / 10
-                        );
-                        emit CommissionPaid(
-                            optionOwner,
-                            address(uint160(builderCode)),
-                            commission / 10
-                        );
-                        _transferFrom(
-                            optionOwner,
-                            address(s_riskEngine),
-                            (4 * commissionShares) / 5
-                        );
-                        emit CommissionPaid(
-                            optionOwner,
-                            address(s_riskEngine),
-                            (4 * commission) / 5
-                        );
-                    } else {
-                        _transferFrom(optionOwner, address(s_riskEngine), commissionShares);
-                        emit CommissionPaid(optionOwner, address(s_riskEngine), commission);
-                    }
-                }
-            } else {
-                // add premium and token deltas not covered by swap to be paid/collected on position close
-                tokenToPay = int256(swappedAmount) - (longAmount - shortAmount) - realizedPremium;
-            }
 
+                    _transferFrom(optionOwner, builderCodeRecipient, commissionShares / 10);
+                    emit CommissionPaid(optionOwner, builderCodeRecipient, commission / 10);
+                    _transferFrom(optionOwner, address(s_riskEngine), (4 * commissionShares) / 5);
+                    emit CommissionPaid(optionOwner, address(s_riskEngine), (4 * commission) / 5);
+                } else {
+                    // if no builder code is supplied, pay the commission by burning share tokens
+                    tokenToPay += int128(commission);
+                    emit CommissionPaid(optionOwner, address(this), commission);
+                }
+            }
             // Mint/Burn Shares
             if (tokenToPay > 0) {
                 uint256 sharesToBurn = Math.mulDivRoundingUp(

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -530,9 +530,10 @@ contract PanopticPool is Multicall {
         bool usePremiaAsCollateral
     ) external {
         if (builderCode != 0) {
+            address recipient = address(uint160((builderCode)));
             bytes32 slot = Constants.BUILDER_CODE_TRANSIENT_SLOT;
             assembly {
-                tstore(slot, builderCode)
+                tstore(slot, recipient)
             }
         }
         // if safeMode, enforce covered at mint and exercise at burn

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -519,14 +519,22 @@ contract PanopticPool is Multicall {
     /// denominated as X32 = (`ratioLimit * 2^32`)
     /// @param tickLimits The lower and lower bounds of an acceptable open interval for the ending price
     /// @param usePremiaAsCollateral Whether to compute accumulated premia for all legs held by the user for collateral (true), or just owed premia for long legs (false)
+    /// @param builderCode The user-provided code to (re)direct the fees to.
     function dispatch(
         TokenId[] calldata positionIdList,
         TokenId[] calldata finalPositionIdList,
+        uint256 builderCode,
         uint128[] calldata positionSizes,
         uint64[] calldata effectiveLiquidityLimitsX32,
         int24[2][] calldata tickLimits,
         bool usePremiaAsCollateral
     ) external {
+        if (builderCode != 0) {
+            bytes32 slot = Constants.BUILDER_CODE_TRANSIENT_SLOT;
+            assembly {
+                tstore(slot, builderCode)
+            }
+        }
         // if safeMode, enforce covered at mint and exercise at burn
         uint8 safeMode = isSafeMode();
 

--- a/contracts/libraries/Constants.sol
+++ b/contracts/libraries/Constants.sol
@@ -21,6 +21,10 @@ library Constants {
     uint160 internal constant MAX_V3POOL_SQRT_RATIO =
         1461446703485210103287273052203988822378723970342;
 
+    /// @dev The transient storage slot for the builder code.
+    /// Used to pass the builderCode across contract calls within a single transaction.
+    bytes32 internal constant BUILDER_CODE_TRANSIENT_SLOT = keccak256("panoptic.builder.code");
+
     /// @notice Parameter that determines which oracle type to use for the "slow" oracle price on non-liquidation solvency checks.
     /// @dev If false, an 8-slot internal median array is used to compute the "slow" oracle price.
     /// @dev This oracle is updated with the last Uniswap observation during `mintOptions` if MEDIAN_PERIOD has elapsed past the last observation.


### PR DESCRIPTION
**Description:**

This PR introduces a new fee-sharing mechanism for "builders" (e.g., UIs, integrators, or referrers).

When a user performs an action via the `dispatch` function, they can now optionally provide a `builderCode`. If provided, the commission fee is split between the builder and the risk engine, and the user receives a 10% discount on the fee as an incentive.

> **Note:** This PR is a work-in-progress. Further development, particularly the addition of comprehensive tests, is still required.

### Implementation Details

This mechanism works by passing the builder's address from `PanopticPool` to `CollateralTracker` within a single transaction using **transient storage** (EIP-1153).

1.  **`Constants.sol`**:
    * A new transient storage slot, `BUILDER_CODE_TRANSIENT_SLOT`, is defined to act as the "pipe" for the builder's address.

2.  **`PanopticPool.sol`**:
    * The `dispatch` function now accepts a `uint256 builderCode` argument.
    * If `builderCode` is not zero, it's stored in `BUILDER_CODE_TRANSIENT_SLOT` using `tstore`.

3.  **`CollateralTracker.sol`**:
    * The `_updateBalancesAndSettle` function now reads the `builderCodeRecipient` from the transient slot using `tload`.
    * **New Fee Logic:** A check is performed to see if a `builderCodeRecipient` exists:
        * **If a builder is present:**
            * The commission is paid via a direct `_transferFrom` of the user's LP shares (instead of a burn).
            * **Fee Split:**
                * **10%** is transferred to the `builderCodeRecipient`.
                * **80%** is transferred to the `s_riskEngine` (currently a placeholder for a "real" protocol address)
                * The remaining **10%** is *not* collected, acting as a **discount for the user**.
        * **If no builder is present:**
            * The original logic applies: 100% of the commission is added to `tokenToPay` and subsequently **burned**.

###  Other Changes

* **Commission Scope:** The commission calculation has been moved to apply to all calls of `_updateBalancesAndSettle`, not just on option creation.
* **New Event:** A `CommissionPaid` event is added to log all commission payments and their recipients (which can be `address(this)` in the case of a burn).
* **Gas Savings:** `totalSupply` and `totalAssets()` are cached to local variables in `_updateBalancesAndSettle` to save gas.