### PR TITLE
Fix: [M-01] Incorrect bit-shift logic for the CollateralTracker's CREATE2 seed

### DIFF
--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -141,8 +141,8 @@ contract PanopticFactory is FactoryNFT, Multicall {
         bytes32 salt32 = bytes32(
             abi.encodePacked(
                 uint80(uint160(msg.sender) >> 80),
-                uint80(uint160(address(v3Pool)) >> 40),
-                uint80(uint160(address(riskEngine)) >> 40),
+                uint40(uint160(address(v3Pool)) >> 120),
+                uint40(uint160(address(riskEngine)) >> 120),
                 salt
             )
         );
@@ -208,6 +208,7 @@ contract PanopticFactory is FactoryNFT, Multicall {
     function minePoolAddress(
         address deployerAddress,
         address v3Pool,
+        address riskEngine,
         uint96 salt,
         uint256 loops,
         uint256 minTargetRarity
@@ -224,7 +225,8 @@ contract PanopticFactory is FactoryNFT, Multicall {
             bytes32 newSalt = bytes32(
                 abi.encodePacked(
                     uint80(uint160(deployerAddress) >> 80),
-                    uint80(uint160(v3Pool) >> 80),
+                    uint40(uint160(v3Pool) >> 120),
+                    uint40(uint160(riskEngine) >> 120),
                     salt
                 )
             );

--- a/test/foundry/core/PanopticFactory.t.sol
+++ b/test/foundry/core/PanopticFactory.t.sol
@@ -215,16 +215,28 @@ contract PanopticFactoryTest is Test {
         }
 
         string[] memory propsStr = vm.parseJsonStringArray(metadata, ".properties");
+        console2.log("properties count", propsStr.length);
+
         bytes32[] memory props = new bytes32[](propsStr.length);
         for (uint256 i = 0; i < propsStr.length; i++) {
             props[i] = bytes32(bytes(propsStr[i]));
         }
 
-        string[][] memory indicesStr = abi.decode(vm.parseJson(metadata, ".indices"), (string[][]));
+        // indices: read each inner string[] directly
+        string[][] memory indicesStr = new string[][](propsStr.length);
+        for (uint256 i = 0; i < propsStr.length; i++) {
+            // Build ".indices[i]" and parse that inner string[]
+            string memory path = string.concat(".indices[", vm.toString(i), "]");
+            indicesStr[i] = vm.parseJsonStringArray(metadata, path);
+            // optional: console2.log("indices[", i, "] len", indicesStr[i].length);
+        }
+
+        // convert to uint256[][]
         uint256[][] memory indices = new uint256[][](indicesStr.length);
         for (uint256 i = 0; i < indicesStr.length; i++) {
             indices[i] = new uint256[](indicesStr[i].length);
             for (uint256 j = 0; j < indicesStr[i].length; j++) {
+                // your JSON numbers are decimal strings (even the huge ones), so parseUint is correct
                 indices[i][j] = vm.parseUint(indicesStr[i][j]);
             }
         }
@@ -257,8 +269,8 @@ contract PanopticFactoryTest is Test {
             bytes32(
                 abi.encodePacked(
                     uint80(uint160(address(this)) >> 80),
-                    uint80(uint160(address(pool)) >> 40),
-                    uint80(uint160(address(riskEngine)) >> 40),
+                    uint40(uint160(address(pool)) >> 120),
+                    uint40(uint160(address(riskEngine)) >> 120),
                     salt
                 )
             ),
@@ -461,7 +473,7 @@ contract PanopticFactoryTest is Test {
         uint256 minTargetRarity
     ) public {
         // limit minTargetRarity to 1-2 leading zeroes for test efficiency
-        minTargetRarity = bound(minTargetRarity, 1, 2);
+        minTargetRarity = bound(minTargetRarity, 1, 5);
 
         nonce = uint96(bound(nonce, 0, type(uint96).max - 1001));
 
@@ -476,6 +488,7 @@ contract PanopticFactoryTest is Test {
         (uint96 bestSalt, uint256 highestRarity) = panopticFactory.minePoolAddress(
             randomAddress,
             address(pool),
+            address(riskEngine),
             nonce,
             50_000,
             minTargetRarity
@@ -489,7 +502,8 @@ contract PanopticFactoryTest is Test {
                     bytes32(
                         abi.encodePacked(
                             uint80(uint160(randomAddress) >> 80),
-                            uint80(uint160(address(pool)) >> 80),
+                            uint40(uint160(address(pool)) >> 120),
+                            uint40(uint160(address(riskEngine)) >> 120),
                             bestSalt
                         )
                     ),


### PR DESCRIPTION
### Description

This PR addresses a logic error in the way the deployment `salt` for the `PanopticPool` contract was constructed within `PanopticFactory.sol`.

The previous logic resulted in a salt that was **336 bits** long, which would overflow the required **256 bits** (`bytes32`) used for deterministic deployment (via `cloneDeterministic`/`CREATE2`).

### Key Changes

1.  **Salt Logic Fix:** Reduced the length of the sampled parts of the `UniswapV3Pool` and `RiskEngine` addresses from **80 bits** to **40 bits** each. This ensures the total salt length is exactly **256 bits** (`80 (deployer) + 40 (v3Pool) + 40 (riskEngine) + 96 (user salt) = 256 bits`).
    * This fix is applied in both the `deployNewPool` and the address prediction logic within `minePoolAddress`.
2.  **`minePoolAddress` Refinement:** The `minePoolAddress` function signature was updated to correctly accept the `riskEngine` address, which is now a required input for the deterministic salt calculation.
3.  **Test Updates:**
    * The address prediction logic in `PanopticFactory.t.sol` was updated to reflect the new 40-bit sampling.


Fixes this: https://github.com/ObsidianAudits/2025-10-panoptic-v2/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic interest rate model with automatic accrual mechanisms
  * Introduced risk engine integration for pool deployment and collateral management
  * Added margin and solvency calculation improvements for better risk assessment

* **Bug Fixes**
  * Enhanced error reporting with detailed transfer and collateral failure information
  * Improved validation for position and liquidity configurations

* **Documentation**
  * Refined error messages for clarity during protocol operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->