### PR TITLE
Fix: [H-01] forceExercise will not be possible for positions with a credit leg (width==0)

### DIFF
--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -274,6 +274,9 @@ contract RiskEngine {
                 // short legs are not counted - exercise is intended to be based on long legs
                 if (tokenId.isLong(leg) == 0) continue;
 
+                // credit/loans are not counted
+                if (tokenId.width(leg) == 0) continue;
+
                 {
                     int24 range = int24(
                         int256(


### PR DESCRIPTION
Added a check to ignore credit/loan legs in the exercise cost calculation

Fixes: https://github.com/ObsidianAudits/2025-10-panoptic-v2/issues/5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Interest rate accrual system with borrow index tracking and per-user accounting
  - Risk engine integration for enhanced margin calculations and collateral management
  - Adaptive interest rate model responding to pool utilization
  - Enhanced oracle mechanism with EMA-based price tracking

* **Improvements**
  - Better solvency and liquidation bonus calculations
  - More detailed error reporting with contextual information
  - Support for multiple pools per Uniswap pair with distinct risk parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->