### PR TITLE
Feat: set LtHash with k-2 as the active `homomorphicHash` implementation

### DIFF
--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -189,6 +189,7 @@ library PanopticMath {
         uint256 item,
         bool addFlag
     ) internal pure returns (uint256) {
+        /*
         {
             // XHASH
             return uint248(hash) ^ (uint248(uint256(keccak256(abi.encode(item)))));
@@ -205,7 +206,7 @@ library PanopticMath {
                         PRIME_MODULUS_248
                     );
         }
-
+        */
         {
             // LtHash, k=2
             uint256 itemHash = uint256(keccak256(abi.encode(item)));

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -4956,10 +4956,7 @@ contract PanopticPoolTest is PositionUtils {
         {
             assertEq(
                 pp.positionsHash(Alice),
-                uint248(
-                    uint256(keccak256(abi.encodePacked(tokenId0))) ^
-                        uint256(keccak256(abi.encodePacked(tokenId1)))
-                ),
+                uint248(pp.generatePositionsHash(posIdList)),
                 "FAIL: position hashes don't match"
             );
 
@@ -5305,16 +5302,16 @@ contract PanopticPoolTest is PositionUtils {
         }
 
         {
-            (, uint256 inAMM, ) = ct1.getPoolData();
-            assertEq(inAMM, 0, "inAMM 1");
-        }
-        {
-            assertEq(
-                pp.positionsHash(Alice),
-                uint248(uint256(keccak256(abi.encodePacked(tokenId0)))),
-                "FAIL: position hashes don't match"
-            );
-
+            {
+                (, uint256 inAMM, ) = ct1.getPoolData();
+                assertEq(inAMM, 0, "inAMM 1");
+                $posIdList.push(tokenId0);
+                assertEq(
+                    pp.positionsHash(Alice),
+                    uint248(pp.generatePositionsHash($posIdList)),
+                    "FAIL: position hashes don't match"
+                );
+            }
             assertEq(pp.numberOfLegs(Alice), 1, "FAIL: nLegs don't match");
 
             {

--- a/test/foundry/libraries/PanopticMath.t.sol
+++ b/test/foundry/libraries/PanopticMath.t.sol
@@ -445,8 +445,9 @@ contract PanopticMathTest is Test, PositionUtils {
             tokenId = tokenId.addLeg(0, optionRatio, asset, isLong, tokenType, 0, strike, width);
         }
 
-        uint248 updatedHash = uint248(existingHash) ^
-            (uint248(uint256(keccak256(abi.encode(tokenId)))));
+        uint248 updatedHash = uint248(
+            PanopticMath.homomorphicHash(existingHash, TokenId.unwrap(tokenId), true)
+        );
         vm.assume((existingHash >> 248) < 255);
         uint256 expectedHash = uint256(updatedHash) + (((existingHash >> 248) + 1) << 248);
 
@@ -507,8 +508,9 @@ contract PanopticMathTest is Test, PositionUtils {
         uint256 expectedHash;
         uint256 returnedHash;
         unchecked {
-            uint248 updatedHash = uint248(existingHash) ^
-                (uint248(uint256(keccak256(abi.encode(tokenId)))));
+            uint248 updatedHash = uint248(
+                PanopticMath.homomorphicHash(existingHash, TokenId.unwrap(tokenId), false)
+            );
             vm.assume((existingHash >> 248) > 0);
 
             expectedHash = uint256(updatedHash) + (((existingHash >> 248) - 1) << 248);


### PR DESCRIPTION
### Summary

This PR modifies the `homomorphicHash` function in `PanopticMath.sol` to **activate the `LtHash` (2-lane) implementation**.

The previous `XHASH` and `AdHash` implementations have been commented out, officially switching the library to use the more secure `LtHash` logic.

### Changes

* **`contracts/libraries/PanopticMath.sol`**:
    * Commented out the deprecated `XHASH` (XOR-based) and `AdHash` (single-lane additive) implementations within the `homomorphicHash` function.
    * This makes the existing `LtHash` (2-lane modular addition) logic the active implementation used by the function.

* **`test/foundry/libraries/PanopticMath.t.sol`**:
    * As a consequence of the change above, the fuzz tests (`test_Success_updatePositionsHash_update`) have been updated.
    * The tests no longer calculate an expected hash using the old `XHASH` logic. Instead, they now call `PanopticMath.homomorphicHash` directly to ensure they are correctly validating the active `LtHash` implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated adaptive interest rate system via Risk Engine for dynamic rate calculations.
  * Enhanced margin and solvency checks for account health monitoring.
  * Safe Mode activation based on oracle price conditions.
  * Improved error reporting with detailed transaction failure context.

* **Refactor**
  * Redesigned interest accounting with per-user borrowing state tracking.
  * Updated pool deployment to incorporate Risk Engine parameters.
  * Restructured collateral initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->