### PR TITLE
feat: propagate safeMode status to RiskEngine via transient storage

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -635,7 +635,13 @@ contract PanopticPool is Multicall {
             totalSwapped
         );
 
-        if (safeMode > 0) poolUtilizations = uint32(10_000 + (10_000 << 16));
+        if (safeMode > 0) {
+            poolUtilizations = uint32(10_000 + (10_000 << 16));
+            bytes32 slot = Constants.SAFE_MODE_TRANSIENT_SLOT;
+            assembly {
+                tstore(slot, safeMode)
+            }
+        }
 
         {
             // update the users options balance of position `tokenId`
@@ -1362,10 +1368,10 @@ contract PanopticPool is Multicall {
     }
 
     /// @notice Checks whether the current tick has deviated too much from the previouslyt stored ticks. Computed in the RiskEngine
-    /// @return Whether the current tick has deviated too much to warrant putting the protocol in safe mode
-    function isSafeMode() public view returns (uint8) {
+    /// @return safeMode Whether the current tick has deviated too much to warrant putting the protocol in safe mode
+    function isSafeMode() public view returns (uint8 safeMode) {
         int24 currentTick = SFPM.getCurrentTick(s_univ3pool);
-        return s_riskEngine.isSafeMode(currentTick, s_oraclePack);
+        safeMode = s_riskEngine.isSafeMode(currentTick, s_oraclePack);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -637,14 +637,22 @@ contract RiskEngine {
         uint256 bal0 = tokenData0.rightSlot();
         uint256 bal1 = tokenData1.rightSlot();
 
+        uint8 safeMode;
+        {
+            bytes32 slot = Constants.SAFE_MODE_TRANSIENT_SLOT;
+            assembly {
+                safeMode := tload(slot)
+            }
+        }
+
         uint256 scaledSurplusToken0 = Math.mulDiv(
             bal0 > maintReq0 ? bal0 - maintReq0 : 0,
-            CROSS_BUFFER_0,
+            safeMode == 0 ? CROSS_BUFFER_0 : 0,
             DECIMALS
         );
         uint256 scaledSurplusToken1 = Math.mulDiv(
             bal1 > maintReq1 ? bal1 - maintReq1 : 0,
-            CROSS_BUFFER_1,
+            safeMode == 0 ? CROSS_BUFFER_1 : 0,
             DECIMALS
         );
 

--- a/contracts/libraries/Constants.sol
+++ b/contracts/libraries/Constants.sol
@@ -21,6 +21,10 @@ library Constants {
     uint160 internal constant MAX_V3POOL_SQRT_RATIO =
         1461446703485210103287273052203988822378723970342;
 
+    /// @dev The transient storage slot for safe mode.
+    /// Used to pass the safeMode across contract calls within a single transaction.
+    bytes32 internal constant SAFE_MODE_TRANSIENT_SLOT = keccak256("panoptic.safe.mode");
+
     /// @notice Parameter that determines which oracle type to use for the "slow" oracle price on non-liquidation solvency checks.
     /// @dev If false, an 8-slot internal median array is used to compute the "slow" oracle price.
     /// @dev This oracle is updated with the last Uniswap observation during `mintOptions` if MEDIAN_PERIOD has elapsed past the last observation.


### PR DESCRIPTION
### Description

This PR implements a way to communicate the protocol's `safeMode` status from the `PanopticPool` to the `RiskEngine` without resorting to "prop drilling" (passing the variable through many function arguments).

The `RiskEngine`'s `isAccountSolvent` function needs to know if the protocol is in `safeMode` to enforce stricter margin requirements. This check happens deep within a call stack that originates in `PanopticPool.mintOptions`.

This PR uses **transient storage (EIP-1153)** as a "memo" for the duration of the transaction.

### Detailed Changes
1.  **`RiskEngine.sol`**
    * In `isAccountSolvent`, we use an `assembly` block with `tload` to **read** the `safeMode` value from the `SAFE_MODE_TRANSIENT_SLOT`.
    * **Functional Impact:** This `safeMode` value is then immediately used to modify the solvency calculation. If `safeMode > 0`, the `CROSS_BUFFER_0` and `CROSS_BUFFER_1` are set to `0`. This disables cross-collateral buffering, making the solvency check significantly stricter as intended during unsafe market conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented transient safe mode tracking mechanism for enhanced per-transaction risk management during pool operations.
  * Safe mode now dynamically adjusts risk calculation multipliers in solvency assessments when activated.
  * Updated safe mode status reporting to provide clearer status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->