### PR TITLE
perf: Optimize s_options gas by replacing nested map with array

### DIFF
--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -214,8 +214,7 @@ contract PanopticPool is Multicall {
     /// @notice Nested mapping that tracks the option formation: address => tokenId => leg => premiaGrowth.
     /// @dev Premia growth is taking a snapshot of the chunk premium in SFPM, which is measuring the amount of fees
     /// collected for every chunk per unit of liquidity (net or short, depending on the isLong value of the specific leg index).
-    mapping(address account => mapping(TokenId tokenId => mapping(uint256 leg => LeftRightUnsigned premiaGrowth)))
-        internal s_options;
+    mapping(address => mapping(TokenId => LeftRightUnsigned[4])) internal s_options;
 
     /// @notice Per-chunk `last` value that gives the aggregate amount of premium owed to all sellers when multiplied by the total amount of liquidity `totalLiquidity`.
     /// @dev `totalGrossPremium = totalLiquidity * (grossPremium(perLiquidityX64) - lastGrossPremium(perLiquidityX64)) / 2**64`


### PR DESCRIPTION
### Description

This PR significantly optimizes the gas cost of accessing `s_options` by replacing the deeply nested `uint256 leg` mapping with a fixed-size array.

### The Optimization

The previous implementation used a 3-level nested mapping. Accessing a specific leg required **three `keccak256` hash operations** to calculate the storage slot.

**Before:**

```solidity
mapping(address account => mapping(TokenId tokenId => mapping(uint256 leg => LeftRightUnsigned premiaGrowth)))
    internal s_options;
```

  * **Storage Slot Calculation:** `keccak256(leg . keccak256(id . keccak256(addr . slot)))`

The new implementation uses a 2-level mapping where the value is a fixed-size array (`LeftRightUnsigned[4]`). This allows the EVM to find all 4 legs by calculating a single base slot (with two hashes) and then using cheap arithmetic addition.

**After:**

```solidity
mapping(address => mapping(TokenId => LeftRightUnsigned[4])) public s_options;
```

  * **Storage Slot Calculation:** `keccak256(id . keccak256(addr . slot)) + leg`

### Impact

  * **Massive Gas Savings:** We save one `keccak256` operation *per leg access*. When accessing all 4 legs in a single transaction (a common operation), this **saves 10 `keccak256` hashes** (12 hashes (3\*4) in the old way vs. 2 hashes in the new way).
