### PR TITLE
Fix: [H-02] _getRequiredCollateralSingleLegPartner does not verify that each leg has the same size when reducing collateral requirements

### DIFF
--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -1035,7 +1035,10 @@ contract RiskEngine {
         // - Delayed Swap (credit at one strike, loan at another; different amounts = effective swap) = requirement is max(loan0 - convert1to0(credit), 1) or max(loan1 - convert0to1(credit), 1)
         {
             // only proceed if the partners have the same asset
-            if (tokenId.asset(partnerIndex) == tokenId.asset(index)) {
+            if (
+                tokenId.asset(partnerIndex) == tokenId.asset(index) &&
+                tokenId.optionRatio(partnerIndex) == tokenId.optionRatio(index)
+            ) {
                 // witdh of associated legs, true if greater than 0 (ie. it is an option leg)
                 bool _width = tokenId.width(index) > 0;
                 bool widthP = tokenId.width(partnerIndex) > 0;
@@ -1063,14 +1066,23 @@ contract RiskEngine {
                         } else if (_isLong != isLongP) {
                             // SYNTHETIC STOCK: different token types, one is long and the other is short
                             return
-                                // return the collateral requirement of the short leg only, the long leg is free!
-                                _isLong == 0
-                                    ? _getRequiredCollateralSingleLegNoPartner(
-                                        tokenId,
-                                        index,
-                                        positionSize,
-                                        atTick,
-                                        poolUtilization
+                                // return the largest collateral requirement of the two legs
+                                index < partnerIndex
+                                    ? Math.max(
+                                        _getRequiredCollateralSingleLegNoPartner(
+                                            tokenId,
+                                            index,
+                                            positionSize,
+                                            atTick,
+                                            poolUtilization
+                                        ),
+                                        _getRequiredCollateralSingleLegNoPartner(
+                                            tokenId,
+                                            partnerIndex,
+                                            positionSize,
+                                            atTick,
+                                            poolUtilization
+                                        )
                                     )
                                     : 0;
                         }


### PR DESCRIPTION



## Summary of Changes

This Pull Request fixes https://github.com/ObsidianAudits/2025-10-panoptic-v2/issues/9 by introducing two key changes to the collateral calculation logic within `RiskEngine.sol` to improve the precision of paired option strategy identification and enhance risk management for Synthetic Stocks.

### 1.  Stricter Strategy Pairing Logic

The condition for pairing two token legs to form a combined strategy (like Strangles, Spreads, or Synthetic Stocks) has been updated to be more rigorous.

**Old Condition:** Legs must have the same underlying asset.
**New Condition:** Legs must have the **same underlying asset** and the **same `optionRatio`**.

This prevents incorrectly pairing tokens that are on the same asset but have different contract sizes, ensuring that only syntactically identical option legs can be combined for risk netting.

### 2. Revised Collateral for Synthetic Stocks

The method for calculating required collateral for a **Synthetic Stock** (a long and a short leg with different token types, e.g., long call + short put) has been revised for a more conservative risk model.

| Strategy | Old Collateral Logic | New Collateral Logic |
| :--- | :--- | :--- |
| **Synthetic Stock** | Collateral of the **Short Leg Only** (long leg considered "free") | **`max(Collateral_Leg1, Collateral_Leg2)`** |

#### Rationale for Change:
The previous logic assumed the long leg provided perfect, cost-free coverage for the short leg's exposure. The new approach calculates the intrinsic collateral requirement of each leg independently and takes the maximum, thereby increasing the required collateral and establishing a more conservative safety buffer.

This change is implemented by calling `Math.max()` on the collateral required for both legs, instead of just returning the requirement for the short leg.

---

### Affected Strategies
* **Synthetic Stocks** (Short Put + Long Call or Short Call + Long Put)
* **All paired option strategies** (Strangles, Spreads) are affected by the stricter `optionRatio` check.