### PR TITLE
Fix: [I-04] Zero-value actions in the CollateralTracker are not completely prevented 

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -424,6 +424,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
         _accrueInterest(msg.sender);
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
+        if (assets == 0) revert Errors.BelowMinimumRedemption();
 
         shares = previewDeposit(assets);
 
@@ -528,6 +529,7 @@ contract CollateralTracker is ERC20Minimal, Multicall {
     ) external returns (uint256 shares) {
         _accrueInterest(owner);
         if (assets > maxWithdraw(owner)) revert Errors.ExceedsMaximumRedemption();
+        if (assets == 0) revert Errors.BelowMinimumRedemption();
 
         shares = previewWithdraw(assets);
 


### PR DESCRIPTION
This PR fixes https://github.com/ObsidianAudits/2025-10-panoptic-v2/issues/8 and completely prevents the minting/burning of zero shares in the deposit and withdraw user flow.