### PR TITLE
fix: docstring about clamping the price-to-strike ratio to max tick as well as min tick

### DIFF
--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -929,13 +929,12 @@ contract RiskEngine {
                     int24 strike = tokenId.strike(index);
                     // if position is ITM or ATM, then the collateral requirement depends on price:
 
-                    // compute the ratio of strike to price for calls (or price to strike for puts)
+                    // We must first get the ratio of strike to price for calls (or price to strike for puts).
+                    // Both of these ratios decrease as the position becomes deeper ITM.
+                    // We must clamp the difference between atTick and strike to the min & max Uniswap ticks,
+                    // to conform with what getSqrtRatioAtTick can support.
+                    // This is acceptable because a higher ratio will result in an increased slope for the collateral requirement.
                     // (- and * 2 in tick space are / and ^ 2 in price space so sqrtRatioAtTick(2 *(a - b)) = a/b (*2^96)
-                    // both of these ratios decrease as the position becomes deeper ITM, and it is possible
-                    // for the ratio of the prices to go under the minimum price
-                    // (which is the limit of what getSqrtRatioAtTick supports)
-                    // so instead we cap it at the minimum price, which is acceptable because
-                    // a higher ratio will result in an increased slope for the collateral requirement
                     uint160 ratio = tokenType == 1 // tokenType
                         ? Math.getSqrtRatioAtTick(
                             int24(


### PR DESCRIPTION
[This report](https://cantina.xyz/code/01da0370-eacb-48a2-a2df-3aa44f7bc838/findings/23) highlighted that in this snippet from `_getRequiredCollateralSingleLegNoPartner`:

```solidity
// compute the ratio of strike to price for calls (or price to strike for puts)
                    // (- and * 2 in tick space are / and ^ 2 in price space so sqrtRatioAtTick(2 *(a - b)) = a/b (*2^96)
                    // both of these ratios decrease as the position becomes deeper ITM, and it is possible
                    // for the ratio of the prices to go under the minimum price
                    // (which is the limit of what getSqrtRatioAtTick supports)
                    // so instead we cap it at the minimum price, which is acceptable because
                    // a higher ratio will result in an increased slope for the collateral requirement
                    uint160 ratio = tokenType == 1 // tokenType
                        ? Math.getSqrtRatioAtTick(
                            Math.max24(2 * (atTick - strike), Constants.MIN_V3POOL_TICK)
                        ) // puts ->  price/strike
                        : Math.getSqrtRatioAtTick(
                            Math.max24(2 * (strike - atTick), Constants.MIN_V3POOL_TICK)
                        ); // calls -> strike/price
```

you could end up passing a value larger than `MAX_V3POOL_TICK` into `Math.getSqrtRatioAtTick`. It would require `atTick` being more then `MAX_V3_POOL_TICK/2` greater than `strike`, but that is theoretically possible.

Of course, by that point, the option holder has probably been liquidatable for a while. But it is technically possible and our code would have been better if we had just ensured the max value that could be passed in there was restricted to MAX_TICK.

Turns out, someone already realised this, and the latest dev3 corrected this in RiskEngine.

However, the docstring still only talks about clamping to the min tick, so this PR updates the docstring to show that we also clamp to the max tick.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interest accrual system for borrowed collateral with continuous compounding.
  * Introduced adaptive interest rate model based on pool utilization.
  * Implemented settlement mechanisms for minting and burning positions.
  * Added multi-risk-engine pool support for flexible collateral management.

* **Improvements**
  * Enhanced error messages with detailed context.
  * Refined collateral tracking and margin calculations.
  * Improved oracle tick management and median computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->