### PR TITLE
Fix: Mitigate Y2K38 overflow and prevent IRM drift

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -197,7 +197,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     /// @dev Layout:
     ///      - Left slot (106 bits): Accumulated unrealized interest that hasn't been distributed (max deposit is 2**104)
     ///      - Next 38 bits: the rateAtTarget value in WAD (2**38 = 800% interest rate)
-    ///      - Next lowest 32 bits: Last interaction timestamp (block.timestamp)
+    ///      - Next lowest 32 bits: Last interaction epoch (1 epoch = block.timestamp/4)
     ///      - Lowest 80 bits: Global borrow index in WAD (starts at 1e18). 2**80 = 1.75 years at 800% interest
     ///      The borrow index tracks the compound growth factor since protocol inception.
     ///      A user's current debt = originalDebt * (currentBorrowIndex / userBorrowIndexSnapshot)
@@ -261,7 +261,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         s_depositedAssets = 1;
 
         // store the initial block and initialize the borrowIndex
-        s_interestRateAccumulator = (uint256(uint32(block.timestamp)) << 80) + uint80(WAD);
+        s_interestRateAccumulator = (uint256(uint32(block.timestamp >> 2)) << 80) + uint80(WAD);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -293,14 +293,14 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     /// @notice Returns the global borrow index that tracks compound interest growth
     /// @dev The index starts at 1e18 and compounds continuously. Represents how much 1 unit of debt has grown since inception
     /// @return The current global borrow index in WAD (18 decimals)
-    function borrowIndex() external view returns (uint96) {
+    function borrowIndex() external view returns (uint80) {
         return uint80(s_interestRateAccumulator);
     }
 
     /// @notice Returns the last time at which interest rates were compounded.
     /// @return The last time at which the interest rates were compounded
     function lastInteractionTimestamp() external view returns (uint256) {
-        return uint32(s_interestRateAccumulator >> 80);
+        return uint32((s_interestRateAccumulator >> 80)) << 2;
     }
 
     /// @notice Returns the accumulated unrealized global interest
@@ -718,7 +718,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
             (
                 uint128 currentBorrowIndex,
                 uint128 _unrealizedGlobalInterest,
-                uint256 currentTime
+                uint256 currentEpoch
             ) = _calculateCurrentInterestState(_assetsInAMM, _updateInterestRate());
 
             // USER
@@ -780,32 +780,36 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
             s_interestRateAccumulator =
                 (uint256(_unrealizedGlobalInterest) << 150) +
                 (s_interestRateAccumulator & (~TARGET_RATE_MASK)) +
-                (uint256(uint32(currentTime)) << 80) +
+                (uint256(uint32(currentEpoch)) << 80) +
                 uint80(currentBorrowIndex);
         }
     }
 
     /// @notice Calculates the current interest state without modifying storage
-    /// @dev Simulates interest accrual from last interaction to current timestamp
+    /// @dev Simulates interest accrual from last interaction to current epoch
     /// @param _assetsInAMM Amount of assets currently deployed in AMM positions
     /// @param interestRateSnapshot The current interest rate to evaluate at
     /// @return currentBorrowIndex Updated global borrow index after simulated accrual
     /// @return _unrealizedGlobalInterest Total unrealized interest including new accrual
-    /// @return currentTime Current block timestamp
+    /// @return currentEpoch Current epoch = block timestamp / 4
     function _calculateCurrentInterestState(
         uint128 _assetsInAMM,
         uint128 interestRateSnapshot
     )
         internal
         view
-        returns (uint128 currentBorrowIndex, uint128 _unrealizedGlobalInterest, uint256 currentTime)
+        returns (
+            uint128 currentBorrowIndex,
+            uint128 _unrealizedGlobalInterest,
+            uint256 currentEpoch
+        )
     {
         unchecked {
             uint256 accumulator = s_interestRateAccumulator;
 
-            currentTime = block.timestamp;
-            uint256 previousTime = uint32(accumulator >> 80);
-            uint128 deltaTime = uint32(currentTime - previousTime);
+            currentEpoch = block.timestamp >> 2;
+            uint256 previousEpoch = uint32(accumulator >> 80);
+            uint128 deltaTime = uint32(currentEpoch - previousEpoch) << 2;
             currentBorrowIndex = uint128(uint80(accumulator));
             _unrealizedGlobalInterest = uint128(accumulator >> 150);
             if (deltaTime > 0) {
@@ -916,8 +920,8 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     }
 
     /// @notice Calculates the current borrow index including uncompounded time
-    /// @dev Simulates interest accrual up to the current block timestamp
-    /// @return The borrow index as if interest was compounded at current timestamp
+    /// @dev Simulates interest accrual up to the current block epoch
+    /// @return The borrow index as if interest was compounded at current epoch
     function _calculateCurrentBorrowIndex() internal view returns (uint256) {
         (uint128 currentBorrowIndex, , ) = _calculateCurrentInterestState(
             s_assetsInAMM,
@@ -929,7 +933,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     /// @notice Previews the interest that would be owed if compounded now
     /// @dev Simulates interest accrual without modifying state
     /// @param owner Address of the user to preview interest for
-    /// @return The amount of interest that would be owed if accrued at current timestamp
+    /// @return The amount of interest that would be owed if accrued at current epoch
     function previewOwedInterest(address owner) public view returns (uint128) {
         uint256 simulatedBorrowIndex = _calculateCurrentBorrowIndex();
         LeftRightSigned userState = s_interestState[owner];

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -65,6 +65,10 @@ contract RiskEngine {
     /// @notice Decimals for WAD calculations.
     int256 internal constant WAD = 1e18;
 
+    /// @notice Constant, in seconds, used to determine the max elapsed time between adaptive interest rate updates.
+    /// @dev the time elapsed will be capped at IRM_MAX_ELAPSED_TIME
+    int256 constant IRM_MAX_ELAPSED_TIME = 4096;
+
     /*//////////////////////////////////////////////////////////////
                             RISK PARAMETERS
     //////////////////////////////////////////////////////////////*/
@@ -1827,8 +1831,12 @@ contract RiskEngine {
             ? WAD - TARGET_UTILIZATION
             : TARGET_UTILIZATION;
         int256 err = Math.wDivToZero(_utilization - TARGET_UTILIZATION, errNormFactor);
+
+        // 38-bit rateAtTarget, 32-bit epoch<<2 in accumulator
         int256 startRateAtTarget = int256(uint256((interestRateAccumulator >> 112) % 2 ** 38));
-        uint256 previousTime = uint32(interestRateAccumulator >> 80);
+
+        // convert from epoch to time. Used to avoid Y2K38
+        uint256 previousTime = uint256(uint32(interestRateAccumulator >> 80)) << 2;
 
         int256 avgRateAtTarget;
         int256 endRateAtTarget;
@@ -1842,7 +1850,11 @@ contract RiskEngine {
             // So the rate is always underestimated.
             int256 speed = Math.wMulToZero(ADJUSTMENT_SPEED, err);
             // Safe "unchecked" cast because block.timestamp - market.lastUpdate <= block.timestamp <= type(int256).max.
-            int256 elapsed = int256(block.timestamp) - int256(previousTime);
+            // Cap the elapsed time to prevent IRM drift
+            int256 elapsed = Math.min(
+                int256(block.timestamp) - int256(previousTime),
+                IRM_MAX_ELAPSED_TIME
+            );
             int256 linearAdaptation = speed * elapsed;
 
             if (linearAdaptation == 0) {

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -921,7 +921,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((startingTime + 12) << 80) +
+            (((startingTime + 12) >> 2) << 80) +
             expectedNewIndex;
 
         // Get the actual new accumulator value from the contract
@@ -960,7 +960,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((startingTime + 12) << 80) +
+            (((startingTime + 12) >> 2) << 80) +
             expectedNewIndex;
 
         // Get the actual new accumulator value from the contract
@@ -987,7 +987,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         collateralToken0.setInAMM(500);
         collateralToken0.accrueInterest();
 
-        vm.warp(2 ** 32 + 10);
+        vm.warp(4 * 2 ** 32 + 10);
 
         uint128 perSecondInterestRate = collateralToken0.interestRate();
         collateralToken0.accrueInterest();
@@ -1005,7 +1005,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            uint128((uint256(uint32(startingTime + 20)) << 80) + expectedNewIndex);
+            uint128((uint256(uint32(startingTime + 20) >> 2) << 80) + expectedNewIndex);
 
         // Get the actual new accumulator value from the contract
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
@@ -1054,7 +1054,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // Construct the full expected accumulator value for the new block.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((startingTime + blocksToSkip * 12) << 80) +
+            (((startingTime + blocksToSkip * 12) >> 2) << 80) +
             expectedNewIndex;
 
         // Get the actual new accumulator value from the contract.
@@ -1144,7 +1144,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((timestampAfterBorrow + blocksToSkip * 12) << 80) +
+            (((timestampAfterBorrow + blocksToSkip * 12) >> 2) << 80) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
@@ -1230,7 +1230,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((timestampAfterBorrow + blocksToSkip * 12) << 80) +
+            (((timestampAfterBorrow + blocksToSkip * 12) >> 2) << 80) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
@@ -1397,7 +1397,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // 3. Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((timestampAfterBorrow + blocksToSkip * 12) << 80) +
+            (((timestampAfterBorrow + blocksToSkip * 12) >> 2) << 80) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
@@ -1570,7 +1570,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // 3. Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (uint256(collateralToken0.rateAtTarget()) << 112) +
-            ((timestampAfterBorrow + blocksToSkip * 12) << 80) +
+            (((timestampAfterBorrow + blocksToSkip * 12) >> 2) << 80) +
             expectedNewIndex;
         uint256 actualAccumulator = (collateralToken0._interestRateAccumulator());
 
@@ -1679,7 +1679,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint256 timestampAfterBorrow = block.timestamp;
 
         uint32 blocksToSkip = 1;
-        uint256 blockTime = 1;
+        uint256 blockTime = 12;
         vm.roll(blockAfterBorrow + blocksToSkip);
         vm.warp(timestampAfterBorrow + blocksToSkip * blockTime);
 
@@ -1707,7 +1707,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // 3. Construct the full expected accumulator value.
         uint256 expectedAccumulator = (unrealizedGlobalInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((timestampAfterBorrow + blocksToSkip * blockTime) << 80) +
+            (((timestampAfterBorrow + blocksToSkip * blockTime) >> 2) << 80) +
             expectedNewIndex;
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
 
@@ -1750,7 +1750,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
         uint32 deltaTime
     ) public {
         // 1. SETUP
-        vm.assume(deltaTime > 0); // Interest only accrues over time.
+        console2.log("deltaTime", deltaTime);
+        vm.assume(deltaTime > 4); // Interest only accrues over time, at least 1 epoch in the future.
+        vm.assume(deltaTime < 2 ** 32 - 4);
         vm.assume(
             uint256(userInitialAssets) > Math.mulDivRoundingUp(4, uint256(borrowAmount), 3) + 3
         );
@@ -1812,6 +1814,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
         if (borrowAmount > 0) {
             if (balanceBefore >= sharesOwed) {
                 // SOLVENT: Base index must be updated.
+                console2.log("baseIndexBefore", baseIndexBefore);
+                console2.log("baseIndexAfter", baseIndexAfter);
                 assertTrue(
                     baseIndexAfter > baseIndexBefore,
                     "FAIL: Solvent user index not updated"
@@ -2329,7 +2333,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // 3. Construct the full expected accumulator value.
         uint256 expectedAccumulator = (finalUnrealizedInterest << 150) +
             (collateralToken0.rateAtTarget() << 112) +
-            ((timestampAfterBorrow + blocksToSkip * 12) << 80) +
+            (((timestampAfterBorrow + blocksToSkip * 12) >> 2) << 80) +
             expectedNewIndex;
 
         uint256 actualAccumulator = collateralToken0._interestRateAccumulator();
@@ -2940,7 +2944,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertApproxEqAbs(
             aliceAssetsAfter - aliceAssetsBefore,
             expectedBonus,
-            1,
+            2,
             "FAIL: wrong bonus"
         );
 
@@ -3246,8 +3250,8 @@ contract CollateralTrackerTest is Test, PositionUtils {
     }
 
     function test_Fuzz_accrueInterest_previewOwedInterest_accuracy(uint32 timeDelta) public {
-        // Bound the time delta to reasonable values (1 second to 1 year)
-        timeDelta = uint32(bound(timeDelta, 1, 3650 days));
+        // Bound the time delta to reasonable values (12 second to 1 year)
+        timeDelta = uint32(bound(timeDelta, 12, 365 days));
 
         _initWorld(0);
         uint104 assets = 1000 ether;
@@ -3308,7 +3312,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         // Verify preview didn't modify state
         assertEq(
             uint32(accumulatorBefore >> 80), // Extract timestamp portion
-            initialTimestamp,
+            initialTimestamp >> 2,
             "Preview modified the accumulator timestamp"
         );
 
@@ -3586,7 +3590,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         // Test 1: Maximum time jump (just under uint32 max to avoid wrap)
         vm.roll(block.number + 1);
-        vm.warp(block.timestamp + type(uint32).max); // 138 years
+        vm.warp(block.timestamp + 4 * uint256(type(uint32).max)); // 138 years
 
         // This should not revert despite massive values
         vm.prank(Bob);

--- a/test/foundry/core/RiskEngine/RiskEngineIRM.t.sol
+++ b/test/foundry/core/RiskEngine/RiskEngineIRM.t.sol
@@ -41,7 +41,7 @@ contract RiskEngineIRMTest is Test {
     /// time -> uint32(interestRateAccumulator >> 80)
     function _packAccumulator(int256 rateAtTarget, uint32 time) internal pure returns (uint256) {
         // Pack rate at bits 112-149 and time at bits 80-111
-        return (uint256((uint256(rateAtTarget)) % 2 ** 38) << 112) | (uint256(time) << 80);
+        return (uint256((uint256(rateAtTarget)) % 2 ** 38) << 112) | (uint256(time / 4) << 80);
     }
 
     /// @notice Packs all fields into the accumulator format.
@@ -301,7 +301,7 @@ contract RiskEngineIRMTest is Test {
         int256 startRate
     ) public {
         // Constrain inputs
-        elapsed = uint64(bound(elapsed, 0, 365 days));
+        elapsed = uint64(bound(elapsed, 12, 365 days));
         // Bound utilOffset to be within [0, 1e18]
         utilOffset = bound(utilOffset, -TARGET_UTILIZATION, WAD - TARGET_UTILIZATION);
         // Bound startRate to be within the allowed min/max


### PR DESCRIPTION
This PR introduces two critical fixes to improve the long-term stability and robustness of the interest rate mechanism.

---

##  Y2K38 Timestamp Mitigation

**The Problem:** The `s_interestRateAccumulator` stored `block.timestamp` in a `uint32` slot. This would cause an overflow in the year 2038 (the "Y2K38" bug), breaking all interest calculations.

**The Fix:** We now store an "epoch" instead of the full timestamp.
* **Epoch Time:** We now write `block.timestamp >> 2` (i.e., `timestamp / 4`) to the 32-bit slot.
* **Quadrupled Lifespan:** This quadruples the time range the slot can represent, pushing the overflow problem from 2038 to ~2242.
* **Implementation:**
    * `CollateralTracker.sol`:
        * `initialize()` now stores the epoch.
        * `lastInteractionTimestamp()` reads the epoch and scales it back up (`<< 2`) to return the correct full timestamp.
        * `_calculateCurrentInterestState()` now calculates `deltaTime` by subtracting the *epochs* and then multiplying the result by 4 (`<< 2`) to get the correct time delta in seconds.
    * `RiskEngine.sol`:
        * `_borrowRate()` correctly reads the epoch and converts it to `previousTime` by scaling (`<< 2`).

---

##  IRM Drift Prevention

**The Problem:** If no one interacts with the contract for a long period (e.g., days), the `elapsed` time in `_borrowRate` would become massive. This could cause the adaptive interest rate to "drift" and then suddenly spike, leading to an extreme and unfair interest rate change in a single block. 

This is an issue that was flagged by the Morpho team which affected curators/deployers which would sometimes deploy weeks before getting any deposits, thereby crushing the interest rate that had to be manually brought back.

**The Fix:** We cap the `elapsed` time used for the interest rate model (IRM) calculation.
* A new constant `IRM_MAX_ELAPSED_TIME` is introduced in `RiskEngine.sol` (set to `4096` seconds, or ~68 minutes).
* The `elapsed` time in `_borrowRate` is now capped using `Math.min(..., IRM_MAX_ELAPSED_TIME)`.
* This ensures that even after long periods of inactivity, the interest rate adapts smoothly and predictably, without massive, sudden spikes.

---

##  Minor Housekeeping

* **Correct Return Type:** Corrected the return type of `borrowIndex()` in `CollateralTracker.sol` from `uint96` to `uint80`. This aligns the function with the storage layout comment, which correctly specifies the borrow index is 80 bits.
* **Clarity:** Renamed `currentTime` to `currentEpoch` where appropriate to make the code's intent clearer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a full RiskEngine for richer margin, liquidation, and adaptive interest behaviors.
  * Added deterministic multi-risk pool deployments enabling multiple pools per Uniswap pool + risk profile.

* **Updates**
  * Pool APIs now use encoded pool keys and accept risk-engine context; pool metadata now reflects collateralized token pair.
  * Oracle/tick handling enhanced with median/EMA-based logic for more robust pricing.

* **Improvements**
  * More informative error reporting and additional safety/validation checks.
  * Expanded tests and harnesses to improve coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->