### PR TITLE
Feat: [L-04] Interest is overcharged in some scenarios, enabling arbitrary amounts of donations to the CollateralTracker

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -93,6 +93,8 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     uint256 internal constant TARGET_RATE_MASK =
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFC000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFF;
 
+    bool internal constant IS_NOT_DEPOSIT = false;
+    bool internal constant IS_DEPOSIT = true;
     /*//////////////////////////////////////////////////////////////
                            PANOPTIC POOL DATA
     //////////////////////////////////////////////////////////////*/
@@ -359,7 +361,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         address recipient,
         uint256 amount
     ) public override(ERC20Minimal) returns (bool) {
-        _accrueInterest(msg.sender);
+        _accrueInterest(msg.sender, IS_NOT_DEPOSIT);
         // make sure the caller does not have any open option positions
         // if they do: we don't want them sending panoptic pool shares to others
         // as this would reduce their amount of collateral against the opened positions
@@ -379,7 +381,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         address to,
         uint256 amount
     ) public override(ERC20Minimal) returns (bool) {
-        _accrueInterest(from);
+        _accrueInterest(from, IS_NOT_DEPOSIT);
         // make sure the sender does not have any open option positions
         // if they do: we don't want them sending panoptic pool shares to others
         // as this would reduce their amount of collateral against the opened positions
@@ -457,7 +459,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return shares The amount of Panoptic pool shares that were minted to the recipient
     function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
-        _accrueInterest(msg.sender);
+        _accrueInterest(msg.sender, IS_DEPOSIT);
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
         if (assets == 0) revert Errors.BelowMinimumRedemption();
 
@@ -503,7 +505,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     /// @param receiver User to receive the shares
     /// @return assets The amount of assets deposited to mint the desired amount of shares
     function mint(uint256 shares, address receiver) external returns (uint256 assets) {
-        _accrueInterest(msg.sender);
+        _accrueInterest(msg.sender, IS_DEPOSIT);
         assets = previewMint(shares);
 
         if (assets > type(uint104).max) revert Errors.DepositTooLarge();
@@ -562,7 +564,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 shares) {
-        _accrueInterest(owner);
+        _accrueInterest(owner, IS_NOT_DEPOSIT);
         if (assets > maxWithdraw(owner)) revert Errors.ExceedsMaximumRedemption();
         if (assets == 0) revert Errors.BelowMinimumRedemption();
 
@@ -610,7 +612,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         TokenId[] calldata positionIdList,
         bool usePremiaAsCollateral
     ) external returns (uint256 shares) {
-        _accrueInterest(owner);
+        _accrueInterest(owner, IS_NOT_DEPOSIT);
         shares = previewWithdraw(assets);
         if (assets == 0) revert Errors.BelowMinimumRedemption();
 
@@ -672,7 +674,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         address receiver,
         address owner
     ) external returns (uint256 assets) {
-        _accrueInterest(owner);
+        _accrueInterest(owner, IS_NOT_DEPOSIT);
         if (shares > maxRedeem(owner)) revert Errors.ExceedsMaximumRedemption();
 
         // check/update allowance for approved redeem
@@ -706,13 +708,13 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
 
     /// @notice Accrues protocol-wide interest.
     function accrueInterest() public {
-        _accrueInterest(msg.sender);
+        _accrueInterest(msg.sender, IS_NOT_DEPOSIT);
     }
 
     /// @notice Accrues protocol-wide interest and settles a specific user's interest.
     /// @dev This function should be called before any user action that affects their borrow balance.
     /// @param owner the account which calls accrue interest
-    function _accrueInterest(address owner) internal {
+    function _accrueInterest(address owner, bool isDeposit) internal {
         unchecked {
             uint128 _assetsInAMM = s_assetsInAMM;
             (
@@ -743,23 +745,32 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
                         address _owner = owner;
                         uint256 userBalance = balanceOf[_owner];
                         if (shares > userBalance) {
-                            // update the accrual of interest paid
-                            burntInterestValue = Math
-                                .mulDiv(userBalance, _totalAssets, totalSupply())
-                                .toUint128();
+                            if (!isDeposit) {
+                                // update the accrual of interest paid
+                                burntInterestValue = Math
+                                    .mulDiv(userBalance, _totalAssets, totalSupply())
+                                    .toUint128();
 
-                            emit InsolvencyPenaltyApplied(
-                                owner,
-                                userInterestOwed,
-                                burntInterestValue,
-                                userBalance
-                            );
+                                emit InsolvencyPenaltyApplied(
+                                    owner,
+                                    userInterestOwed,
+                                    burntInterestValue,
+                                    userBalance
+                                );
 
-                            /// Insolvent case: Pay what you can
-                            _burn(_owner, userBalance);
+                                /// Insolvent case: Pay what you can
+                                _burn(_owner, userBalance);
 
-                            /// @dev DO NOT update index. By keeping the user's old baseIndex, their debt continues to compound correctly from the original point in time.
-                            userBorrowIndex = userState.rightSlot();
+                                /// @dev DO NOT update index. By keeping the user's old baseIndex, their debt continues to compound correctly from the original point in time.
+                                userBorrowIndex = userState.rightSlot();
+                            } else {
+                                // set interest paid to zero
+                                burntInterestValue = 0;
+
+                                // we effectively **did not settle** this user:
+                                // we keep their old baseIndex so future interest is computed correctly.
+                                userBorrowIndex = userState.rightSlot();
+                            }
                         } else {
                             // Solvent case: Pay in full.
                             _burn(_owner, shares);
@@ -1122,7 +1133,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         int128 ammDeltaAmount,
         int128 realizedPremium
     ) internal returns (uint32, uint128, int128) {
-        _accrueInterest(optionOwner);
+        _accrueInterest(optionOwner, IS_NOT_DEPOSIT);
         unchecked {
             int256 tokenToPay;
             uint128 commission;

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -741,40 +741,39 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
                     );
 
                     uint128 burntInterestValue = userInterestOwed;
-                    if (shares > 0) {
-                        address _owner = owner;
-                        uint256 userBalance = balanceOf[_owner];
-                        if (shares > userBalance) {
-                            if (!isDeposit) {
-                                // update the accrual of interest paid
-                                burntInterestValue = Math
-                                    .mulDiv(userBalance, _totalAssets, totalSupply())
-                                    .toUint128();
 
-                                emit InsolvencyPenaltyApplied(
-                                    owner,
-                                    userInterestOwed,
-                                    burntInterestValue,
-                                    userBalance
-                                );
+                    address _owner = owner;
+                    uint256 userBalance = balanceOf[_owner];
+                    if (shares > userBalance) {
+                        if (!isDeposit) {
+                            // update the accrual of interest paid
+                            burntInterestValue = Math
+                                .mulDiv(userBalance, _totalAssets, totalSupply())
+                                .toUint128();
 
-                                /// Insolvent case: Pay what you can
-                                _burn(_owner, userBalance);
+                            emit InsolvencyPenaltyApplied(
+                                owner,
+                                userInterestOwed,
+                                burntInterestValue,
+                                userBalance
+                            );
 
-                                /// @dev DO NOT update index. By keeping the user's old baseIndex, their debt continues to compound correctly from the original point in time.
-                                userBorrowIndex = userState.rightSlot();
-                            } else {
-                                // set interest paid to zero
-                                burntInterestValue = 0;
+                            /// Insolvent case: Pay what you can
+                            _burn(_owner, userBalance);
 
-                                // we effectively **did not settle** this user:
-                                // we keep their old baseIndex so future interest is computed correctly.
-                                userBorrowIndex = userState.rightSlot();
-                            }
+                            /// @dev DO NOT update index. By keeping the user's old baseIndex, their debt continues to compound correctly from the original point in time.
+                            userBorrowIndex = userState.rightSlot();
                         } else {
-                            // Solvent case: Pay in full.
-                            _burn(_owner, shares);
+                            // set interest paid to zero
+                            burntInterestValue = 0;
+
+                            // we effectively **did not settle** this user:
+                            // we keep their old baseIndex so future interest is computed correctly.
+                            userBorrowIndex = userState.rightSlot();
                         }
+                    } else {
+                        // Solvent case: Pay in full.
+                        _burn(_owner, shares);
                     }
 
                     _unrealizedGlobalInterest = burntInterestValue > _unrealizedGlobalInterest

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -3249,6 +3249,105 @@ contract CollateralTrackerTest is Test, PositionUtils {
         assertLe(uint128(baseIndex), collateralToken0.borrowIndex(), "Bob's index should be stale");
     }
 
+    function test_Success_accrueInterest_deposit_does_not_crystallize_insolvency() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether;
+
+        // Charlie the PLP deposits to provide liquidity
+        vm.startPrank(Charlie);
+        _grantTokens(Charlie);
+        IERC20Partial(token0).approve(address(collateralToken0), assets * 10);
+        collateralToken0.deposit(100 ether, Charlie);
+        vm.stopPrank();
+
+        // Alice (liquidator) does not deposit
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        vm.stopPrank();
+
+        // Bob deposits and borrows in a way that will make him insolvent over time
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(100 ether, Bob); // initial collateral
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+        strike = 198600 + 6000;
+        width = 2;
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // Bob borrows aggressively
+        mintOptions(
+            panopticPool,
+            positionIdList,
+            100 ether, // borrow against the deposit
+            0,
+            Constants.MAX_POOL_TICK,
+            Constants.MIN_POOL_TICK,
+            true
+        );
+        collateralToken0.burnShares(Bob, collateralToken0.balanceOf(Bob));
+        vm.stopPrank();
+
+        // Let time pass so interest explodes and Bob becomes insolvent
+        vm.warp(block.timestamp + 365 days);
+
+        // Preview the full mathematical interest owed
+        uint128 previewedInterestBefore = collateralToken0.previewOwedInterest(Bob);
+        assertGt(previewedInterestBefore, 0, "Bob should owe non-zero interest");
+
+        uint256 sharesOwed = collateralToken0.convertToShares(previewedInterestBefore);
+        uint256 bobBalanceBefore = collateralToken0.balanceOf(Bob);
+        assertGt(sharesOwed, bobBalanceBefore, "Bob must be insolvent for this test");
+
+        // Sanity: preview says he owes more than he can pay at current balance
+        uint256 maxBobCanPay = collateralToken0.convertToAssets(bobBalanceBefore);
+        assertGt(previewedInterestBefore, maxBobCanPay, "Interest owed should exceed Bob's assets");
+
+        // Take a snapshot of Bob's interest state
+        (int128 baseIndexBefore, int128 netBorrowsBefore) = collateralToken0.interestState(Bob);
+
+        // Compute expected shares from a fresh deposit
+        uint256 depositAssets = 10 ether;
+        uint256 depositShares = collateralToken0.previewDeposit(depositAssets);
+
+        // Bob deposits to "cure" while insolvent
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAssets);
+        collateralToken0.deposit(depositAssets, Bob);
+        vm.stopPrank();
+
+        // 1) Existing shares should NOT be burned: total shares = old + depositShares (up to rounding)
+        uint256 bobBalanceAfter = collateralToken0.balanceOf(Bob);
+        assertApproxEqAbs(
+            collateralToken0.convertToAssets(bobBalanceAfter),
+            collateralToken0.convertToAssets(bobBalanceBefore) + depositAssets,
+            1,
+            "Deposit should not burn Bob's existing shares when insolvent"
+        );
+
+        // 2) Interest preview should be unchanged (no settlement on deposit-path insolvency)
+        uint128 previewedInterestAfter = collateralToken0.previewOwedInterest(Bob);
+        assertApproxEqAbs(
+            previewedInterestAfter,
+            previewedInterestBefore,
+            1,
+            "Deposit should not settle or reduce Bob's interest when insolvent"
+        );
+
+        // 3) Interest state: same netBorrows and same stale baseIndex
+        (int128 baseIndexAfter, int128 netBorrowsAfter) = collateralToken0.interestState(Bob);
+        assertEq(netBorrowsAfter, netBorrowsBefore, "netBorrows should remain unchanged");
+        assertEq(
+            uint128(baseIndexAfter),
+            uint128(baseIndexBefore),
+            "baseIndex should remain stale"
+        );
+    }
+
     function test_Fuzz_accrueInterest_previewOwedInterest_accuracy(uint32 timeDelta) public {
         // Bound the time delta to reasonable values (12 second to 1 year)
         timeDelta = uint32(bound(timeDelta, 12, 365 days));


### PR DESCRIPTION
### Summary

This PR fixes a critical issue where an insolvent user (owing more interest shares than their balance) would have their entire remaining collateral burned when attempting to deposit new funds.

Fixes this: https://github.com/ObsidianAudits/2025-10-panoptic-v2/issues/10#issuecomment-3509725596

### The Problem

The `_accrueInterest` function is called before most user actions, including `deposit`. If a user was insolvent, this function would trigger an "insolvency penalty," burning all their remaining shares (`_burn(_owner, userBalance)`).

This meant a user trying to *cure* their insolvency by adding more collateral was instead penalized, having their existing funds wiped out in the process.

### The Solution

1.  **Add `isDeposit` flag:** The internal `_accrueInterest` function signature is changed to `_accrueInterest(address owner, bool isDeposit)`.
2.  **Update Callers:**
    * `deposit` and `mint` now call `_accrueInterest(..., IS_DEPOSIT)`.
    * All other actions (`withdraw`, `transfer`, `redeem`, etc.) call `_accrueInterest(..., IS_NOT_DEPOSIT)`.
3.  **Conditional Logic:** Inside `_accrueInterest`, the insolvency penalty logic is now wrapped in an `if (!isDeposit)` block.

### New Behavior

* **On Deposit:** An insolvent user can now successfully deposit new funds. Their existing balance is **not** burned, and their new shares are added. Their interest debt remains unsettled (as intended), allowing it to continue compounding correctly from their original stale index.
* **On Other Actions:** If an insolvent user attempts to `withdraw`, `transfer`, etc., the original penalty logic still applies, and their remaining balance will be burned.

### Testing

* A new test, `test_Success_accrueInterest_deposit_does_not_crystallize_insolvency`, is added.
* It confirms that an insolvent user who makes a deposit (a) keeps their old shares, (b) receives their new shares, and (c) still shows the same amount of previewable interest owed.