### PR TITLE
Fix: [L-02] An attacker can manipulate the utilisation rate to mint an option at a lower collateralisation ratio

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.24;
 // Interfaces
+import "forge-std/Test.sol";
 import {PanopticPool} from "./PanopticPool.sol";
 import {RiskEngine} from "./RiskEngine.sol";
 // Inherited implementations
@@ -700,8 +701,6 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
             s_depositedAssets -= uint128(assets);
         }
 
-        _poolUtilization();
-
         // transfer assets (underlying token funds) from the PanopticPool to the LP
         SafeTransferLib.safeTransferFrom(
             underlyingToken(),
@@ -975,6 +974,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
 
         poolUtilization = _poolUtilizationView();
 
+        console2.log("stored, u", storedUtilization, poolUtilization);
         if (storedUtilization > poolUtilization) {
             return storedUtilization;
         } else {

--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -95,6 +95,11 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
 
     bool internal constant IS_NOT_DEPOSIT = false;
     bool internal constant IS_DEPOSIT = true;
+
+    /// @notice Transient storage slot for the utilization
+    bytes32 internal constant UTILIZATION_TRANSIENT_SLOT =
+        keccak256("panoptic.utilization.snapshot");
+
     /*//////////////////////////////////////////////////////////////
                            PANOPTIC POOL DATA
     //////////////////////////////////////////////////////////////*/
@@ -289,7 +294,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         depositedAssets = s_depositedAssets;
         insideAMM = s_assetsInAMM;
         creditedShares = s_creditedShares;
-        currentPoolUtilization = _poolUtilization();
+        currentPoolUtilization = _poolUtilizationView();
     }
 
     /// @notice Returns the global borrow index that tracks compound interest growth
@@ -695,6 +700,8 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
             s_depositedAssets -= uint128(assets);
         }
 
+        _poolUtilization();
+
         // transfer assets (underlying token funds) from the PanopticPool to the LP
         SafeTransferLib.safeTransferFrom(
             underlyingToken(),
@@ -854,7 +861,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
 
     function interestRate() public view returns (uint128) {
         uint128 avgRate = riskEngine().interestRate(
-            _poolUtilizationWAD(),
+            _poolUtilizationWadView(),
             s_interestRateAccumulator
         );
         return avgRate;
@@ -866,10 +873,11 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     }
 
     /// @notice Returns the interest rate per second based on pool utilization
+    /// @dev uses the maximum utilization during this transaction, users to prevent flash deposits from loweing the interest rate
     /// @return The interest rate per second in 18 decimal precision
     function _updateInterestRate() internal returns (uint128) {
         (uint128 avgRate, uint256 endRateAtTarget) = riskEngine().updateInterestRate(
-            _poolUtilizationWAD(),
+            _poolUtilizationWad(),
             s_interestRateAccumulator
         );
         s_interestRateAccumulator =
@@ -924,7 +932,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         LeftRightSigned userState = s_interestState[owner];
         (uint128 currentBorrowIndex, , ) = _calculateCurrentInterestState(
             s_assetsInAMM,
-            _interestRateView(_poolUtilizationWAD())
+            _interestRateView(_poolUtilizationWadView())
         );
         return _getUserInterest(userState, currentBorrowIndex);
     }
@@ -935,7 +943,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     function _calculateCurrentBorrowIndex() internal view returns (uint256) {
         (uint128 currentBorrowIndex, , ) = _calculateCurrentInterestState(
             s_assetsInAMM,
-            _interestRateView(_poolUtilizationWAD())
+            _interestRateView(_poolUtilizationWadView())
         );
         return currentBorrowIndex;
     }
@@ -944,7 +952,7 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     /// @dev Simulates interest accrual without modifying state
     /// @param owner Address of the user to preview interest for
     /// @return The amount of interest that would be owed if accrued at current epoch
-    function previewOwedInterest(address owner) public view returns (uint128) {
+    function previewOwedInterest(address owner) external view returns (uint128) {
         uint256 simulatedBorrowIndex = _calculateCurrentBorrowIndex();
         LeftRightSigned userState = s_interestState[owner];
         return _getUserInterest(userState, simulatedBorrowIndex);
@@ -955,11 +963,34 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Get the pool utilization defined by the ratio of assets in the AMM to total assets.
+    /// @dev calling this function will also store the utilization in the UTILIZATION_TRANSIENT_SLOT as DECIMALS
+    /// if the current one is higher than the one already stored. This ensures that flash deposits can't lower the utilization for a single tx
     /// @return poolUtilization The pool utilization in basis points
-    function _poolUtilization() internal view returns (uint256 poolUtilization) {
+    function _poolUtilization() internal returns (uint256 poolUtilization) {
+        uint256 storedUtilization;
+        bytes32 slot = UTILIZATION_TRANSIENT_SLOT;
+        assembly {
+            storedUtilization := tload(slot)
+        }
+
+        poolUtilization = _poolUtilizationView();
+
+        if (storedUtilization > poolUtilization) {
+            return storedUtilization;
+        } else {
+            assembly {
+                tstore(slot, poolUtilization)
+            }
+            return poolUtilization;
+        }
+    }
+
+    /// @notice Get the pool utilization defined by the ratio of assets in the AMM to total assets.
+    /// @return poolUtilization The pool utilization in basis points
+    function _poolUtilizationView() internal view returns (uint256 poolUtilization) {
         unchecked {
             return
-                Math.mulDivRoundingUp(
+                poolUtilization = Math.mulDivRoundingUp(
                     s_assetsInAMM + (s_interestRateAccumulator >> 150),
                     DECIMALS,
                     totalAssets()
@@ -968,8 +999,39 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
     }
 
     /// @notice Get the pool utilization defined by the ratio of assets in the AMM to total assets.
+    /// @dev calling this function will also store the utilization in the UTILIZATION_TRANSIENT_SLOT as DECIMALS
+    /// if the current one is higher than the one already stored. This ensures that flash deposits can't lower the utilization for a single tx
+    /// @return poolUtilization The pool utilization in basis points
+    function _poolUtilizationWad() internal returns (uint256 poolUtilization) {
+        uint256 storedUtilization;
+        bytes32 slot = UTILIZATION_TRANSIENT_SLOT;
+        assembly {
+            storedUtilization := tload(slot)
+        }
+
+        unchecked {
+            // convert to WAD
+            storedUtilization = (storedUtilization * WAD) / DECIMALS;
+        }
+        poolUtilization = _poolUtilizationWadView();
+
+        if (storedUtilization > poolUtilization) {
+            return storedUtilization;
+        } else {
+            unchecked {
+                // store the utilization as DECIMALS
+                poolUtilization = (poolUtilization * DECIMALS) / WAD;
+            }
+            assembly {
+                tstore(slot, poolUtilization)
+            }
+            return poolUtilization;
+        }
+    }
+
+    /// @notice Get the pool utilization defined by the ratio of assets in the AMM to total assets.
     /// @return poolUtilization The pool utilization in WAD
-    function _poolUtilizationWAD() internal view returns (uint256 poolUtilization) {
+    function _poolUtilizationWadView() internal view returns (uint256 poolUtilization) {
         unchecked {
             return
                 Math.mulDivRoundingUp(
@@ -1230,7 +1292,10 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
                     netBorrows
                 );
             }
-            uint32 utilization = isCreation ? uint32(_poolUtilization()) : 0;
+
+            // get the utilization, store the current one in transient storage
+            uint32 utilization = uint32(_poolUtilization());
+
             return (utilization, commission, int128(tokenToPay));
         }
     }

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -100,7 +100,7 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
     }
 
     function poolUtilizationHook() external view returns (int128) {
-        return int128(int256(_poolUtilization()));
+        return int128(int256(_poolUtilizationView()));
     }
 }
 
@@ -300,6 +300,34 @@ contract UniswapV3PoolMock {
     function setSlot0(int24 _tick) external {
         slot0.tick = _tick;
         slot0.sqrtPriceX96 = TickMath.getSqrtRatioAtTick(_tick);
+    }
+}
+
+contract Attacker {
+    CollateralTracker internal collateralToken;
+    IERC20Partial internal underlyingToken;
+
+    constructor(CollateralTracker _collateral, IERC20Partial _token) {
+        collateralToken = _collateral;
+        underlyingToken = _token;
+    }
+
+    /// @notice This function performs the attack sequence in a single transaction
+    function attackUtilizationRate(uint256 depositAmount) public {
+        // 1. Approve the collateral token to take the funds
+        underlyingToken.approve(address(collateralToken), depositAmount);
+
+        // 2. Deposit funds to ARTIFICIALLY LOWER utilization
+        uint256 shares = collateralToken.deposit(depositAmount, address(this));
+
+        // 3. Call the target function.
+        // The new transient storage defense should be active here.
+        // It should see the "real" utilization from before the deposit.
+        collateralToken.accrueInterest();
+
+        // 4. Withdraw the funds immediately
+        // We use redeem to pull out the exact shares we just minted
+        collateralToken.redeem(shares, address(this), address(this));
     }
 }
 
@@ -1153,6 +1181,123 @@ contract CollateralTrackerTest is Test, PositionUtils {
             actualAccumulator,
             expectedAccumulator,
             "FAIL: Interest did not accrue correctly after borrow was made"
+        );
+    }
+
+    // This is the new test function
+    function test_Success_Defend_FlashDeposit_mintOptions() public {
+        _initWorld(0);
+        uint104 assets = 1000 ether; // Total LP assets
+
+        // --- Alice and Bob deposit to provide initial liquidity ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Alice);
+        vm.stopPrank();
+
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+        vm.stopPrank();
+
+        // --- Set up HIGH UTILIZATION state ---
+        // We set 80% of the pool to be "in the AMM" (i.e., borrowed)
+        uint128 totalPoolAssets = uint128(collateralToken0.totalAssets());
+        uint128 amountToBorrow = (totalPoolAssets * 8) / 10; // 80% utilization
+        collateralToken0.setPoolAssets(totalPoolAssets - amountToBorrow);
+        collateralToken0.setInAMM(int128(amountToBorrow));
+
+        // Check that utilization is high and rate is positive
+        (, , , uint256 utilization) = collateralToken0.getPoolData();
+
+        uint256 preAttackUtilization = utilization;
+        uint128 preAttackRate = collateralToken0.interestRate();
+        assertGe(preAttackUtilization, 8000, "FAIL: Utilization should be ~80%");
+        assertGt(preAttackRate, 0, "FAIL: Rate should be positive");
+
+        // --- Warp time forward to accrue interest ---
+        uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
+        uint32 blocksToSkip = 7200;
+        vm.roll(blockAfterBorrow + blocksToSkip);
+        vm.warp(timestampAfterBorrow + 12 * blocksToSkip);
+
+        // Fund the attacker with a massive amount of tokens
+        uint256 attackDepositAmount = 1_000_000 ether;
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        // --- 1. CALCULATE EXPECTED RESULT (No attack) ---
+        // This is what the accumulator SHOULD be, based on the high utilization rate
+
+        uint256 snapshot = vm.snapshot();
+        {
+            vm.startPrank(Alice);
+
+            // 1. Approve the collateral token to take the funds
+            IERC20Partial(token0).approve(address(collateralToken0), attackDepositAmount);
+            // 2. Deposit funds to ARTIFICIALLY LOWER utilization
+            uint256 shares = collateralToken0.deposit(attackDepositAmount, Alice);
+
+            (, , , utilization) = collateralToken0.getPoolData();
+            uint256 postDepositUtilization = utilization;
+            uint128 postDepositRate = collateralToken0.interestRate();
+
+            assertLe(postDepositUtilization, 20, "FAIL: Utilization should be <0.2%");
+            assertGt(preAttackRate, postDepositRate, "FAIL: Rate should be lower after deposit");
+            // 3. Call the target function.
+            // The new transient storage defense should NOT be active here.
+            // It should see the "real" utilization from before the deposit.
+            uint128 _assets = assets / 2;
+            mintOptions(
+                panopticPool,
+                positionIdList,
+                _assets,
+                0,
+                Constants.MAX_POOL_TICK,
+                Constants.MIN_POOL_TICK,
+                true
+            );
+
+            (, , , , int256 u0, int256 u1, uint128 positionSize) = panopticPool.positionData(
+                Alice,
+                tokenId
+            );
+            // 4. Withdraw the funds immediately
+            // We use redeem to pull out the exact shares we just minted
+            //collateralToken0.redeem(shares, Alice, Alice);
+        }
+
+        uint256 expectedAccumulator = collateralToken0._interestRateAccumulator();
+
+        vm.stopPrank();
+        vm.revertTo(snapshot);
+        // --- 2. RUN THE ATTACK ---
+        Attacker attacker = new Attacker(collateralToken0, IERC20Partial(token0));
+
+        _grantTokens(address(attacker));
+
+        // Prank as the attacker and run the attack function
+        vm.prank(address(attacker));
+        attacker.attackUtilizationRate(attackDepositAmount);
+
+        // --- 3. ASSERT THE RESULT ---
+        // The transient storage should have protected the state.
+        // The final accumulator should match the one we calculated
+        // using the *high* utilization rate.
+        uint256 attackAccumulator = collateralToken0._interestRateAccumulator();
+
+        assertTrue(
+            attackAccumulator != expectedAccumulator,
+            "FAIL: Attack was successful! Accumulator was manipulated."
         );
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -102,6 +102,20 @@ contract CollateralTrackerHarness is CollateralTracker, PositionUtils, MiniPosit
     function poolUtilizationHook() external view returns (int128) {
         return int128(int256(_poolUtilizationView()));
     }
+
+    function readUtilizationSlot() external view returns (uint128 u) {
+        bytes32 slot = keccak256("panoptic.utilization.snapshot");
+        assembly {
+            u := tload(slot)
+        }
+    }
+
+    function wipeUtilizationSlot() external returns (uint128 u) {
+        bytes32 slot = keccak256("panoptic.utilization.snapshot");
+        assembly {
+            tstore(slot, 0)
+        }
+    }
 }
 
 // Inherits all of PanopticPool's functionality, however uses a modified version of startPool
@@ -306,14 +320,20 @@ contract UniswapV3PoolMock {
 contract Attacker {
     CollateralTracker internal collateralToken;
     IERC20Partial internal underlyingToken;
+    PanopticPool internal panopticPool;
 
-    constructor(CollateralTracker _collateral, IERC20Partial _token) {
+    constructor(CollateralTracker _collateral, IERC20Partial _token, PanopticPool _panopticPool) {
         collateralToken = _collateral;
         underlyingToken = _token;
+        panopticPool = _panopticPool;
     }
 
     /// @notice This function performs the attack sequence in a single transaction
-    function attackUtilizationRate(uint256 depositAmount) public {
+    function attackUtilizationRate(
+        uint256 depositAmount,
+        TokenId tokenId,
+        uint128 positionSize
+    ) public {
         // 1. Approve the collateral token to take the funds
         underlyingToken.approve(address(collateralToken), depositAmount);
 
@@ -323,11 +343,33 @@ contract Attacker {
         // 3. Call the target function.
         // The new transient storage defense should be active here.
         // It should see the "real" utilization from before the deposit.
-        collateralToken.accrueInterest();
+        TokenId[] memory posIdList = new TokenId[](1);
+        posIdList[0] = tokenId;
+
+        uint128[] memory sizeList = new uint128[](1);
+        sizeList[0] = positionSize;
+
+        int24[2][] memory tickLimits = new int24[2][](1);
+        tickLimits[0][0] = Constants.MAX_POOL_TICK;
+        tickLimits[0][1] = Constants.MIN_POOL_TICK;
+
+        panopticPool.dispatch(posIdList, posIdList, sizeList, new uint64[](1), tickLimits, true);
+
+        (, , , , int256 u0, int256 u1, uint128 positionSize) = panopticPool.positionData(
+            address(this),
+            tokenId
+        );
 
         // 4. Withdraw the funds immediately
         // We use redeem to pull out the exact shares we just minted
-        collateralToken.redeem(shares, address(this), address(this));
+        collateralToken.withdraw(
+            collateralToken.convertToAssets(collateralToken.balanceOf(address(this))) -
+                positionSize,
+            address(this),
+            address(this),
+            posIdList,
+            true
+        );
     }
 }
 
@@ -1245,7 +1287,9 @@ contract CollateralTrackerTest is Test, PositionUtils {
             // 1. Approve the collateral token to take the funds
             IERC20Partial(token0).approve(address(collateralToken0), attackDepositAmount);
             // 2. Deposit funds to ARTIFICIALLY LOWER utilization
+
             uint256 shares = collateralToken0.deposit(attackDepositAmount, Alice);
+            collateralToken0.wipeUtilizationSlot();
 
             (, , , utilization) = collateralToken0.getPoolData();
             uint256 postDepositUtilization = utilization;
@@ -1253,10 +1297,14 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
             assertLe(postDepositUtilization, 20, "FAIL: Utilization should be <0.2%");
             assertGt(preAttackRate, postDepositRate, "FAIL: Rate should be lower after deposit");
+            vm.roll(block.number + 1);
+            vm.warp(block.timestamp + 12 seconds);
+
             // 3. Call the target function.
             // The new transient storage defense should NOT be active here.
             // It should see the "real" utilization from before the deposit.
             uint128 _assets = assets / 2;
+            console2.log("mint");
             mintOptions(
                 panopticPool,
                 positionIdList,
@@ -1266,11 +1314,26 @@ contract CollateralTrackerTest is Test, PositionUtils {
                 Constants.MIN_POOL_TICK,
                 true
             );
+            collateralToken0.wipeUtilizationSlot();
 
+            console2.log("get u");
             (, , , , int256 u0, int256 u1, uint128 positionSize) = panopticPool.positionData(
                 Alice,
                 tokenId
             );
+            console2.log("burn");
+            burnOptions(
+                panopticPool,
+                positionIdList,
+                new TokenId[](0),
+                Constants.MAX_POOL_TICK,
+                Constants.MIN_POOL_TICK,
+                true
+            );
+            collateralToken0.wipeUtilizationSlot();
+
+            assertLe(u0, 21, "FAIL: utilization is less than 0.2% 1");
+
             // 4. Withdraw the funds immediately
             // We use redeem to pull out the exact shares we just minted
             //collateralToken0.redeem(shares, Alice, Alice);
@@ -1281,14 +1344,24 @@ contract CollateralTrackerTest is Test, PositionUtils {
         vm.stopPrank();
         vm.revertTo(snapshot);
         // --- 2. RUN THE ATTACK ---
-        Attacker attacker = new Attacker(collateralToken0, IERC20Partial(token0));
+        (, , , utilization) = collateralToken0.getPoolData();
+
+        preAttackUtilization = utilization;
+        assertEq(preAttackUtilization, 8000, "FAIL: Utilization should be at 80%");
+        console2.log("preAttack", preAttackUtilization);
+        Attacker attacker = new Attacker(collateralToken0, IERC20Partial(token0), panopticPool);
 
         _grantTokens(address(attacker));
 
         // Prank as the attacker and run the attack function
         vm.prank(address(attacker));
-        attacker.attackUtilizationRate(attackDepositAmount);
-
+        uint128 _assets = assets;
+        attacker.attackUtilizationRate(attackDepositAmount, tokenId, _assets / 2);
+        (, , , , int256 u0, int256 u1, uint128 positionSize) = panopticPool.positionData(
+            address(attacker),
+            tokenId
+        );
+        assertGe(u0, 8000, "FAIL: utilization is more than 80%");
         // --- 3. ASSERT THE RESULT ---
         // The transient storage should have protected the state.
         // The final accumulator should match the one we calculated


### PR DESCRIPTION
Fixes this: https://github.com/ObsidianAudits/2025-10-panoptic-v2/issues/6


###  Description

This PR introduces a security enhancement to the `CollateralTracker` to defend against a flash deposit attack that can be used to manipulate the pool's utilization rate.

###  The Vulnerability

The interest rate paid by borrowers is determined by the pool's utilization (i.e., `totalAssets` vs. `inAmm`). An attacker can exploit this in a single transaction by:

1.  **Depositing** a massive amount of assets (e.g., from a flash loan) into the pool.
2.  **Manipulating State:** This deposit artificially plummets the pool's utilization rate to near-zero.
3.  **Triggering Accrual:** The attacker then calls a function that triggers interest accrual (like `accrueInterest` or `mintOptions`). The contract sees the fake, low utilization and calculates an incorrectly low interest rate for the period.
4.  **Withdrawing:** The attacker immediately redeems their assets, and the pool returns to its original high-utilization state.

This attack effectively "steals" interest from LPs by forcing the protocol to miscalculate the accrual.

###  The Solution (Inferred)

This patch implements a defense using **transient storage (EIP-1153)**.

At the beginning of any transaction, the *current* (and correct) pool utilization is calculated and saved to a transient storage slot. When `accrueInterest` is called later in the *same transaction*—even after a malicious deposit—it ignores the current (manipulated) pool state and instead reads the original, correct utilization rate from transient storage.

This ensures the correct interest is always calculated, neutralizing the attack.
