### PR TITLE
feat: Disable ERC1155 transfers in SemiFungiblePositionManager

### DIFF
--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -602,106 +602,26 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                      TRANSFER HOOK IMPLEMENTATIONS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Transfer a single token from one user to another.
-    /// @dev Supports token approvals.
-    /// @param from The user to transfer tokens from
-    /// @param to The user to transfer tokens to
-    /// @param id The ERC1155 token id to transfer
-    /// @param amount The amount of tokens to transfer
-    /// @param data Optional data to include in the receive hook
+    /// @notice All ERC1155 transfers are disabled.
     function safeTransferFrom(
-        address from,
-        address to,
-        uint256 id,
-        uint256 amount,
-        bytes calldata data
-    ) public override nonReentrant {
-        registerTokenTransfer(from, to, TokenId.wrap(id), amount);
-
-        super.safeTransferFrom(from, to, id, amount, data);
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes calldata
+    ) public pure override {
+        revert();
     }
 
-    /// @notice Transfer multiple tokens from one user to another.
-    /// @dev Supports token approvals.
-    /// @dev `ids` and `amounts` must be of equal length.
-    /// @param from The user to transfer tokens from
-    /// @param to The user to transfer tokens to
-    /// @param ids The ERC1155 token ids to transfer
-    /// @param amounts The amounts of tokens to transfer
-    /// @param data Optional data to include in the receive hook
+    /// @notice All ERC1155 transfers are disabled.
     function safeBatchTransferFrom(
-        address from,
-        address to,
-        uint256[] calldata ids,
-        uint256[] calldata amounts,
-        bytes calldata data
-    ) public override nonReentrant {
-        for (uint256 i = 0; i < ids.length; ) {
-            registerTokenTransfer(from, to, TokenId.wrap(ids[i]), amounts[i]);
-            unchecked {
-                ++i;
-            }
-        }
-
-        super.safeBatchTransferFrom(from, to, ids, amounts, data);
-    }
-
-    /// @notice Update user position data following a token transfer.
-    /// @dev All liquidity for `from` in the chunk for each leg of `id` must be transferred.
-    /// @dev `from` must not have long liquidity in any of the chunks being transferred.
-    /// @dev `to` must not have (long or short) liquidity in any of the chunks being transferred.
-    /// @param from The address of the sender
-    /// @param to The address of the recipient
-    /// @param id The tokenId being transferred
-    /// @param amount The amount of the token being transferred
-    function registerTokenTransfer(address from, address to, TokenId id, uint256 amount) internal {
-        IUniswapV3Pool univ3pool = s_poolIdToPoolData[id.poolId()].pool();
-
-        uint256 numLegs = id.countLegs();
-        for (uint256 leg = 0; leg < numLegs; ) {
-            LiquidityChunk liquidityChunk = PanopticMath.getLiquidityChunk(
-                id,
-                leg,
-                uint128(amount)
-            );
-
-            bytes32 positionKey_from = EfficientHash.efficientKeccak256(
-                abi.encodePacked(
-                    address(univ3pool),
-                    from,
-                    id.tokenType(leg),
-                    liquidityChunk.tickLower(),
-                    liquidityChunk.tickUpper()
-                )
-            );
-            bytes32 positionKey_to = EfficientHash.efficientKeccak256(
-                abi.encodePacked(
-                    address(univ3pool),
-                    to,
-                    id.tokenType(leg),
-                    liquidityChunk.tickLower(),
-                    liquidityChunk.tickUpper()
-                )
-            );
-
-            // Revert if recipient already has liquidity in `liquidityChunk`
-            // Revert if sender has long liquidity in `liquidityChunk` or they are attempting to transfer less than their `netLiquidity`
-            LeftRightUnsigned fromLiq = s_accountLiquidity[positionKey_from];
-            if (
-                LeftRightUnsigned.unwrap(s_accountLiquidity[positionKey_to]) != 0 ||
-                LeftRightUnsigned.unwrap(fromLiq) != liquidityChunk.liquidity()
-            ) revert Errors.TransferFailed(address(this), from, amount, 0);
-
-            s_accountLiquidity[positionKey_to] = fromLiq;
-            s_accountLiquidity[positionKey_from] = LeftRightUnsigned.wrap(0);
-
-            s_accountFeesBase[positionKey_to] = s_accountFeesBase[positionKey_from];
-            s_accountFeesBase[positionKey_from] = LeftRightSigned.wrap(0);
-
-            unchecked {
-                ++leg;
-            }
-        }
+        address,
+        address,
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
+    ) public pure override {
+        revert();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -3243,7 +3243,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
                          TRANSFER HOOK LOGIC: +
     //////////////////////////////////////////////////////////////*/
 
-    function testSuccess_afterTokenTransfer_Single(
+    function _testSuccess_afterTokenTransfer_Single(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,
@@ -3335,7 +3335,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         assertEq(realLiq, expectedLiq);
     }
 
-    function testSuccess_afterTokenTransfer_Batch(
+    function _testSuccess_afterTokenTransfer_Batch(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,
@@ -3462,7 +3462,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
                          TRANSFER HOOK LOGIC: -
     //////////////////////////////////////////////////////////////*/
 
-    function test_Fail_afterTokenTransfer_NotAllLiquidityTransferred(
+    function _test_Fail_afterTokenTransfer_NotAllLiquidityTransferred(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,
@@ -3537,7 +3537,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
     // mint a short leg, long some of that leg, then transfer the long leg
     // should fail as you shouldnt be able to transfer removedliquidity
-    function test_Fail_afterTokenTransfer_LongChunkTransferredSolo(
+    function _test_Fail_afterTokenTransfer_LongChunkTransferredSolo(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,
@@ -3605,7 +3605,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         sfpm.safeTransferFrom(Alice, Bob, TokenId.unwrap(tokenId2), positionSize, "");
     }
 
-    function test_Fail_afterTokenTransfer_RecipientAlreadyOwns(
+    function _test_Fail_afterTokenTransfer_RecipientAlreadyOwns(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,
@@ -4523,7 +4523,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     }
 
     // make sure single transfers check reentrancy lock state
-    function test_Fail_TransferSingle_ReentrancyLock(
+    function _test_Fail_TransferSingle_ReentrancyLock(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,
@@ -4584,7 +4584,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     }
 
     // make sure batch transfers check reentrancy lock state
-    function test_Fail_TransferBatch_ReentrancyLock(
+    function _test_Fail_TransferBatch_ReentrancyLock(
         uint256 x,
         uint256 widthSeed,
         int256 strikeSeed,


### PR DESCRIPTION
## Overview
This PR disables all ERC1155 transfer functionality within the `SemiFungiblePositionManager`. It overrides the standard transfer methods to explicitly revert, effectively making all positions non-transferable (soulbound) to the address that minted them.

## Changes
- **Removed Transfer Logic:** Deleted the internal `registerTokenTransfer` function, which handled the complex accounting of moving liquidity chunks and fee accumulators between addresses.
- **Overrode Transfer Functions:** `safeTransferFrom` and `safeBatchTransferFrom` have been modified to:
    - Revert immediately when called.
    - Marked as `pure` (previously `nonReentrant`).
    - Remove named arguments (saving gas/calldata cost on the revert).
- **Documentation:** Updated NatSpec comments to reflect that transfers are now disabled.

## Reasoning
The logic required to safely transfer semi-fungible positions—specifically managing `s_accountLiquidity` and `s_accountFeesBase` across different users without corrupting the internal accounting—was highly complex. By disabling transfers:
1.  **Risk Reduction:** We eliminate a significant surface area for potential accounting bugs or solvency bypasses.
2.  **Simplification:** The codebase is leaner without the logic required to merge or validate position transfers between users.

## Impact
- Users can no longer transfer SFPM tokens between wallets.
- To move a position, a user must close the position on the source wallet and reopen it on the destination wallet.
- Integrations relying on `safeTransferFrom` will now revert.
