### PR TITLE
feat: Add `donate` function to CollateralTracker

### DIFF
--- a/contracts/CollateralTracker.sol
+++ b/contracts/CollateralTracker.sol
@@ -63,6 +63,16 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         uint256 shares
     );
 
+    /// @notice Emitted when shares are donated to the protocol.
+    /// @param sender The address of the caller
+    /// @param shares The amount of shares burned by the sender
+    event Donate(address indexed sender, uint256 shares);
+
+    /// @notice Emitted when a commission is paid.
+    /// @param owner The address of the owner of the shares being used to pay for the commission
+    /// @param builder The address of the account that received the commission if a builderCode is provided
+    /// @param commissionPaidProtocol The amount of assets paid that goes to the PLPs (if builder == address(0)) or to the protocol
+    /// @param commissionPaidBuilder The amount of assets paid that goes to the builder
     event CommissionPaid(
         address indexed owner,
         address indexed builder,
@@ -847,9 +857,26 @@ contract CollateralTracker is Clone, ERC20Minimal, Multicall {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
+    /// @notice Donate exact shares to all shareholders.
+    /// @dev Can only be used when the user has no open positions
+    /// @param shares Amount of shares to be donated
+    function donate(uint256 shares) external {
+        _accrueInterest(msg.sender, IS_NOT_DEPOSIT);
+
+        if (shares > maxRedeem(msg.sender)) revert Errors.ExceedsMaximumRedemption();
+
+        uint256 assets = previewRedeem(shares);
+        if (assets == 0) revert Errors.BelowMinimumRedemption();
+
+        // burn collateral shares of the Panoptic Pool funds (this ERC20 token)
+        _burn(msg.sender, shares);
+
+        emit Donate(msg.sender, shares);
+    }
+
     /// @notice Accrues protocol-wide interest for the calling user
     /// @dev Updates global interest state and settles any outstanding interest for msg.sender
-    function accrueInterest() public {
+    function accrueInterest() external {
         _accrueInterest(msg.sender, IS_NOT_DEPOSIT);
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -403,6 +403,8 @@ contract Attacker {
 contract CollateralTrackerTest is Test, PositionUtils {
     using Math for uint256;
 
+    event Donate(address indexed sender, uint256 shares);
+
     // users who will send/receive deposits, transfers, and withdrawals
     address Alice = makeAddr("Alice");
     address Bob = makeAddr("Bob");
@@ -6302,6 +6304,381 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         vm.expectRevert(Errors.BelowMinimumRedemption.selector);
         collateralToken1.redeem(sharesBelow1, Alice, Bob);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        SHARE DONATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Success_donate(uint256 x, uint104 shares) public {
+        uint256 assetsToken0;
+        uint256 assetsToken1;
+
+        {
+            _initWorld(x);
+
+            // Invoke all interactions with the Collateral Tracker from user Bob
+            vm.startPrank(Bob);
+
+            // give Bob the max amount of tokens
+            _grantTokens(Bob);
+
+            // calculate underlying assets via amount of shares
+            assetsToken0 = convertToAssets(shares, collateralToken0);
+            assetsToken1 = convertToAssets(shares, collateralToken1);
+
+            // approve collateral tracker to move tokens on Bob's behalf
+            IERC20Partial(token0).approve(address(collateralToken0), assetsToken0);
+            IERC20Partial(token1).approve(address(collateralToken1), assetsToken1);
+
+            // deposit a number of assets determined via fuzzing
+            _mockMaxDeposit(Bob);
+        }
+
+        // We must ensure Bob leaves at least 1 share to avoid "CannotBurnLastShare" logic
+        // We also ensure shares > 0 to avoid BelowMinimumRedemption
+        uint256 maxRedeem0 = collateralToken0.maxRedeem(Bob);
+        uint256 maxRedeem1 = collateralToken1.maxRedeem(Bob);
+
+        // If maxRedeem is too small to split (need at least 2 shares: 1 to donate, 1 to keep), skip
+        if (maxRedeem0 < 2) return;
+        if (maxRedeem1 < 2) return;
+
+        // Bound shares to [previewWithdraw(1), maxRedeem - 1]
+        // This ensures we don't burn the very last share of the protocol
+        uint256 shares0 = bound(shares, collateralToken0.previewWithdraw(1), maxRedeem0 - 1);
+        uint256 shares1 = bound(shares, collateralToken1.previewWithdraw(1), maxRedeem1 - 1);
+
+        // Snapshot state before
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
+        uint256 totalSupplyBefore0 = collateralToken0.totalSupply();
+        uint256 totalSupplyBefore1 = collateralToken1.totalSupply();
+
+        // Expect Event
+        vm.expectEmit(true, false, false, true, address(collateralToken0));
+        emit Donate(Bob, shares0);
+        collateralToken0.donate(shares0);
+
+        vm.expectEmit(true, false, false, true, address(collateralToken1));
+        emit Donate(Bob, shares1);
+        collateralToken1.donate(shares1);
+
+        // Snapshot state after
+        uint256 sharesAfter0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesAfter1 = collateralToken1.balanceOf(Bob);
+
+        // assertions
+        assertEq(sharesAfter0, sharesBefore0 - shares0, "Bob shares not burned correctly");
+        assertEq(sharesAfter1, sharesBefore1 - shares1, "Bob shares not burned correctly");
+
+        assertEq(
+            collateralToken0.totalSupply(),
+            totalSupplyBefore0 - shares0,
+            "Total supply not updated"
+        );
+        assertEq(
+            collateralToken1.totalSupply(),
+            totalSupplyBefore1 - shares1,
+            "Total supply not updated"
+        );
+
+        // Verify assets did NOT move (Balance of pool should be same)
+        // Indirectly checked because no transfer events were emitted and balance check would show no change
+    }
+
+    function test_Success_donate_IncreasesSharePrice(uint256 x) public {
+        _initWorld(x);
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        // 1. Bob deposits 1000 assets -> gets 1000 shares (assuming 1:1 initially)
+        uint256 depositAmt = 1000e18;
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 shares = collateralToken0.deposit(depositAmt, Bob);
+
+        // 2. Alice deposits 1000 assets -> gets 1000 shares
+        vm.stopPrank();
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        collateralToken0.deposit(depositAmt, Alice);
+
+        // Current state: Total Assets 2000, Total Shares 2000. Price = 1.0
+
+        // 3. Alice donates 500 shares
+        // Alice burns 500 shares, but assets remain 2000.
+        // New State: Total Assets 2000, Total Shares 1500.
+        // Expected Price = 2000 / 1500 = 1.333...
+        collateralToken0.donate(collateralToken0.convertToShares(500e18));
+        vm.stopPrank();
+
+        // 4. Bob checks exchange rate
+        vm.startPrank(Bob);
+
+        // If Bob redeems his 1000 shares now, he should get > 1000 assets
+        uint256 previewAssets = collateralToken0.previewRedeem(shares);
+
+        assertGt(previewAssets, 1000e18, "Share price did not increase after donation");
+
+        // Math check: (1000 shares / 1500 total shares) * 2000 total assets = 1333.33
+        assertEq(previewAssets, 1333333333333333333333);
+    }
+
+    function testFuzz_Success_donate_IncreasesSharePrice(uint256 donationSize) public {
+        // 0. Init
+        _initWorld(1);
+        uint256 depositAmt = 1000e18;
+
+        // 1. Bob deposits
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 bobShares = collateralToken0.deposit(depositAmt, Bob);
+        vm.stopPrank();
+
+        // 2. Alice deposits
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 aliceShares = collateralToken0.deposit(depositAmt, Alice);
+
+        // 3. Fuzz Constraint
+        // Alice cannot donate less than 0 assets and cannot donate more than she has.
+        uint256 minimumDonation = collateralToken0.previewWithdraw(1);
+        donationSize = bound(donationSize, minimumDonation, aliceShares);
+
+        // Capture state before donation
+        uint256 totalAssetsBefore = collateralToken0.totalAssets();
+        uint256 totalSupplyBefore = collateralToken0.totalSupply();
+
+        // 4. Alice donates (burns shares)
+        collateralToken0.donate(donationSize);
+        vm.stopPrank();
+
+        // 5. Invariant Checks
+
+        // Bob's Check: His 1000 shares should now be worth MORE than 1000 assets
+        // because the total assets are the same, but there are fewer shares in existence.
+        uint256 bobPreviewAssets = collateralToken0.previewRedeem(bobShares);
+        assertGe(bobPreviewAssets, depositAmt, "Bob's share value should increase after donation");
+
+        // Alice's Check: Her remaining value must be LOWER than her initial deposit
+        // because she literally gave away value to the pool.
+        uint256 aliceRemainingShares = aliceShares - donationSize;
+        uint256 alicePreviewAssets = collateralToken0.previewRedeem(aliceRemainingShares);
+        assertLt(
+            alicePreviewAssets,
+            depositAmt,
+            "Alice's share value should decrease after donation"
+        );
+
+        assertEq(
+            collateralToken0.totalAssets(),
+            totalAssetsBefore,
+            "Total assets changed during share donation"
+        );
+        assertEq(
+            collateralToken0.totalSupply(),
+            totalSupplyBefore - donationSize,
+            "Total supply did not decrease by donation amount"
+        );
+        // Allow for 1 wei rounding error due to division
+        assertApproxEqAbs(
+            bobPreviewAssets + alicePreviewAssets,
+            totalAssetsBefore,
+            3,
+            "Assets extracted do not match assets in vault"
+        );
+        assertLe(
+            bobPreviewAssets + alicePreviewAssets,
+            totalAssetsBefore,
+            "Assets after are less than before (although should be same)"
+        );
+    }
+
+    function test_Fail_donate_exceedsMax(uint256 x, uint256 sharesSeed) public {
+        _initWorld(x);
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        IERC20Partial(token1).approve(address(collateralToken1), type(uint256).max);
+        _mockMaxDeposit(Bob);
+
+        // We want to try donating more than we own OR more than allowed
+        // maxRedeem is the strict upper bound
+        uint256 maxRedeem0 = collateralToken0.maxRedeem(Bob);
+        uint256 maxRedeem1 = collateralToken1.maxRedeem(Bob);
+
+        uint256 badShares0 = bound(sharesSeed, maxRedeem0 + 1, type(uint136).max);
+        uint256 badShares1 = bound(sharesSeed, maxRedeem1 + 1, type(uint136).max);
+
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.donate(badShares0);
+
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken1.donate(badShares1);
+    }
+
+    function test_Fail_donate_LastShare(uint256 x) public {
+        // This tests the "Zero Supply Bug" protection logic
+        _initWorld(x);
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        uint256 virtualShares = collateralToken0.totalSupply();
+        uint256 oneShareAssets = collateralToken0.previewRedeem(1);
+
+        // Deposit
+        uint256 depositAmt = 1000e18;
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 shares = collateralToken0.deposit(depositAmt, Bob);
+
+        // Verify Bob owns everything
+        assertEq(collateralToken0.totalSupply(), shares + 1_000_000, "totalSupply");
+        assertEq(collateralToken0.balanceOf(Bob), shares, "bob shares");
+
+        // Attempt to donate EVERYTHING (totalSupply)
+        // This should revert because shares >= totalSupply()
+        collateralToken0.donate(shares);
+
+        assertEq(collateralToken0.balanceOf(Bob), 0, "Bob should be empty");
+        assertEq(collateralToken0.totalSupply(), virtualShares, "Only virtual shares remain");
+
+        // 5. Verify the Virtual Shares now have huge value (PPS increased)
+        assertGt(collateralToken0.previewRedeem(1), oneShareAssets);
+
+        // The virtual shares now claim the 1 virtual asset + Bob's 1000e18 assets
+        // Price Per Share = ~1000e18 / 10**6 = 10**12
+        assertEq(
+            collateralToken0.previewRedeem(1),
+            depositAmt / virtualShares,
+            "one share is 1e15 assets"
+        );
+    }
+
+    function test_Fail_donate_BelowMinimumRedemption(uint256 x, uint104 depositAssets) public {
+        _initWorld(x);
+        depositAssets = uint104(bound(depositAssets, 1e18, type(uint104).max));
+
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), depositAssets);
+        IERC20Partial(token1).approve(address(collateralToken1), depositAssets);
+
+        collateralToken0.deposit(depositAssets, Bob);
+        collateralToken1.deposit(depositAssets, Bob);
+
+        // 1. Try to donate 0
+        vm.expectRevert(Errors.BelowMinimumRedemption.selector);
+        collateralToken0.donate(0);
+
+        // 2. Try to donate amount that converts to 0 assets
+        // (This catches rounding issues where shares are non-zero but assets are zero)
+        uint256 sharesBelow0 = collateralToken0.convertToShares(1) - 1;
+        uint256 sharesBelow1 = collateralToken1.convertToShares(1) - 1;
+
+        // Only run if rounding actually creates a gap (sharesBelow > 0)
+        if (sharesBelow0 > 0) {
+            vm.expectRevert(Errors.BelowMinimumRedemption.selector);
+            collateralToken0.donate(sharesBelow0);
+        }
+        if (sharesBelow1 > 0) {
+            vm.expectRevert(Errors.BelowMinimumRedemption.selector);
+            collateralToken1.donate(sharesBelow1);
+        }
+    }
+
+    function test_Fail_donate_RevertDueToAccruedInterestLiquidityCrunch() public {
+        _initWorld(0);
+
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = collateralToken0.borrowIndex();
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        uint256 initialShares = collateralToken0.deposit(assets, Alice);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+        collateralToken1.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // --- Bob deposits + Mints ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        mintOptions(
+            panopticPool,
+            positionIdList,
+            (assets * 15) / 10,
+            0,
+            Constants.MAX_POOL_TICK,
+            Constants.MIN_POOL_TICK,
+            true
+        );
+
+        // At this specific moment (price 1:1), maxRedeem is exactly 100 shares (worth 100 assets).
+        // But Bob has 1000 shares.
+        // If he tried to donate 100 shares now, it would work.
+        // We want to show that INTEREST ACCRUAL specifically tightens this constraint.
+
+        // 3. Accrue Massive Interest
+        // We warp time forward significantly.
+        uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
+        uint32 timeSkip = 20 * 365 days; // Large time jump to generate significant interest
+
+        vm.roll(blockAfterBorrow + timeSkip / 12);
+        vm.warp(timestampAfterBorrow + timeSkip);
+
+        burnOptions(
+            panopticPool,
+            positionIdList,
+            new TokenId[](0),
+            Constants.MAX_POOL_TICK,
+            Constants.MIN_POOL_TICK,
+            true
+        );
+        assertEq(collateralToken0.balanceOf(Bob), 0, "bob has zero balance");
+        // 4. Alice burns
+
+        vm.startPrank(Alice);
+        uint256 maxRedeemableShares = collateralToken0.maxRedeem(Alice);
+
+        assertLt(maxRedeemableShares, initialShares, "less shares due to interest rate accrual");
+
+        uint256 aliceAssetValue = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        // 5. Bob tries to donate what WAS a valid liquid amount (e.g. 100 shares)
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.donate(initialShares);
+
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.donate(maxRedeemableShares + 1);
+
+        collateralToken0.donate(maxRedeemableShares);
+
+        assertLt(
+            collateralToken0.convertToAssets(collateralToken0.balanceOf(Alice)),
+            aliceAssetValue,
+            "Alice's balance is zero"
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/foundry/coreV3/CollateralTracker.t.sol
+++ b/test/foundry/coreV3/CollateralTracker.t.sol
@@ -384,6 +384,8 @@ contract Attacker {
 contract CollateralTrackerTest is Test, PositionUtils {
     using Math for uint256;
 
+    event Donate(address indexed sender, uint256 shares);
+
     // users who will send/receive deposits, transfers, and withdrawals
     address Alice = makeAddr("Alice");
     address Bob = makeAddr("Bob");
@@ -6171,6 +6173,381 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
         vm.expectRevert(Errors.BelowMinimumRedemption.selector);
         collateralToken1.redeem(sharesBelow1, Alice, Bob);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        SHARE DONATION TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Success_donate(uint256 x, uint104 shares) public {
+        uint256 assetsToken0;
+        uint256 assetsToken1;
+
+        {
+            _initWorld(x);
+
+            // Invoke all interactions with the Collateral Tracker from user Bob
+            vm.startPrank(Bob);
+
+            // give Bob the max amount of tokens
+            _grantTokens(Bob);
+
+            // calculate underlying assets via amount of shares
+            assetsToken0 = convertToAssets(shares, collateralToken0);
+            assetsToken1 = convertToAssets(shares, collateralToken1);
+
+            // approve collateral tracker to move tokens on Bob's behalf
+            IERC20Partial(token0).approve(address(collateralToken0), assetsToken0);
+            IERC20Partial(token1).approve(address(collateralToken1), assetsToken1);
+
+            // deposit a number of assets determined via fuzzing
+            _mockMaxDeposit(Bob);
+        }
+
+        // We must ensure Bob leaves at least 1 share to avoid "CannotBurnLastShare" logic
+        // We also ensure shares > 0 to avoid BelowMinimumRedemption
+        uint256 maxRedeem0 = collateralToken0.maxRedeem(Bob);
+        uint256 maxRedeem1 = collateralToken1.maxRedeem(Bob);
+
+        // If maxRedeem is too small to split (need at least 2 shares: 1 to donate, 1 to keep), skip
+        if (maxRedeem0 < 2) return;
+        if (maxRedeem1 < 2) return;
+
+        // Bound shares to [previewWithdraw(1), maxRedeem - 1]
+        // This ensures we don't burn the very last share of the protocol
+        uint256 shares0 = bound(shares, collateralToken0.previewWithdraw(1), maxRedeem0 - 1);
+        uint256 shares1 = bound(shares, collateralToken1.previewWithdraw(1), maxRedeem1 - 1);
+
+        // Snapshot state before
+        uint256 sharesBefore0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesBefore1 = collateralToken1.balanceOf(Bob);
+        uint256 totalSupplyBefore0 = collateralToken0.totalSupply();
+        uint256 totalSupplyBefore1 = collateralToken1.totalSupply();
+
+        // Expect Event
+        vm.expectEmit(true, false, false, true, address(collateralToken0));
+        emit Donate(Bob, shares0);
+        collateralToken0.donate(shares0);
+
+        vm.expectEmit(true, false, false, true, address(collateralToken1));
+        emit Donate(Bob, shares1);
+        collateralToken1.donate(shares1);
+
+        // Snapshot state after
+        uint256 sharesAfter0 = collateralToken0.balanceOf(Bob);
+        uint256 sharesAfter1 = collateralToken1.balanceOf(Bob);
+
+        // assertions
+        assertEq(sharesAfter0, sharesBefore0 - shares0, "Bob shares not burned correctly");
+        assertEq(sharesAfter1, sharesBefore1 - shares1, "Bob shares not burned correctly");
+
+        assertEq(
+            collateralToken0.totalSupply(),
+            totalSupplyBefore0 - shares0,
+            "Total supply not updated"
+        );
+        assertEq(
+            collateralToken1.totalSupply(),
+            totalSupplyBefore1 - shares1,
+            "Total supply not updated"
+        );
+
+        // Verify assets did NOT move (Balance of pool should be same)
+        // Indirectly checked because no transfer events were emitted and balance check would show no change
+    }
+
+    function test_Success_donate_IncreasesSharePrice(uint256 x) public {
+        _initWorld(x);
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        // 1. Bob deposits 1000 assets -> gets 1000 shares (assuming 1:1 initially)
+        uint256 depositAmt = 1000e18;
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 shares = collateralToken0.deposit(depositAmt, Bob);
+
+        // 2. Alice deposits 1000 assets -> gets 1000 shares
+        vm.stopPrank();
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        collateralToken0.deposit(depositAmt, Alice);
+
+        // Current state: Total Assets 2000, Total Shares 2000. Price = 1.0
+
+        // 3. Alice donates 500 shares
+        // Alice burns 500 shares, but assets remain 2000.
+        // New State: Total Assets 2000, Total Shares 1500.
+        // Expected Price = 2000 / 1500 = 1.333...
+        collateralToken0.donate(collateralToken0.convertToShares(500e18));
+        vm.stopPrank();
+
+        // 4. Bob checks exchange rate
+        vm.startPrank(Bob);
+
+        // If Bob redeems his 1000 shares now, he should get > 1000 assets
+        uint256 previewAssets = collateralToken0.previewRedeem(shares);
+
+        assertGt(previewAssets, 1000e18, "Share price did not increase after donation");
+
+        // Math check: (1000 shares / 1500 total shares) * 2000 total assets = 1333.33
+        assertEq(previewAssets, 1333333333333333333333);
+    }
+
+    function testFuzz_Success_donate_IncreasesSharePrice(uint256 donationSize) public {
+        // 0. Init
+        _initWorld(1);
+        uint256 depositAmt = 1000e18;
+
+        // 1. Bob deposits
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 bobShares = collateralToken0.deposit(depositAmt, Bob);
+        vm.stopPrank();
+
+        // 2. Alice deposits
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 aliceShares = collateralToken0.deposit(depositAmt, Alice);
+
+        // 3. Fuzz Constraint
+        // Alice cannot donate less than 0 assets and cannot donate more than she has.
+        uint256 minimumDonation = collateralToken0.previewWithdraw(1);
+        donationSize = bound(donationSize, minimumDonation, aliceShares);
+
+        // Capture state before donation
+        uint256 totalAssetsBefore = collateralToken0.totalAssets();
+        uint256 totalSupplyBefore = collateralToken0.totalSupply();
+
+        // 4. Alice donates (burns shares)
+        collateralToken0.donate(donationSize);
+        vm.stopPrank();
+
+        // 5. Invariant Checks
+
+        // Bob's Check: His 1000 shares should now be worth MORE than 1000 assets
+        // because the total assets are the same, but there are fewer shares in existence.
+        uint256 bobPreviewAssets = collateralToken0.previewRedeem(bobShares);
+        assertGe(bobPreviewAssets, depositAmt, "Bob's share value should increase after donation");
+
+        // Alice's Check: Her remaining value must be LOWER than her initial deposit
+        // because she literally gave away value to the pool.
+        uint256 aliceRemainingShares = aliceShares - donationSize;
+        uint256 alicePreviewAssets = collateralToken0.previewRedeem(aliceRemainingShares);
+        assertLt(
+            alicePreviewAssets,
+            depositAmt,
+            "Alice's share value should decrease after donation"
+        );
+
+        assertEq(
+            collateralToken0.totalAssets(),
+            totalAssetsBefore,
+            "Total assets changed during share donation"
+        );
+        assertEq(
+            collateralToken0.totalSupply(),
+            totalSupplyBefore - donationSize,
+            "Total supply did not decrease by donation amount"
+        );
+        // Allow for 1 wei rounding error due to division
+        assertApproxEqAbs(
+            bobPreviewAssets + alicePreviewAssets,
+            totalAssetsBefore,
+            3,
+            "Assets extracted do not match assets in vault"
+        );
+        assertLe(
+            bobPreviewAssets + alicePreviewAssets,
+            totalAssetsBefore,
+            "Assets after are less than before (although should be same)"
+        );
+    }
+
+    function test_Fail_donate_exceedsMax(uint256 x, uint256 sharesSeed) public {
+        _initWorld(x);
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), type(uint256).max);
+        IERC20Partial(token1).approve(address(collateralToken1), type(uint256).max);
+        _mockMaxDeposit(Bob);
+
+        // We want to try donating more than we own OR more than allowed
+        // maxRedeem is the strict upper bound
+        uint256 maxRedeem0 = collateralToken0.maxRedeem(Bob);
+        uint256 maxRedeem1 = collateralToken1.maxRedeem(Bob);
+
+        uint256 badShares0 = bound(sharesSeed, maxRedeem0 + 1, type(uint136).max);
+        uint256 badShares1 = bound(sharesSeed, maxRedeem1 + 1, type(uint136).max);
+
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.donate(badShares0);
+
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken1.donate(badShares1);
+    }
+
+    function test_Fail_donate_LastShare(uint256 x) public {
+        // This tests the "Zero Supply Bug" protection logic
+        _initWorld(x);
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        uint256 virtualShares = collateralToken0.totalSupply();
+        uint256 oneShareAssets = collateralToken0.previewRedeem(1);
+
+        // Deposit
+        uint256 depositAmt = 1000e18;
+        IERC20Partial(token0).approve(address(collateralToken0), depositAmt);
+        uint256 shares = collateralToken0.deposit(depositAmt, Bob);
+
+        // Verify Bob owns everything
+        assertEq(collateralToken0.totalSupply(), shares + 1_000_000, "totalSupply");
+        assertEq(collateralToken0.balanceOf(Bob), shares, "bob shares");
+
+        // Attempt to donate EVERYTHING (totalSupply)
+        // This should revert because shares >= totalSupply()
+        collateralToken0.donate(shares);
+
+        assertEq(collateralToken0.balanceOf(Bob), 0, "Bob should be empty");
+        assertEq(collateralToken0.totalSupply(), virtualShares, "Only virtual shares remain");
+
+        // 5. Verify the Virtual Shares now have huge value (PPS increased)
+        assertGt(collateralToken0.previewRedeem(1), oneShareAssets);
+
+        // The virtual shares now claim the 1 virtual asset + Bob's 1000e18 assets
+        // Price Per Share = ~1000e18 / 10**6 = 10**12
+        assertEq(
+            collateralToken0.previewRedeem(1),
+            depositAmt / virtualShares,
+            "one share is 1e15 assets"
+        );
+    }
+
+    function test_Fail_donate_BelowMinimumRedemption(uint256 x, uint104 depositAssets) public {
+        _initWorld(x);
+        depositAssets = uint104(bound(depositAssets, 1e18, type(uint104).max));
+
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+
+        IERC20Partial(token0).approve(address(collateralToken0), depositAssets);
+        IERC20Partial(token1).approve(address(collateralToken1), depositAssets);
+
+        collateralToken0.deposit(depositAssets, Bob);
+        collateralToken1.deposit(depositAssets, Bob);
+
+        // 1. Try to donate 0
+        vm.expectRevert(Errors.BelowMinimumRedemption.selector);
+        collateralToken0.donate(0);
+
+        // 2. Try to donate amount that converts to 0 assets
+        // (This catches rounding issues where shares are non-zero but assets are zero)
+        uint256 sharesBelow0 = collateralToken0.convertToShares(1) - 1;
+        uint256 sharesBelow1 = collateralToken1.convertToShares(1) - 1;
+
+        // Only run if rounding actually creates a gap (sharesBelow > 0)
+        if (sharesBelow0 > 0) {
+            vm.expectRevert(Errors.BelowMinimumRedemption.selector);
+            collateralToken0.donate(sharesBelow0);
+        }
+        if (sharesBelow1 > 0) {
+            vm.expectRevert(Errors.BelowMinimumRedemption.selector);
+            collateralToken1.donate(sharesBelow1);
+        }
+    }
+
+    function test_Fail_donate_RevertDueToAccruedInterestLiquidityCrunch() public {
+        _initWorld(0);
+
+        uint104 assets = 1000 ether; // Use a fixed deposit amount
+
+        // Get the initial borrow index right after initialization
+        uint128 initialBorrowIndex = collateralToken0.borrowIndex();
+
+        // --- Alice deposits ---
+        vm.startPrank(Alice);
+        _grantTokens(Alice);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        uint256 initialShares = collateralToken0.deposit(assets, Alice);
+        IERC20Partial(token1).approve(address(collateralToken1), assets);
+        collateralToken1.deposit(assets, Alice);
+        vm.stopPrank();
+
+        // --- Bob deposits + Mints ---
+        vm.startPrank(Bob);
+        _grantTokens(Bob);
+        IERC20Partial(token0).approve(address(collateralToken0), assets);
+        collateralToken0.deposit(assets, Bob);
+
+        (currentSqrtPriceX96, currentTick, , , , , ) = pool.slot0();
+
+        strike = 198600 + 6000;
+        width = 2;
+
+        tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(0, 1, 0, 0, 0, 0, strike, width);
+        positionIdList.push(tokenId);
+
+        mintOptions(
+            panopticPool,
+            positionIdList,
+            (assets * 15) / 10,
+            0,
+            Constants.MAX_POOL_TICK,
+            Constants.MIN_POOL_TICK,
+            true
+        );
+
+        // At this specific moment (price 1:1), maxRedeem is exactly 100 shares (worth 100 assets).
+        // But Bob has 1000 shares.
+        // If he tried to donate 100 shares now, it would work.
+        // We want to show that INTEREST ACCRUAL specifically tightens this constraint.
+
+        // 3. Accrue Massive Interest
+        // We warp time forward significantly.
+        uint256 blockAfterBorrow = block.number;
+        uint256 timestampAfterBorrow = block.timestamp;
+        uint32 timeSkip = 20 * 365 days; // Large time jump to generate significant interest
+
+        vm.roll(blockAfterBorrow + timeSkip / 12);
+        vm.warp(timestampAfterBorrow + timeSkip);
+
+        burnOptions(
+            panopticPool,
+            positionIdList,
+            new TokenId[](0),
+            Constants.MAX_POOL_TICK,
+            Constants.MIN_POOL_TICK,
+            true
+        );
+        assertEq(collateralToken0.balanceOf(Bob), 0, "bob has zero balance");
+        // 4. Alice burns
+
+        vm.startPrank(Alice);
+        uint256 maxRedeemableShares = collateralToken0.maxRedeem(Alice);
+
+        assertLt(maxRedeemableShares, initialShares, "less shares due to interest rate accrual");
+
+        uint256 aliceAssetValue = collateralToken0.convertToAssets(
+            collateralToken0.balanceOf(Alice)
+        );
+        // 5. Bob tries to donate what WAS a valid liquid amount (e.g. 100 shares)
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.donate(initialShares);
+
+        vm.expectRevert(Errors.ExceedsMaximumRedemption.selector);
+        collateralToken0.donate(maxRedeemableShares + 1);
+
+        collateralToken0.donate(maxRedeemableShares);
+
+        assertLt(
+            collateralToken0.convertToAssets(collateralToken0.balanceOf(Alice)),
+            aliceAssetValue,
+            "Alice's balance is zero"
+        );
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
#Description

This PR introduces a `donate` function to the `CollateralTracker` contract. This allows shareholders (LPs) to voluntarily burn their shares without redeeming the underlying assets. By reducing the `totalSupply` while maintaining the same `totalAssets`, this action effectively distributes value pro-rata to all remaining shareholders by increasing the Price Per Share (PPS).

## Changes
### Contracts (`CollateralTracker.sol`)

* **Added `donate(uint256 shares)`:**
* Burns the specified amount of shares from the caller.
* Emits a new `Donate` event.
* **Safety Check:** Enforces `shares <= maxRedeem(msg.sender)`. This ensures that a user cannot donate shares that are currently locked as collateral for open options positions or violate liquidity constraints.
* **Interest Accrual:** Calls `_accrueInterest` before execution to ensure solvency calculations are up-to-date.
* **Events:** Added `Donate` event and updated `CommissionPaid` docstrings for clarity.
* **Optimization:** Changed `accrueInterest()` visibility from `public` to `external`.

### Tests (`CollateralTracker.t.sol`)

Added comprehensive unit and fuzz tests covering:

* **Economics:** Verifying that `donate` correctly burns shares and increases the exchange rate (PPS) for other holders.
* **Access Control:** Verifying `donate` reverts if the user has open positions (via `maxRedeem` check).
* **Edge Cases:**
* Reverts on donating 0 shares (`BelowMinimumRedemption`).
* Reverts if attempting to burn the last share (violating `depositedAssets - 1` logic).
* Reverts if interest accrual pushes the user into a state where they lack sufficient free collateral.

## Technical Details & Safety

The `donate` function leverages the existing `maxRedeem` logic to ensure protocol safety. Since donating shares is functionally equivalent to a redemption where the assets are left behind, the same constraints must apply:

```solidity
// From CollateralTracker.sol
if (shares > maxRedeem(msg.sender)) revert Errors.ExceedsMaximumRedemption();

```

This prevents:

1. **Under-collateralization:** Users with open legs (`numberOfLegs > 0`) return `0` for `maxRedeem`, preventing them from burning collateral backing active trades.
2. **Insolvency:** Users cannot donate shares needed to cover accrued interest.

##Checklist* [x] New `donate` function implemented.
* [x] `Donate` event added.
* [x] `accrueInterest` visibility updated.
* [x] Tests added for success paths (PPS increase).
* [x] Tests added for failure paths (open positions, exceeds balance, liquidity crunch).