### PR TITLE
Feat: move vegoid to RiskEngine

### DIFF
--- a/contracts/PanopticFactory.sol
+++ b/contracts/PanopticFactory.sol
@@ -131,7 +131,7 @@ contract PanopticFactory is FactoryNFT, Multicall {
             revert Errors.PoolAlreadyInitialized();
 
         // initialize pool in SFPM if it has not already been initialized
-        uint64 poolId = SFPM.initializeAMMPool(token0, token1, fee);
+        uint64 poolId = SFPM.initializeAMMPool(token0, token1, fee, riskEngine.vegoid());
 
         // Users can specify a salt, the aim is to incentivize the mining of addresses with leading zeros
         // salt format: (first 20 characters of deployer address) + (first 10 characters of UniswapV3Pool) + (first 10 characters of RiskEngine) + (uint96 user supplied salt)

--- a/contracts/PanopticFactoryV4.sol
+++ b/contracts/PanopticFactoryV4.sol
@@ -132,7 +132,7 @@ contract PanopticFactory is FactoryNFT, Multicall {
             revert Errors.PoolAlreadyInitialized();
 
         // initialize pool in SFPM if it has not already been initialized
-        uint64 poolId = SFPM.initializeAMMPool(key);
+        uint64 poolId = SFPM.initializeAMMPool(key, riskEngine.vegoid());
 
         // Users can specify a salt, the aim is to incentivize the mining of addresses with leading zeros
         // salt format: (first 20 characters of deployer address) + (first 10 characters of UniswapV3Pool) + (first 10 characters of RiskEngine) + (uint96 user supplied salt)

--- a/contracts/PanopticPool.sol
+++ b/contracts/PanopticPool.sol
@@ -1019,17 +1019,22 @@ contract PanopticPool is Clone, Multicall {
                 uint256 grossCurrent0;
                 uint256 grossCurrent1;
                 {
-                    uint256 tokenType = tokenId.tokenType(leg);
-                    // can use (type(int24).max flag because premia accumulators were updated during the mintTokenizedPosition step.
-                    (grossCurrent0, grossCurrent1) = SFPM.getAccountPremium(
-                        poolKey(),
-                        address(this),
-                        tokenType,
-                        liquidityChunk.tickLower(),
-                        liquidityChunk.tickUpper(),
-                        type(int24).max,
-                        isLong
-                    );
+                    {
+                        uint256 tokenType = tokenId.tokenType(leg);
+                        uint256 vegoid = tokenId.vegoid();
+                        uint256 _isLong = isLong;
+                        // can use (type(int24).max flag because premia accumulators were updated during the mintTokenizedPosition step.
+                        (grossCurrent0, grossCurrent1) = SFPM.getAccountPremium(
+                            poolKey(),
+                            address(this),
+                            tokenType,
+                            liquidityChunk.tickLower(),
+                            liquidityChunk.tickUpper(),
+                            type(int24).max,
+                            _isLong,
+                            vegoid
+                        );
+                    }
 
                     s_options[owner][tokenId][leg] = LeftRightUnsigned
                         .wrap(uint128(grossCurrent0))
@@ -1959,18 +1964,22 @@ contract PanopticPool is Clone, Multicall {
                     leg,
                     positionSize
                 );
-                uint256 tokenType = tokenId.tokenType(leg);
-
-                (premiumAccumulatorsByLeg[leg][0], premiumAccumulatorsByLeg[leg][1]) = SFPM
-                    .getAccountPremium(
-                        poolKey(),
-                        address(this),
-                        tokenType,
-                        liquidityChunk.tickLower(),
-                        liquidityChunk.tickUpper(),
-                        atTick,
-                        isLong
-                    );
+                {
+                    uint256 vegoid = tokenId.vegoid();
+                    uint256 tokenType = tokenId.tokenType(leg);
+                    int24 _atTick = atTick;
+                    (premiumAccumulatorsByLeg[leg][0], premiumAccumulatorsByLeg[leg][1]) = SFPM
+                        .getAccountPremium(
+                            poolKey(),
+                            address(this),
+                            tokenType,
+                            liquidityChunk.tickLower(),
+                            liquidityChunk.tickUpper(),
+                            _atTick,
+                            isLong,
+                            vegoid
+                        );
+                }
                 unchecked {
                     LeftRightUnsigned premiumAccumulatorLast = s_options[owner][tokenId][leg];
                     premiaByLeg[leg] = LeftRightSigned

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -2097,6 +2097,10 @@ contract RiskEngine {
     }
 }
 
+/*//////////////////////////////////////////////////////////////
+                       BUILDER WALLETS
+//////////////////////////////////////////////////////////////*/
+
 interface IERC20 {
     function balanceOf(address) external view returns (uint256);
 

--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -96,6 +96,14 @@ contract RiskEngine {
     /// @notice The maximum amount of change, in ticks, permitted between internal median updates.
     int24 internal constant MAX_CLAMP_DELTA = 149;
 
+    /// @notice Parameter used to modify the [equation](https://www.desmos.com/calculator/mdeqob2m04) of the utilization-based multiplier for long premium.
+    // ν = 1/VEGOID = multiplicative factor for long premium (Eqns 1-5)
+    // Similar to vega in options because the liquidity utilization is somewhat reflective of the implied volatility (IV),
+    // and vegoid modifies the sensitivity of the streamia to changes in that utilization,
+    // much like vega measures the sensitivity of traditional option prices to IV.
+    // The effect of vegoid on the long premium multiplier can be explored here: https://www.desmos.com/calculator/mdeqob2m04
+    uint8 internal constant VEGOID = 4;
+
     /*//////////////////////////////////////////////////////////////
                             RISK PARAMETERS
     //////////////////////////////////////////////////////////////*/
@@ -2077,6 +2085,15 @@ contract RiskEngine {
                 MIN_RATE_AT_TARGET,
                 MAX_RATE_AT_TARGET
             );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             QUERY HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Returns the stored VEGOID parameter
+    function vegoid() external view returns (uint256) {
+        return VEGOID;
     }
 }
 

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -160,7 +160,6 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Retrieve the corresponding poolId for a given Uniswap V3 pool address.
-    /// @dev pool address => pool id + 2 ** 255 (initialization bit for `poolId == 0`, set if the pool exists)
     mapping(address univ3pool => PoolData poolData) internal s_addressToPoolData;
 
     /// @notice Retrieve the PoolData struct corresponding to a given poolId.
@@ -338,7 +337,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     function initializeAMMPool(
         address token0,
         address token1,
-        uint24 fee
+        uint24 fee,
+        uint256 vegoid
     ) external returns (uint64 poolId) {
         // sort the tokens, if necessary:
         (token0, token1) = token0 < token1 ? (token0, token1) : (token1, token0);
@@ -360,7 +360,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         // The base poolId is composed as follows:
         // [tickSpacing][pool pattern]
         // [16 bit tickSpacing][most significant 48 bits of the pool address]
-        poolId = _getPoolId(univ3pool, tickSpacing);
+        poolId = _getPoolId(univ3pool, tickSpacing, vegoid);
 
         // There are 281,474,976,710,655 possible pool patterns.
         // A modern GPU can generate a collision in such a space relatively quickly,
@@ -425,9 +425,14 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     /// @param univ3pool The address of the Uniswap V3 pool to get the ID of
     /// @param tickSpacing The tick spacing of `univ3pool`
     /// @return A uint64 representing a fingerprint of the Uniswap V3 pool address
-    function _getPoolId(address univ3pool, int24 tickSpacing) internal pure returns (uint64) {
+    function _getPoolId(
+        address univ3pool,
+        int24 tickSpacing,
+        uint256 vegoid
+    ) internal pure returns (uint64) {
         unchecked {
-            uint64 poolId = uint64(uint160(univ3pool) >> 112);
+            uint64 poolId = uint40(uint160(univ3pool) >> 112);
+            poolId += (uint64(uint8(vegoid)) << 40);
             poolId += uint64(uint24(tickSpacing)) << 48;
             return poolId;
         }

--- a/contracts/SemiFungiblePositionManager.sol
+++ b/contracts/SemiFungiblePositionManager.sol
@@ -1024,13 +1024,15 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
 
         // if there was liquidity at that tick before the transaction, collect any accumulated fees
         if (currentLiquidity.rightSlot() > 0) {
+            uint256 vegoid = tokenId.vegoid();
             collectedSingleLeg = _collectAndWritePositionData(
                 liquidityChunk,
                 univ3pool,
                 currentLiquidity,
                 positionKey,
                 moved,
-                isLong
+                isLong,
+                vegoid
             );
         }
 
@@ -1051,12 +1053,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     function _updateStoredPremia(
         bytes32 positionKey,
         LeftRightUnsigned currentLiquidity,
-        LeftRightUnsigned collectedAmounts
+        LeftRightUnsigned collectedAmounts,
+        uint256 vegoid
     ) private {
         (
             LeftRightUnsigned deltaPremiumOwed,
             LeftRightUnsigned deltaPremiumGross
-        ) = _getPremiaDeltas(currentLiquidity, collectedAmounts);
+        ) = _getPremiaDeltas(currentLiquidity, collectedAmounts, vegoid);
 
         // add deltas to accumulators and freeze both accumulators (for a token) if one of them overflows
         // (i.e if only token0 (right slot) of the owed premium overflows, then stop accumulating  both token0 owed premium and token0 gross premium for the chunk)
@@ -1196,20 +1199,19 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         LeftRightUnsigned currentLiquidity,
         bytes32 positionKey,
         LeftRightSigned movedInLeg,
-        uint256 isLong
+        uint256 isLong,
+        uint256 vegoid
     ) internal returns (LeftRightUnsigned collectedChunk) {
-        uint128 startingLiquidity = currentLiquidity.rightSlot();
-        // round down current fees base to minimize Δfeesbase
-        // If the current feesBase is close or identical to the stored one, the amountToCollect can be negative.
-        // This is because the stored feesBase is rounded up, and the current feesBase is rounded down.
-        // When this is the case, we want to behave as if there are 0 fees, so we just rectify the values.
-        LeftRightUnsigned amountToCollect = _getFeesBase(
-            univ3pool,
-            startingLiquidity,
-            liquidityChunk,
-            false
-        ).subRect(s_accountFeesBase[positionKey]);
-
+        LeftRightUnsigned amountToCollect;
+        {
+            uint128 startingLiquidity = currentLiquidity.rightSlot();
+            // round down current fees base to minimize Δfeesbase
+            // If the current feesBase is close or identical to the stored one, the amountToCollect can be negative.
+            // This is because the stored feesBase is rounded up, and the current feesBase is rounded down.
+            // When this is the case, we want to behave as if there are 0 fees, so we just rectify the values.
+            amountToCollect = _getFeesBase(univ3pool, startingLiquidity, liquidityChunk, false)
+                .subRect(s_accountFeesBase[positionKey]);
+        }
         if (isLong == 1) {
             // movedInLeg deltas are always represented as negative during liquidity burns (for long positions), so the result here will always be positive
             amountToCollect = LeftRightUnsigned.wrap(
@@ -1250,7 +1252,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
             collectedChunk = LeftRightUnsigned.wrap(collected0).addToLeftSlot(collected1);
 
             // record the collected amounts in the s_accountPremiumOwed and s_accountPremiumGross accumulators
-            _updateStoredPremia(positionKey, currentLiquidity, collectedChunk);
+            _updateStoredPremia(positionKey, currentLiquidity, collectedChunk, vegoid);
         }
     }
 
@@ -1262,7 +1264,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     /// @return deltaPremiumGross The extra premium (per liquidity X64) to be added to the gross accumulator for token0 (right) and token1 (left)
     function _getPremiaDeltas(
         LeftRightUnsigned currentLiquidity,
-        LeftRightUnsigned collectedAmounts
+        LeftRightUnsigned collectedAmounts,
+        uint256 vegoid
     )
         private
         pure
@@ -1306,7 +1309,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                 uint128 premium1X64_owed;
                 {
                     // compute the owed premium (from Eqn 3)
-                    uint256 numerator = netLiquidity + (removedLiquidity / 2 ** VEGOID);
+                    uint256 numerator = netLiquidity + (removedLiquidity / vegoid);
 
                     premium0X64_owed = Math
                         .mulDiv(premium0X64_base, numerator, totalLiquidity)
@@ -1329,7 +1332,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                     uint256 numerator = totalLiquidity ** 2 -
                         totalLiquidity *
                         removedLiquidity +
-                        ((removedLiquidity ** 2) / 2 ** (VEGOID));
+                        ((removedLiquidity ** 2) / vegoid);
 
                     premium0X64_gross = Math
                         .mulDiv(premium0X64_base, numerator, totalLiquidity ** 2)
@@ -1395,7 +1398,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         int24 tickLower,
         int24 tickUpper,
         int24 atTick,
-        uint256 isLong
+        uint256 isLong,
+        uint256 vegoid
     ) external view returns (uint128, uint128) {
         IUniswapV3Pool univ3pool = IUniswapV3Pool(abi.decode(poolKey, (address)));
 
@@ -1439,7 +1443,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
 
             (LeftRightUnsigned premiumOwed, LeftRightUnsigned premiumGross) = _getPremiaDeltas(
                 accountLiquidities,
-                amountToCollect
+                amountToCollect,
+                vegoid
             );
 
             // add deltas to accumulators and freeze both accumulators (for a token) if one of them overflows

--- a/contracts/SemiFungiblePositionManagerV4.sol
+++ b/contracts/SemiFungiblePositionManagerV4.sol
@@ -327,7 +327,10 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     /// @notice Initialize a Uniswap V4 pool in the SFPM.
     /// @dev Revert if already initialized.
     /// @param key An identifying key for a Uniswap V4 pool
-    function initializeAMMPool(PoolKey calldata key) external returns (uint64 poolId) {
+    function initializeAMMPool(
+        PoolKey calldata key,
+        uint256 vegoid
+    ) external returns (uint64 poolId) {
         PoolId idV4 = key.toId();
 
         if (V4StateReader.getSqrtPriceX96(POOL_MANAGER_V4, idV4) == 0)
@@ -341,7 +344,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         // The base poolId is composed as follows:
         // [tickSpacing][pool pattern]
         // [16 bit tickSpacing][most significant 48 bits of the V4 poolId]
-        poolId = _getPoolId(idV4, key.tickSpacing);
+        poolId = _getPoolId(idV4, key.tickSpacing, vegoid);
 
         // There are 281,474,976,710,655 possible pool patterns.
         // A modern GPU can generate a collision in such a space relatively quickly,
@@ -400,17 +403,27 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     //      e.g.:
     //        idV4        = 0x9c33e1937fe23c3ff82d7725f2bb5af696db1c89a9b8cae141cb0e986847638a
     //        tickSpacing = 60
+    //        vegoid      = 9
     //      the returned id is then:
     //        poolPattern = 0x0000e986847638a
     //        tickSpacing = 0x003c000000000000    +
     //        --------------------------------------------
     //        poolId      = 0x003ce986847638a
+    //                      0x03c09986847638a
     /// @param idV4 The 256-bit Uniswap V4 pool ID
     /// @param tickSpacing The tick spacing of the Uniswap V4 pool identified by `idV4`
+    /// @param vegoid The vegoid of the SFPM, must be 8 bits
     /// @return A fingerprint representing the Uniswap V4 pool
-    function _getPoolId(PoolId idV4, int24 tickSpacing) internal pure returns (uint64) {
+    function _getPoolId(
+        PoolId idV4,
+        int24 tickSpacing,
+        uint256 vegoid
+    ) internal pure returns (uint64) {
         unchecked {
-            return uint48(uint256(PoolId.unwrap(idV4))) + (uint64(uint24(tickSpacing)) << 48);
+            return
+                uint40(uint256(PoolId.unwrap(idV4))) +
+                (uint64(uint8(vegoid)) << 40) +
+                (uint64(uint24(tickSpacing)) << 48);
         }
     }
 

--- a/contracts/SemiFungiblePositionManagerV4.sol
+++ b/contracts/SemiFungiblePositionManagerV4.sol
@@ -833,14 +833,14 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                     LeftRightSigned movedLeg;
                     TokenId _tokenId = tokenId;
                     bool _isBurn = isBurn;
-
                     (movedLeg, collectedByLeg[leg]) = _createLegInAMM(
                         _account,
                         _key,
                         _tokenId,
                         leg,
                         liquidityChunk,
-                        _isBurn
+                        _isBurn,
+                        _tokenId.vegoid()
                     );
 
                     totalMoved = totalMoved.add(movedLeg);
@@ -927,7 +927,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         TokenId tokenId,
         uint256 leg,
         LiquidityChunk liquidityChunk,
-        bool isBurn
+        bool isBurn,
+        uint256 vegoid
     ) internal returns (LeftRightSigned moved, LeftRightUnsigned collectedSingleLeg) {
         // unique key to identify the liquidity chunk in this Uniswap pool
         bytes32 positionKey = EfficientHash.efficientKeccak256(
@@ -1052,7 +1053,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                 .addToRightSlot(uint128(feesAccrued.amount0()))
                 .addToLeftSlot(uint128(feesAccrued.amount1()));
 
-            _updateStoredPremia(positionKey, currentLiquidity, collectedSingleLeg);
+            _updateStoredPremia(positionKey, currentLiquidity, collectedSingleLeg, vegoid);
         }
     }
 
@@ -1063,12 +1064,13 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     function _updateStoredPremia(
         bytes32 positionKey,
         LeftRightUnsigned currentLiquidity,
-        LeftRightUnsigned collectedAmounts
+        LeftRightUnsigned collectedAmounts,
+        uint256 vegoid
     ) private {
         (
             LeftRightUnsigned deltaPremiumOwed,
             LeftRightUnsigned deltaPremiumGross
-        ) = _getPremiaDeltas(currentLiquidity, collectedAmounts);
+        ) = _getPremiaDeltas(currentLiquidity, collectedAmounts, vegoid);
 
         // add deltas to accumulators and freeze both accumulators (for a token) if one of them overflows
         // (i.e if only currency0 (right slot) of the owed premium overflows, then stop accumulating  both currency0 owed premium and currency0 gross premium for the chunk)
@@ -1090,7 +1092,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
     /// @return deltaPremiumGross The extra premium (per liquidity X64) to be added to the gross accumulator for currency0 (right) and currency1 (left)
     function _getPremiaDeltas(
         LeftRightUnsigned currentLiquidity,
-        LeftRightUnsigned collectedAmounts
+        LeftRightUnsigned collectedAmounts,
+        uint256 vegoid
     )
         private
         pure
@@ -1134,7 +1137,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                 uint128 premium1X64_owed;
                 {
                     // compute the owed premium (from Eqn 3)
-                    uint256 numerator = netLiquidity + (removedLiquidity / 2 ** VEGOID);
+                    uint256 numerator = netLiquidity + (removedLiquidity / vegoid);
 
                     premium0X64_owed = Math
                         .mulDiv(premium0X64_base, numerator, totalLiquidity)
@@ -1157,7 +1160,7 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
                     uint256 numerator = totalLiquidity ** 2 -
                         totalLiquidity *
                         removedLiquidity +
-                        ((removedLiquidity ** 2) / 2 ** (VEGOID));
+                        ((removedLiquidity ** 2) / vegoid);
 
                     premium0X64_gross = Math
                         .mulDiv(premium0X64_base, numerator, totalLiquidity ** 2)
@@ -1223,7 +1226,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
         int24 tickLower,
         int24 tickUpper,
         int24 atTick,
-        uint256 isLong
+        uint256 isLong,
+        uint256 vegoid
     ) external view returns (uint128, uint128) {
         PoolKey memory key = abi.decode(poolKey, (PoolKey));
         bytes32 positionKey = EfficientHash.efficientKeccak256(
@@ -1281,7 +1285,8 @@ contract SemiFungiblePositionManager is ERC1155, Multicall, TransientReentrancyG
 
             (LeftRightUnsigned premiumOwed, LeftRightUnsigned premiumGross) = _getPremiaDeltas(
                 accountLiquidities,
-                amountToCollect
+                amountToCollect,
+                vegoid
             );
 
             // add deltas to accumulators and freeze both accumulators (for a token) if one of them overflows

--- a/contracts/interfaces/IRiskEngine.sol
+++ b/contracts/interfaces/IRiskEngine.sol
@@ -286,4 +286,11 @@ interface IRiskEngine {
         uint256 utilization,
         MarketState interestRateAccumulator
     ) external view returns (uint128, uint256);
+
+    /*//////////////////////////////////////////////////////////////
+                             QUERY HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Returns the stored VEGOID parameter
+    function vegoid() external view returns (uint256);
 }

--- a/contracts/interfaces/ISemiFungiblePositionManager.sol
+++ b/contracts/interfaces/ISemiFungiblePositionManager.sol
@@ -90,7 +90,8 @@ interface ISemiFungiblePositionManager {
         int24 tickLower,
         int24 tickUpper,
         int24 atTick,
-        uint256 isLong
+        uint256 isLong,
+        uint256 vegoid
     ) external view returns (uint128 premium0, uint128 premium1);
 
     function getPoolId(bytes memory id) external view returns (uint64 poolId);

--- a/contracts/libraries/PanopticMath.sol
+++ b/contracts/libraries/PanopticMath.sol
@@ -27,8 +27,8 @@ library PanopticMath {
     /// @notice This is equivalent to `type(uint256).max` — used in assembly blocks as a replacement.
     uint256 internal constant MAX_UINT256 = 2 ** 256 - 1;
 
-    /// @notice Masks 16-bit tickSpacing out of 64-bit `[16-bit tickspacing][48-bit poolPattern]` format poolId.
-    uint64 internal constant TICKSPACING_MASK = 0xFFFF000000000000;
+    /// @notice Masks 16-bit tickSpacing and 8 bits of vegoid out of 64-bit `[16-bit tickspacing][8-bit vegoid][40-bit poolPattern]` format poolId.
+    uint64 internal constant TICKSPACING_VEGOID_MASK = 0xFFFFFF0000000000;
 
     uint256 internal constant PRIME_MODULUS_248 =
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff13;
@@ -54,7 +54,7 @@ library PanopticMath {
     /// @return The provided `poolId` with its pool pattern slot incremented by 1
     function incrementPoolPattern(uint64 poolId) internal pure returns (uint64) {
         unchecked {
-            return (poolId & TICKSPACING_MASK) + (uint48(poolId) + 1);
+            return (poolId & TICKSPACING_VEGOID_MASK) + (uint40(poolId + 1));
         }
     }
 

--- a/contracts/types/TokenId.sol
+++ b/contracts/types/TokenId.sol
@@ -21,16 +21,17 @@ using TokenIdLibrary for TokenId global;
 // From the LSB to the MSB:
 // ===== 1 time (same for all legs) ==============================================================
 //      Property         Size      Offset      Comment
-// (0) univ3pool        48bits     0bits      : first 6 bytes of the Uniswap V3 pool address (first 48 bits; little-endian), plus a pseudorandom number in the event of a collision
-// (1) tickSpacing      16bits     48bits     : tickSpacing for the univ3pool. Up to 16 bits
+// (0) univ3pool        40bits     0bits      : first 6 bytes of the Uniswap V3 pool address (first 48 bits; little-endian), plus a pseudorandom number in the event of a collision
+// (1) vegoid           8bits     40bits      : vegoid for the sfpm pool
+// (2) tickSpacing      16bits     48bits     : tickSpacing for the univ3pool. Up to 16 bits
 // ===== 4 times (one for each leg) ==============================================================
-// (2) asset             1bit      0bits      : Specifies the asset (0: token0, 1: token1)
-// (3) optionRatio       7bits     1bits      : number of contracts per leg
-// (4) isLong            1bit      8bits      : long==1 means liquidity is removed, long==0 -> liquidity is added
-// (5) tokenType         1bit      9bits      : put/call: which token is moved when deployed (0 -> token0, 1 -> token1)
-// (6) riskPartner       2bits     10bits     : normally its own index. Partner in defined risk position otherwise
-// (7) strike           24bits     12bits     : strike price; defined as (tickUpper + tickLower) / 2
-// (8) width            12bits     36bits     : width; defined as (tickUpper - tickLower) / tickSpacing
+// (3) asset             1bit      0bits      : Specifies the asset (0: token0, 1: token1)
+// (4) optionRatio       7bits     1bits      : number of contracts per leg
+// (5) isLong            1bit      8bits      : long==1 means liquidity is removed, long==0 -> liquidity is added
+// (6) tokenType         1bit      9bits      : put/call: which token is moved when deployed (0 -> token0, 1 -> token1)
+// (7) riskPartner       2bits     10bits     : normally its own index. Partner in defined risk position otherwise
+// (8) strike           24bits     12bits     : strike price; defined as (tickUpper + tickLower) / 2
+// (9) width            12bits     36bits     : width; defined as (tickUpper - tickLower) / tickSpacing
 // Total                48bits                : Each leg takes up this many bits
 // ===============================================================================================
 //
@@ -39,9 +40,9 @@ using TokenIdLibrary for TokenId global;
 //                        (strike price tick of the 3rd leg)
 //                            |             (width of the 2nd leg)
 //                            |                   |
-// (8)(7)(6)(5)(4)(3)(2)  (8)(7)(6)(5)(4)(3)(2)  (8)(7)(6)(5)(4)(3)(2)   (8)(7)(6)(5)(4)(3)(2)        (1)           (0)
-//  <---- 48 bits ---->    <---- 48 bits ---->    <---- 48 bits ---->     <---- 48 bits ---->   <- 16 bits ->   <- 48 bits ->
-//         Leg 4                  Leg 3                  Leg 2                   Leg 1           tickSpacing Uniswap Pool Pattern
+// (9)(8)(7)(6)(5)(4)(3)  (9)(8)(7)(6)(5)(4)(3)  (9)(8)(7)(6)(5)(4)(3)   (9)(8)(7)(6)(5)(4)(3)       (2)          (1)           (0)
+//  <---- 48 bits ---->    <---- 48 bits ---->    <---- 48 bits ---->     <---- 48 bits ---->   <- 16 bits -> <- 8 bits ->  <- 40 bits ->
+//         Leg 4                  Leg 3                  Leg 2                   Leg 1           tickSpacing   vegoid    Uniswap Pool Pattern
 //
 //  <--- most significant bit                                                                             least significant bit --->
 //
@@ -87,6 +88,15 @@ library TokenIdLibrary {
     function poolId(TokenId self) internal pure returns (uint64) {
         unchecked {
             return uint64(TokenId.unwrap(self));
+        }
+    }
+
+    /// @notice The vegoid of this option position.
+    /// @param self The TokenId to extract `vegoid` from
+    /// @return The `vegoid` of the Uniswap V3 pool
+    function vegoid(TokenId self) internal pure returns (uint8) {
+        unchecked {
+            return uint8((TokenId.unwrap(self) >> 40) % 2 ** 8);
         }
     }
 

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -209,8 +209,12 @@ contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
         return s_accountLiquidity[positionKey];
     }
 
-    function __getPoolId(PoolId idV4, int24 tickSpacing) external view returns (uint64 poolId) {
-        poolId = _getPoolId(idV4, tickSpacing);
+    function __getPoolId(
+        PoolId idV4,
+        int24 tickSpacing,
+        uint256 vegoid
+    ) external view returns (uint64 poolId) {
+        poolId = _getPoolId(idV4, tickSpacing, vegoid);
     }
 }
 
@@ -459,6 +463,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
     // store some data about the pool we are testing
     IUniswapV3Pool pool;
     uint64 poolId;
+    uint256 vegoid = 4;
     uint256 isWETH;
     address token0;
     address token1;
@@ -776,7 +781,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
             IHooks(address(0))
         );
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(_pool.tickSpacing())) << 48;
         }
     }
@@ -816,7 +821,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         address t0 = address(uint160(poolKey.currency0.toId()));
         address t1 = address(uint160(poolKey.currency1.toId()));
         // Initialize the world pool
-        uint64 poolId = sfpm.initializeAMMPool(poolKey);
+        uint64 poolId = sfpm.initializeAMMPool(poolKey, vegoid);
 
         // 2) Risk engine
         riskEngine = new RiskEngineHarness(10_000_000, 10_000_000, address(0), address(0));
@@ -946,7 +951,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         address t0 = address(uint160(poolKey.currency0.toId()));
         address t1 = address(uint160(poolKey.currency1.toId()));
         // Initialize the world pool
-        uint64 poolId = sfpm.initializeAMMPool(poolKey);
+        uint64 poolId = sfpm.initializeAMMPool(poolKey, vegoid);
 
         // 2) Risk engine
         riskEngine = new RiskEngineHarness(crossBuffer0, crossBuffer1, address(0), address(0));
@@ -1072,7 +1077,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         address t0 = address(uint160(poolKey.currency0.toId()));
         address t1 = address(uint160(poolKey.currency1.toId()));
         // Initialize the world pool
-        uint64 poolId = sfpm.initializeAMMPool(poolKey);
+        uint64 poolId = sfpm.initializeAMMPool(poolKey, vegoid);
 
         // 2) Risk engine
         builderFactory = new BuilderFactory(guardian);

--- a/test/foundry/core/Misc.t.sol
+++ b/test/foundry/core/Misc.t.sol
@@ -180,6 +180,7 @@ contract Misctest is Test, PositionUtils {
     OraclePack oraclePack;
     uint64 $poolId;
     uint64 poolId;
+    uint256 vegoid = 4;
     uint256 medianData;
 
     uint256 assetsBefore0;
@@ -561,7 +562,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -622,7 +623,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == positionCount - 1) {
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -710,7 +711,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -740,7 +741,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == positionCount - 1) {
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
                 posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -796,7 +797,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -856,7 +857,7 @@ contract Misctest is Test, PositionUtils {
             );
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -902,7 +903,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == 0) {
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
                 posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -989,7 +990,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -1018,7 +1019,7 @@ contract Misctest is Test, PositionUtils {
             );
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -1034,7 +1035,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == 0) {
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
                 posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -1114,7 +1115,7 @@ contract Misctest is Test, PositionUtils {
 
         manager.initialize(poolKey, 2 ** 96);
 
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -1350,7 +1351,7 @@ contract Misctest is Test, PositionUtils {
 
         manager.initialize(poolKey, 2 ** 96);
 
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         token0Supply = bound(token0Supply, 0, type(uint256).max / 10_000);
         token1Supply = bound(token1Supply, 0, type(uint256).max / 10_000);
@@ -1580,7 +1581,7 @@ contract Misctest is Test, PositionUtils {
 
         manager.initialize(poolKey, 2 ** 96);
 
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         (, int24 tickLimitUpper) = sfpm.getEnforcedTickLimits(
             sfpm.getPoolId(abi.encode(poolKey.toId()))
@@ -1745,7 +1746,7 @@ contract Misctest is Test, PositionUtils {
         routerV4.modifyLiquidity(address(0), poolKey, -10000, 10000, 10 ** 24);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1794,7 +1795,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1838,7 +1839,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1858,7 +1859,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1880,7 +1881,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1897,7 +1898,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1946,7 +1947,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2006,7 +2007,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2082,7 +2083,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2154,7 +2155,7 @@ contract Misctest is Test, PositionUtils {
         $tempIdList = $posIdList;
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2425,7 +2426,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2508,7 +2509,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2552,7 +2553,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2573,7 +2574,7 @@ contract Misctest is Test, PositionUtils {
         TokenId[] memory longPositionList = new TokenId[](256);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2647,7 +2648,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2776,7 +2777,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2798,7 +2799,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2887,7 +2888,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2909,7 +2910,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2971,7 +2972,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3022,7 +3023,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3244,7 +3245,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3401,7 +3402,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3452,7 +3453,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3696,7 +3697,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3748,7 +3749,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3765,7 +3766,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3786,7 +3787,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3818,7 +3819,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3850,7 +3851,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3940,7 +3941,8 @@ contract Misctest is Test, PositionUtils {
                 10,
                 20,
                 currentTick,
-                0
+                0,
+                vegoid
             );
 
             console2.log(
@@ -3963,7 +3965,8 @@ contract Misctest is Test, PositionUtils {
                 10,
                 20,
                 currentTick,
-                1
+                1,
+                vegoid
             );
 
             console2.log(
@@ -3998,7 +4001,8 @@ contract Misctest is Test, PositionUtils {
                 -20,
                 -10,
                 0,
-                0
+                0,
+                vegoid
             );
 
             console2.log(
@@ -4021,7 +4025,8 @@ contract Misctest is Test, PositionUtils {
                 -20,
                 -10,
                 0,
-                1
+                1,
+                vegoid
             );
 
             console2.log(
@@ -4095,12 +4100,12 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4557,7 +4562,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4611,7 +4616,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4788,7 +4793,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4822,7 +4827,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4856,7 +4861,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4893,7 +4898,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4941,7 +4946,7 @@ contract Misctest is Test, PositionUtils {
         routerV4.modifyLiquidity(address(0), poolKey, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5013,7 +5018,7 @@ contract Misctest is Test, PositionUtils {
         routerV4.modifyLiquidity(address(0), poolKey, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5084,7 +5089,7 @@ contract Misctest is Test, PositionUtils {
         routerV4.modifyLiquidity(address(0), poolKey, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5265,7 +5270,7 @@ contract Misctest is Test, PositionUtils {
         routerV4.modifyLiquidity(address(0), poolKey, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5449,7 +5454,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5625,7 +5630,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(pp.isSafeMode() == 0, "not in safe mode");
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5740,7 +5745,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(pp.isSafeMode() > 0, "in safe mode");
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5833,7 +5838,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(pp.isSafeMode() == 0, "not in safe mode");
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5940,7 +5945,7 @@ contract Misctest is Test, PositionUtils {
         (, , slowOracleTick, , oraclePack) = pp.getOracleTicks();
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6065,7 +6070,7 @@ contract Misctest is Test, PositionUtils {
         (, , slowOracleTick, , oraclePack) = pp.getOracleTicks();
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6186,7 +6191,7 @@ contract Misctest is Test, PositionUtils {
         (, , slowOracleTick, , oraclePack) = pp.getOracleTicks();
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6287,7 +6292,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6423,7 +6428,7 @@ contract Misctest is Test, PositionUtils {
         console2.log("uniPool.tickSpacing", uniPool.tickSpacing());
         int24 tickSpacing = 10;
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(tickSpacing)) << 48;
         }
 
@@ -6611,7 +6616,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6834,7 +6839,7 @@ contract Misctest is Test, PositionUtils {
         uniPool.liquidity();
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6903,7 +6908,8 @@ contract Misctest is Test, PositionUtils {
             -20470,
             20470,
             0,
-            0
+            0,
+            vegoid
         );
         assertEq(premium0, 340282366920938463444927863358058659840);
         assertEq(premium1, 44704247211996718928643);
@@ -6957,7 +6963,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6998,7 +7004,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7079,7 +7085,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7120,7 +7126,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7193,7 +7199,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7310,7 +7316,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7369,7 +7375,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -7535,7 +7541,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7619,7 +7625,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7736,7 +7742,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
@@ -7894,7 +7900,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -8047,7 +8053,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8152,7 +8158,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8262,7 +8268,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = ((i % 4) / 2);
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8376,7 +8382,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = ((i % 4) / 2);
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8490,7 +8496,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = ((i % 4) / 2);
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8615,7 +8621,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8706,7 +8712,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8806,7 +8812,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = (i / 2);
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8909,7 +8915,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = (i / 2);
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -9010,7 +9016,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = (i / 2);
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -9116,7 +9122,7 @@ contract Misctest is Test, PositionUtils {
                 vm.startPrank(Charlie);
 
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -9145,7 +9151,7 @@ contract Misctest is Test, PositionUtils {
                 );
 
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -9256,7 +9262,7 @@ contract Misctest is Test, PositionUtils {
                 vm.startPrank(Charlie);
 
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -9392,7 +9398,7 @@ contract Misctest is Test, PositionUtils {
                 vm.startPrank(Charlie);
 
                 {
-                    poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                    poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 

--- a/test/foundry/core/PanopticPool.t.sol
+++ b/test/foundry/core/PanopticPool.t.sol
@@ -206,6 +206,7 @@ contract PanopticPoolTest is PositionUtils {
     address Charlie = address(0x1234567891);
     address Seller = address(0x12345678912);
 
+    uint256 vegoid = 4;
     IPoolManager manager;
 
     V4RouterSimple routerV4;
@@ -515,7 +516,7 @@ contract PanopticPoolTest is PositionUtils {
         pool = _pool;
 
         {
-            poolId = uint64(uint160(address(_pool)) >> 112);
+            poolId = uint40((uint160(address(_pool)) >> 112)) + uint64(vegoid << 40);
             poolId += uint64(uint24(_pool.tickSpacing())) << 48;
         }
 
@@ -538,7 +539,7 @@ contract PanopticPoolTest is PositionUtils {
             IHooks(address(0))
         );
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(_pool.tickSpacing())) << 48;
         }
     }
@@ -1938,7 +1939,8 @@ contract PanopticPoolTest is PositionUtils {
                 tickLowers[0],
                 tickUppers[0],
                 currentTick,
-                0
+                0,
+                vegoid
             );
 
             expectedPremia[0] += (premiumToken0 * expectedLiqs[0]) / 2 ** 64;
@@ -1954,7 +1956,8 @@ contract PanopticPoolTest is PositionUtils {
                 tickLowers[1],
                 tickUppers[1],
                 currentTick,
-                0
+                0,
+                vegoid
             );
 
             expectedPremia[0] += (premiumToken0 * expectedLiqs[1]) / 2 ** 64;

--- a/test/foundry/core/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/core/SemiFungiblePositionManager.t.sol
@@ -101,6 +101,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     // immutable data about the pool being tested
     IUniswapV3Pool pool;
     uint64 poolId;
+    uint256 vegoid = 4;
     address token0;
     address token1;
     uint24 fee;
@@ -199,7 +200,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     /// @notice Intialize testing pool in the SFPM instance after world state is setup
     function _initPool(uint256 seed) internal {
         _initWorld(seed);
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
     }
 
     /// @notice Set up world state with data from a random pool off the list and fund+approve actors
@@ -280,7 +281,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             IHooks(address(0))
         );
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(tickSpacing)) << 48;
         }
     }
@@ -994,7 +995,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         uint64 poolId;
 
         {
-            poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+            poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
             poolId += uint64(uint24(pool.tickSpacing())) << 48;
         }
 
@@ -1017,11 +1018,11 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             _cacheWorldState(pools[i]);
 
             manager.initialize(poolKey, currentSqrtPriceX96);
-            sfpm.initializeAMMPool(poolKey);
+            sfpm.initializeAMMPool(poolKey, vegoid);
             uint64 poolId;
 
             {
-                poolId = uint48(uint256(PoolId.unwrap(poolKey.toId())));
+                poolId = uint40(uint256(PoolId.unwrap(poolKey.toId()))) + uint64(vegoid << 40);
                 poolId += uint64(uint24(pool.tickSpacing())) << 48;
             }
 
@@ -1094,7 +1095,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         vm.expectRevert(Errors.PoolNotInitialized.selector);
 
         // These values are zero at this point; thus there is no corresponding uni pool and we should revert
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
     }
 
     /// NOTE - the definitions of "call" and "put" can vary by Uniswap pair and which token is considered the asset
@@ -2200,7 +2201,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         _cacheWorldState(USDC_USDT_5);
 
         _initAccounts();
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
         // since we didn't go through the standard setup flow we need to repeat some of the initialization tasks here
         vm.startPrank(Alice);
 
@@ -2211,7 +2212,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
 
         // Initialize the world pool
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
             widthSeed,
@@ -2284,7 +2285,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
 
         // Initialize the world pool
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
             widthSeed,
@@ -2505,7 +2506,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         vm.startPrank(Charlie);
         deal(token1, Charlie, 10 ** 6);
         IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         // --- GIVEN: A short put option (pays token0) ---
         int24 strike = currentTick + 10 * tickSpacing; // In-the-money
@@ -3732,7 +3733,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            0
+            0,
+            vegoid
         );
         assertEq(premium0Short, 0);
         assertEq(premium1Short, 0);
@@ -3744,7 +3746,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            1
+            1,
+            vegoid
         );
         assertEq(premium0Long, 0);
         assertEq(premium1Long, 0);
@@ -3769,7 +3772,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            0
+            0,
+            vegoid
         );
 
         assertApproxEqAbs(
@@ -3790,7 +3794,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(
             premium0Long,
@@ -3860,7 +3865,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            0
+            0,
+            vegoid
         );
 
         assertApproxEqAbs(
@@ -3881,7 +3887,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(
             premium0Long,
@@ -3913,7 +3920,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            0
+            0,
+            vegoid
         );
 
         {
@@ -3993,7 +4001,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            1
+            1,
+            vegoid
         );
 
         {
@@ -4056,7 +4065,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(premium0Long, premium0LongOld, premiaError0[1]);
         assertApproxEqAbs(premium1Long, premium1LongOld, premiaError1[1]);
@@ -4068,7 +4078,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(premium0Long, premium0LongOld, premiaError0[1]);
         assertApproxEqAbs(premium1Long, premium1LongOld, premiaError1[1]);
@@ -4094,7 +4105,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            0
+            0,
+            vegoid
         );
 
         assertApproxEqAbs(premium0Short, premium0ShortOld, premiaError0[0]);
@@ -4107,7 +4119,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            0
+            0,
+            vegoid
         );
         assertApproxEqAbs(premium0Short, premium0ShortOld, premiaError0[0]);
         assertApproxEqAbs(premium1Short, premium1ShortOld, premiaError1[0]);
@@ -4557,12 +4570,13 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         // need a super wide position to exxagerate position size units
         _cacheWorldState(USDC_WETH_30);
         _initAccounts();
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         int24 width = 4090;
         int24 strike = 0;
         populatePositionData(width, strike, 0, 0);
 
+        console2.log("test poolId", poolId);
         /// position size is denominated in the opposite of asset, so we do it in the token that is not WETH
         TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
             0,
@@ -4620,7 +4634,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         _cacheWorldState(USDC_WETH_30);
         manager.initialize(poolKey, 100 * 2 ** 96);
 
-        sfpm.initializeAMMPool(poolKey);
+        sfpm.initializeAMMPool(poolKey, vegoid);
 
         int24 width = 4090;
         int24 strike = 0;

--- a/test/foundry/coreV3/CollateralTracker.t.sol
+++ b/test/foundry/coreV3/CollateralTracker.t.sol
@@ -191,8 +191,12 @@ contract SemiFungiblePositionManagerHarness is SemiFungiblePositionManager {
         return s_accountLiquidity[positionKey];
     }
 
-    function __getPoolId(address pool, int24 tickSpacing) external view returns (uint64 poolId) {
-        poolId = _getPoolId(pool, tickSpacing);
+    function __getPoolId(
+        address pool,
+        int24 tickSpacing,
+        uint256 vegoid
+    ) external view returns (uint64 poolId) {
+        poolId = _getPoolId(pool, tickSpacing, vegoid);
     }
 }
 
@@ -440,6 +444,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
     // store some data about the pool we are testing
     IUniswapV3Pool pool;
     uint64 poolId;
+    uint256 vegoid = 4;
     uint256 isWETH;
     address token0;
     address token1;
@@ -765,7 +770,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
     function _cacheWorldState(IUniswapV3Pool _pool) internal {
         pool = _pool;
         {
-            poolId = uint64(uint160(address(_pool)) >> 112);
+            poolId = uint40(uint160(address(_pool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(_pool.tickSpacing())) << 48;
         }
         token0 = _pool.token0();
@@ -787,7 +792,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         sfpm = new SemiFungiblePositionManagerHarness(V3FACTORY);
         // enforce token sort like the factory does
         (address t0, address t1) = _token0 < _token1 ? (_token0, _token1) : (_token1, _token0);
-        poolId = sfpm.initializeAMMPool(t0, t1, fee);
+        poolId = sfpm.initializeAMMPool(t0, t1, fee, vegoid);
 
         // 2) Risk engine
         riskEngine = new RiskEngineHarness(10_000_000, 10_000_000, address(0));
@@ -882,7 +887,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         sfpm = new SemiFungiblePositionManagerHarness(V3FACTORY);
         // enforce token sort like the factory does
         (address t0, address t1) = _token0 < _token1 ? (_token0, _token1) : (_token1, _token0);
-        poolId = sfpm.initializeAMMPool(t0, t1, fee);
+        poolId = sfpm.initializeAMMPool(t0, t1, fee, vegoid);
 
         // 2) Risk engine
         riskEngine = new RiskEngineHarness(crossBuffer0, crossBuffer1, address(0));
@@ -976,7 +981,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         sfpm = new SemiFungiblePositionManagerHarness(V3FACTORY);
         // enforce token sort like the factory does
         (address t0, address t1) = _token0 < _token1 ? (_token0, _token1) : (_token1, _token0);
-        poolId = sfpm.initializeAMMPool(t0, t1, fee);
+        poolId = sfpm.initializeAMMPool(t0, t1, fee, vegoid);
 
         // 2) Risk engine
         riskEngine = new RiskEngineHarness(10_000_000, 10_000_000, guardian);

--- a/test/foundry/coreV3/Misc.t.sol
+++ b/test/foundry/coreV3/Misc.t.sol
@@ -159,6 +159,7 @@ contract Misctest is Test, PositionUtils {
     OraclePack oraclePack;
     uint64 $poolId;
     uint64 poolId;
+    uint256 vegoid = 4;
     uint256 medianData;
 
     uint256 assetsBefore0;
@@ -536,7 +537,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -597,7 +598,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == positionCount - 1) {
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -679,7 +680,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -709,7 +710,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == positionCount - 1) {
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
                 posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -759,7 +760,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -819,7 +820,7 @@ contract Misctest is Test, PositionUtils {
             );
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -865,7 +866,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == 0) {
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
                 posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -946,7 +947,7 @@ contract Misctest is Test, PositionUtils {
 
         for (uint256 i = 0; i < positionCount; i++) {
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             TokenId posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -975,7 +976,7 @@ contract Misctest is Test, PositionUtils {
             );
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
             posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -991,7 +992,7 @@ contract Misctest is Test, PositionUtils {
 
             if (i == 0) {
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
                 posId = TokenId.wrap(0).addPoolId(poolId).addLeg({
@@ -1066,7 +1067,7 @@ contract Misctest is Test, PositionUtils {
 
         IUniswapV3Pool(uniPool).initialize(2 ** 96);
 
-        sfpm.initializeAMMPool(address(token0), address(token1), feeTier);
+        sfpm.initializeAMMPool(address(token0), address(token1), feeTier, vegoid);
 
         vm.startPrank(Swapper);
         token0.mint(Swapper, type(uint128).max);
@@ -1083,7 +1084,7 @@ contract Misctest is Test, PositionUtils {
         uint256 expectedDOSCost = Math.max(2100 * 10 ** 18, token0Supply);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         (int24 tickLimitLower, int24 tickLimitUpper) = sfpm.getEnforcedTickLimits(poolId);
@@ -1158,7 +1159,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         TokenId tickPosition = TokenId.wrap(0).addPoolId(poolId).addLeg(
@@ -1184,7 +1185,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         tickPosition = TokenId.wrap(0).addPoolId(poolId).addLeg(
@@ -1222,7 +1223,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         tickPosition = TokenId.wrap(0).addPoolId(poolId).addLeg(
@@ -1248,7 +1249,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         tickPosition = TokenId.wrap(0).addPoolId(poolId).addLeg(
@@ -1312,7 +1313,7 @@ contract Misctest is Test, PositionUtils {
 
         IUniswapV3Pool(uniPool).initialize(2 ** 96);
 
-        sfpm.initializeAMMPool(address(token0), address(token1), feeTier);
+        sfpm.initializeAMMPool(address(token0), address(token1), feeTier, vegoid);
 
         token0Supply = bound(token0Supply, 0, type(uint256).max / 10_000);
         token1Supply = bound(token1Supply, 0, type(uint256).max / 10_000);
@@ -1321,7 +1322,7 @@ contract Misctest is Test, PositionUtils {
         token1.editSupply(token1Supply);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         sfpm.expandEnforcedTickRange(poolId);
@@ -1344,7 +1345,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1420,7 +1421,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1447,7 +1448,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1486,7 +1487,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Alice);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1513,7 +1514,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1558,7 +1559,7 @@ contract Misctest is Test, PositionUtils {
         swapperc.mint(uniPool, -100000, 100000, 10 ** 24);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1607,7 +1608,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1651,7 +1652,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1671,7 +1672,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1693,7 +1694,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1710,7 +1711,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1759,7 +1760,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1819,7 +1820,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1838,7 +1839,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1900,7 +1901,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -1961,7 +1962,7 @@ contract Misctest is Test, PositionUtils {
         $tempIdList = $posIdList;
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2228,7 +2229,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2247,7 +2248,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2316,7 +2317,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2360,7 +2361,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2381,7 +2382,7 @@ contract Misctest is Test, PositionUtils {
         TokenId[] memory longPositionList = new TokenId[](256);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2455,7 +2456,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2580,7 +2581,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2602,7 +2603,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2683,7 +2684,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2705,7 +2706,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -2759,7 +2760,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         swapperc.mint(uniPool, -887200, 887200, 10 ** 18);
@@ -2809,7 +2810,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3018,7 +3019,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         swapperc.mint(uniPool, -887200, 887200, 10 ** 18);
@@ -3068,7 +3069,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3277,7 +3278,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3329,7 +3330,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3346,7 +3347,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3367,7 +3368,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3399,7 +3400,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3431,7 +3432,7 @@ contract Misctest is Test, PositionUtils {
         }
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -3505,7 +3506,8 @@ contract Misctest is Test, PositionUtils {
                 10,
                 20,
                 currentTick,
-                0
+                0,
+                vegoid
             );
 
             console2.log(
@@ -3528,7 +3530,8 @@ contract Misctest is Test, PositionUtils {
                 10,
                 20,
                 currentTick,
-                1
+                1,
+                vegoid
             );
 
             console2.log(
@@ -3563,7 +3566,8 @@ contract Misctest is Test, PositionUtils {
                 -20,
                 -10,
                 0,
-                0
+                0,
+                vegoid
             );
 
             console2.log(
@@ -3586,7 +3590,8 @@ contract Misctest is Test, PositionUtils {
                 -20,
                 -10,
                 0,
-                1
+                1,
+                vegoid
             );
 
             console2.log(
@@ -3660,12 +3665,12 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4108,7 +4113,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4162,7 +4167,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4331,7 +4336,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4365,7 +4370,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4399,7 +4404,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4436,7 +4441,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4483,7 +4488,7 @@ contract Misctest is Test, PositionUtils {
         swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4553,7 +4558,7 @@ contract Misctest is Test, PositionUtils {
         swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4622,7 +4627,7 @@ contract Misctest is Test, PositionUtils {
         swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4800,7 +4805,7 @@ contract Misctest is Test, PositionUtils {
         swapperc.mint(uniPool, -10000, 10000, 10 ** 18);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -4982,7 +4987,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5141,7 +5146,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(pp.isSafeMode() == 0, "not in safe mode");
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5253,7 +5258,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(pp.isSafeMode() > 0, "in safe mode");
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5345,7 +5350,7 @@ contract Misctest is Test, PositionUtils {
         assertTrue(pp.isSafeMode() == 0, "not in safe mode");
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5450,7 +5455,7 @@ contract Misctest is Test, PositionUtils {
         (, , slowOracleTick, , oraclePack) = pp.getOracleTicks();
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5573,7 +5578,7 @@ contract Misctest is Test, PositionUtils {
         (, , slowOracleTick, , oraclePack) = pp.getOracleTicks();
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5692,7 +5697,7 @@ contract Misctest is Test, PositionUtils {
         (, , slowOracleTick, , oraclePack) = pp.getOracleTicks();
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5789,7 +5794,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -5905,7 +5910,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6081,7 +6086,7 @@ contract Misctest is Test, PositionUtils {
         token1.approve(address(swapperc), type(uint128).max);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6302,7 +6307,7 @@ contract Misctest is Test, PositionUtils {
         uniPool.liquidity();
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6368,7 +6373,8 @@ contract Misctest is Test, PositionUtils {
             -20470,
             20470,
             0,
-            0
+            0,
+            vegoid
         );
         assertEq(premium0, 340282366920938463444927863358058659840);
         assertEq(premium1, 44704247211996718928643);
@@ -6420,7 +6426,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6461,7 +6467,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6540,7 +6546,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6581,7 +6587,7 @@ contract Misctest is Test, PositionUtils {
         );
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6652,7 +6658,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Seller);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6766,7 +6772,7 @@ contract Misctest is Test, PositionUtils {
         vm.startPrank(Bob);
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -6821,7 +6827,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -6975,7 +6981,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7057,7 +7063,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7172,7 +7178,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
         TokenId tokenId = TokenId.wrap(0).addPoolId(poolId).addLeg(
@@ -7322,7 +7328,7 @@ contract Misctest is Test, PositionUtils {
         uint256 tokenType = 0;
 
         {
-            poolId = uint64(uint160(address(uniPool)) >> 112);
+            poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
         }
 
@@ -7467,7 +7473,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -7566,7 +7572,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -7671,7 +7677,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = ((i % 4) / 2);
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -7779,7 +7785,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = ((i % 4) / 2);
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -7888,7 +7894,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = ((i % 4) / 2);
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8007,7 +8013,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8098,7 +8104,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = i / 2;
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8198,7 +8204,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = (i / 2);
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8301,7 +8307,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = (i / 2);
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8402,7 +8408,7 @@ contract Misctest is Test, PositionUtils {
             uint256 tokenType = (i / 2);
 
             {
-                poolId = uint64(uint160(address(uniPool)) >> 112);
+                poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
             }
 
@@ -8508,7 +8514,7 @@ contract Misctest is Test, PositionUtils {
                 vm.startPrank(Charlie);
 
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -8537,7 +8543,7 @@ contract Misctest is Test, PositionUtils {
                 );
 
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -8648,7 +8654,7 @@ contract Misctest is Test, PositionUtils {
                 vm.startPrank(Charlie);
 
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 
@@ -8784,7 +8790,7 @@ contract Misctest is Test, PositionUtils {
                 vm.startPrank(Charlie);
 
                 {
-                    poolId = uint64(uint160(address(uniPool)) >> 112);
+                    poolId = uint40(uint160(address(uniPool)) >> 112) + uint64(vegoid << 40);
                     poolId += uint64(uint24(uniPool.tickSpacing())) << 48;
                 }
 

--- a/test/foundry/coreV3/PanopticPool.t.sol
+++ b/test/foundry/coreV3/PanopticPool.t.sol
@@ -147,6 +147,7 @@ contract PanopticPoolTest is PositionUtils {
     // store some data about the pool we are testing
     IUniswapV3Pool pool;
     uint64 poolId;
+    uint256 vegoid = 4;
     address token0;
     address token1;
     // We range position size in terms of WETH, so need to figure out which token is WETH
@@ -495,7 +496,7 @@ contract PanopticPoolTest is PositionUtils {
         pool = _pool;
 
         {
-            poolId = uint64(uint160(address(_pool)) >> 112);
+            poolId = uint40(uint160(address(_pool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(_pool.tickSpacing())) << 48;
         }
 
@@ -1906,7 +1907,8 @@ contract PanopticPoolTest is PositionUtils {
                 tickLowers[0],
                 tickUppers[0],
                 currentTick,
-                0
+                0,
+                vegoid
             );
 
             expectedPremia[0] += (premiumToken0 * expectedLiqs[0]) / 2 ** 64;
@@ -1922,7 +1924,8 @@ contract PanopticPoolTest is PositionUtils {
                 tickLowers[1],
                 tickUppers[1],
                 currentTick,
-                0
+                0,
+                vegoid
             );
 
             expectedPremia[0] += (premiumToken0 * expectedLiqs[1]) / 2 ** 64;

--- a/test/foundry/coreV3/SemiFungiblePositionManager.t.sol
+++ b/test/foundry/coreV3/SemiFungiblePositionManager.t.sol
@@ -90,6 +90,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     // immutable data about the pool being tested
     IUniswapV3Pool pool;
     uint64 poolId;
+    uint256 vegoid = 4;
     address token0;
     address token1;
     uint24 fee;
@@ -181,7 +182,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     /// @notice Intialize testing pool in the SFPM instance after world state is setup
     function _initPool(uint256 seed) internal {
         _initWorld(seed);
-        sfpm.initializeAMMPool(token0, token1, fee);
+        sfpm.initializeAMMPool(token0, token1, fee, vegoid);
     }
 
     /// @notice Set up world state with data from a random pool off the list and fund+approve actors
@@ -225,7 +226,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
     function _cacheWorldState(IUniswapV3Pool _pool) internal {
         pool = _pool;
         {
-            poolId = uint64(uint160(address(_pool)) >> 112);
+            poolId = uint40(uint160(address(_pool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(_pool.tickSpacing())) << 48;
         }
         token0 = _pool.token0();
@@ -898,7 +899,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         uint64 poolId;
 
         {
-            poolId = uint64(uint160(address(pool)) >> 112);
+            poolId = uint40(uint160(address(pool)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(pool.tickSpacing())) << 48;
         }
 
@@ -913,11 +914,11 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         // Loop through all pools and test
         for (uint256 i = 0; i < pools.length; i++) {
             _cacheWorldState(pools[i]);
-            sfpm.initializeAMMPool(token0, token1, fee);
+            sfpm.initializeAMMPool(token0, token1, fee, vegoid);
             uint64 poolId;
 
             {
-                poolId = uint64(uint160(address(pool)) >> 112);
+                poolId = uint40(uint160(address(pool)) >> 112) + uint64(vegoid << 40);
                 poolId += uint64(uint24(pool.tickSpacing())) << 48;
             }
 
@@ -939,7 +940,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         );
 
         UniPoolPriceMock pm = new UniPoolPriceMock();
-        uint64 poolIdNew = (200 << 48);
+        uint64 poolIdNew = (200 << 48) + (4 << 40);
         for (uint160 i = 0; i < 100; i++) {
             factoryMock.increment();
 
@@ -966,18 +967,25 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
             // etch tickSpacing
             // These values are zero at this point, but they are ignored by the factory mock
-            sfpm_t.initializeAMMPool(token0, token1, fee);
+            sfpm_t.initializeAMMPool(token0, token1, fee, vegoid);
 
             if (i != 0) {
                 poolIdNew = PanopticMath.incrementPoolPattern(poolIdNew);
             }
-
             // Check that the pool address is set correctly
-            assertEq(address(sfpm_t.getUniswapV3PoolFromId(poolIdNew)), address((i + 1) << 24));
+            assertEq(
+                address(sfpm_t.getUniswapV3PoolFromId(poolIdNew)),
+                address((i + 1) << 24),
+                "address is set correctly"
+            );
 
             // Check that the pool ID is set correctly
             // Addresses output from the factory mock start at 1 to avoid errors so we need to add that to the address
-            assertEq(sfpm_t.addressToPoolData(address((i + 1) << 24)).initialized(), true);
+            assertEq(
+                sfpm_t.addressToPoolData(address((i + 1) << 24)).initialized(),
+                true,
+                "initialized"
+            );
 
             token0 = address(uint160(token0) + 1);
         }
@@ -991,7 +999,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         vm.expectRevert(Errors.PoolNotInitialized.selector);
 
         // These values are zero at this point; thus there is no corresponding uni pool and we should revert
-        sfpm.initializeAMMPool(token0, token1, fee);
+        sfpm.initializeAMMPool(token0, token1, fee, vegoid);
     }
 
     /// NOTE - the definitions of "call" and "put" can vary by Uniswap pair and which token is considered the asset
@@ -2031,7 +2039,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
 
         // Initialize the world pool
-        sfpm.initializeAMMPool(token0, token1, fee);
+        sfpm.initializeAMMPool(token0, token1, fee, vegoid);
 
         (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
             widthSeed,
@@ -2100,7 +2108,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
 
         // Initialize the world pool
-        sfpm.initializeAMMPool(token0, token1, fee);
+        sfpm.initializeAMMPool(token0, token1, fee, vegoid);
 
         (int24 width, int24 strike) = PositionUtils.getOutOfRangeSW(
             widthSeed,
@@ -2321,7 +2329,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
         vm.startPrank(Alice);
         deal(token1, Alice, 10 ** 6);
         IERC20Partial(token1).approve(address(sfpm), type(uint256).max);
-        sfpm.initializeAMMPool(token0, token1, fee);
+        sfpm.initializeAMMPool(token0, token1, fee, vegoid);
 
         // --- GIVEN: A short put option (pays token0) ---
         int24 strike = currentTick + 10 * tickSpacing; // In-the-money
@@ -3842,7 +3850,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
                 tickLower,
                 tickUpper,
                 currentTick,
-                0
+                0,
+                vegoid
             );
             assertEq(premiumToken0, 0);
             assertEq(premiumtoken1, 0);
@@ -3897,7 +3906,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
                 tickLower,
                 tickUpper,
                 currentTick,
-                0
+                0,
+                vegoid
             );
             assertEq(
                 premiumToken0,
@@ -3940,7 +3950,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
                 tickLower,
                 tickUpper,
                 type(int24).max,
-                0
+                0,
+                vegoid
             );
             assertEq(premiumToken0, 0);
             assertEq(premiumtoken1, 0);
@@ -4052,7 +4063,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            0
+            0,
+            vegoid
         );
         assertEq(premium0Short, 0);
         assertEq(premium1Short, 0);
@@ -4064,7 +4076,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            1
+            1,
+            vegoid
         );
         assertEq(premium0Long, 0);
         assertEq(premium1Long, 0);
@@ -4085,7 +4098,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            0
+            0,
+            vegoid
         );
 
         assertApproxEqAbs(
@@ -4106,7 +4120,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(
             premium0Long,
@@ -4176,7 +4191,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            0
+            0,
+            vegoid
         );
 
         assertApproxEqAbs(
@@ -4197,7 +4213,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(
             premium0Long,
@@ -4231,7 +4248,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            0
+            0,
+            vegoid
         );
 
         {
@@ -4311,7 +4329,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            1
+            1,
+            vegoid
         );
 
         {
@@ -4373,7 +4392,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(premium0Long, premium0LongOld, premiaError0[1]);
         assertApproxEqAbs(premium1Long, premium1LongOld, premiaError1[1]);
@@ -4385,7 +4405,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            1
+            1,
+            vegoid
         );
         assertApproxEqAbs(premium0Long, premium0LongOld, premiaError0[1]);
         assertApproxEqAbs(premium1Long, premium1LongOld, premiaError1[1]);
@@ -4410,7 +4431,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             type(int24).max,
-            0
+            0,
+            vegoid
         );
 
         assertApproxEqAbs(premium0Short, premium0ShortOld, premiaError0[0]);
@@ -4423,7 +4445,8 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
             tickLower,
             tickUpper,
             currentTick,
-            0
+            0,
+            vegoid
         );
         assertApproxEqAbs(premium0Short, premium0ShortOld, premiaError0[0]);
         assertApproxEqAbs(premium1Short, premium1ShortOld, premiaError1[0]);
@@ -4900,7 +4923,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         // need a super wide position to exxagerate position size units
         _cacheWorldState(USDC_WETH_30);
-        sfpm.initializeAMMPool(token0, token1, fee);
+        sfpm.initializeAMMPool(token0, token1, fee, vegoid);
 
         int24 width = 4090;
         int24 strike = 0;
@@ -4962,7 +4985,7 @@ contract SemiFungiblePositionManagerTest is PositionUtils {
 
         _cacheWorldState(USDC_WETH_30);
 
-        sfpm.initializeAMMPool(token0, token1, fee);
+        sfpm.initializeAMMPool(token0, token1, fee, vegoid);
 
         int24 width = 4090;
         int24 strike = 0;

--- a/test/foundry/testUtils/ReentrancyMocks.sol
+++ b/test/foundry/testUtils/ReentrancyMocks.sol
@@ -57,9 +57,10 @@ contract ReenterBurn {
         bool reenter = !activated;
         activated = true;
         uint64 poolId;
+        uint256 vegoid = 4;
 
         {
-            poolId = uint64(uint160(address(this)) >> 112);
+            poolId = uint40(uint160(address(this)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(tickSpacing)) << 48;
         }
 
@@ -124,9 +125,10 @@ contract ReenterMint {
         bool reenter = !activated;
         activated = true;
         uint64 poolId;
+        uint256 vegoid = 4;
 
         {
-            poolId = uint64(uint160(address(this)) >> 112);
+            poolId = uint40(uint160(address(this)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(tickSpacing)) << 48;
         }
 
@@ -191,9 +193,9 @@ contract ReenterTransferSingle {
         bool reenter = !activated;
         activated = true;
         uint64 poolId;
-
+        uint256 vegoid = 4;
         {
-            poolId = uint64(uint160(address(this)) >> 112);
+            poolId = uint40(uint160(address(this)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(tickSpacing)) << 48;
         }
 
@@ -258,9 +260,9 @@ contract ReenterTransferBatch {
         bool reenter = !activated;
         activated = true;
         uint64 poolId;
-
+        uint256 vegoid = 4;
         {
-            poolId = uint64(uint160(address(this)) >> 112);
+            poolId = uint40(uint160(address(this)) >> 112) + uint64(vegoid << 40);
             poolId += uint64(uint24(tickSpacing)) << 48;
         }
 
@@ -283,7 +285,7 @@ contract Reenter1155Initialize {
     address public token1;
     uint24 public fee;
     uint64 poolId;
-
+    uint256 vegoid = 4;
     bool activated;
 
     function construct(address _token0, address _token1, uint24 _fee, uint64 _poolId) public {
@@ -304,7 +306,12 @@ contract Reenter1155Initialize {
         activated = true;
 
         if (reenter)
-            SemiFungiblePositionManagerHarness(msg.sender).initializeAMMPool(token0, token1, fee);
+            SemiFungiblePositionManagerHarness(msg.sender).initializeAMMPool(
+                token0,
+                token1,
+                fee,
+                vegoid
+            );
         if (reenter)
             SemiFungiblePositionManagerHarness(msg.sender).mintTokenizedPosition(
                 new bytes(0),
@@ -323,7 +330,7 @@ contract Reenter1155InitializeV4 {
     uint256[65535] private __gap;
 
     PoolKey key;
-
+    uint256 vegoid = 4;
     bool activated;
 
     function construct(PoolKey memory _key) public {
@@ -347,7 +354,7 @@ contract Reenter1155InitializeV4 {
         activated = true;
 
         PoolKey memory _key = key;
-        if (reenter) SFPMHarnessV4(msg.sender).initializeAMMPool(key);
+        if (reenter) SFPMHarnessV4(msg.sender).initializeAMMPool(key, vegoid);
         if (reenter)
             SFPMHarnessV4(msg.sender).mintTokenizedPosition(
                 abi.encode(_key),


### PR DESCRIPTION
## Summary
This PR introduces a configurable `vegoid` parameter (premium sensitivity to utilization) per pool, sourced from the `RiskEngine`. To achieve this without increasing storage costs, the `PoolId` structure within `TokenId` has been refactored to pack the `vegoid` value directly into the ID.

## Key Changes

### 1. Storage & Types (`TokenId.sol`, `PanopticMath.sol`)
Refactored the `PoolId` bit layout to accommodate the 8-bit `vegoid` parameter.
* **Reduced** the Uniswap Pool Address hash from **48 bits** to **40 bits**.
* **Added** the **8-bit** `vegoid` parameter into the vacated space.
* **Updated** `TokenId` masks and helper functions (`vegoid()`) to extract this value dynamically.

**New `PoolId` Layout (64 LSBs):**
`[16-bit tickSpacing] [8-bit vegoid] [40-bit Pool Address Hash]`

### 2. Risk Engine & Factory
* **RiskEngine:** Exposed a `vegoid()` view function (currently set to `4`).
* **Factories (V3 & V4):** Updated `initializeAMMPool` to fetch the `vegoid` from the `RiskEngine` at deployment time and pass it to the SFPM.

### 3. Core Logic (`SFPM.sol`)
* **Initialization:** The `vegoid` is now permanently "stamped" into the `poolId` upon initialization.
* **Premium Calculation:** Updated `_getPremiaDeltas` to use the passed `vegoid` value.
    * **Previous:** Divisor was calculated as `2 ** VEGOID`.
    * **Current:** Divisor is the raw `vegoid` value.
    * *Note:* This allows for linear tuning of the Streamia divisor rather than being restricted to powers of two.

## Technical Details

### Bit-Packing Trade-off
To avoid an `SLOAD` on every premium calculation, we reduced the collision resistance of the Pool Address fingerprint:
* **Before:** 48 bits (approx. 2.81e14 combinations)
* **After:** 40 bits (approx. 1.10e12 combinations)

### Math Update
The "Streamia" formula in `_getPremiaDeltas` has been updated:
```solidity
// Old
uint256 numerator = netLiquidity + (removedLiquidity / 2 ** VEGOID);

// New
uint256 numerator = netLiquidity + (removedLiquidity / vegoid);