### PR TITLE
feat: Add BuilderDeployed event to BuilderFactory

### DIFF
--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -2346,6 +2346,8 @@ library Create2Lib {
 contract BuilderFactory {
     using Create2Lib for uint256;
 
+    event BuilderDeployed(uint48 indexed builderCode, address indexed wallet, address builderAdmin);
+
     address public immutable OWNER;
 
     constructor(address owner) {
@@ -2383,6 +2385,8 @@ contract BuilderFactory {
         wallet = Create2Lib.deploy(0, salt, initCode);
         // now set the admin in storage (not part of init code)
         BuilderWallet(wallet).init(builderAdmin);
+
+        emit BuilderDeployed(builderCode, wallet, builderAdmin);
     }
 
     /**

--- a/test/foundry/core/BuilderFactory.t.sol
+++ b/test/foundry/core/BuilderFactory.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {BuilderFactory} from "@contracts/RiskEngine.sol";
+import {BuilderWallet} from "@contracts/RiskEngine.sol";
+
+contract BuilderFactoryTest is Test {
+    BuilderFactory public builderFactory;
+
+    address public owner = address(0x1);
+    address public builderAdmin = address(0x2);
+
+    event BuilderDeployed(uint48 indexed builderCode, address indexed wallet, address builderAdmin);
+
+    function setUp() public {
+        vm.prank(owner);
+        builderFactory = new BuilderFactory(owner);
+    }
+
+    function test_DeployBuilder_EmitsBuilderDeployedEvent() public {
+        uint48 builderCode = 123456;
+
+        address expectedWallet = builderFactory.predictBuilderWallet(builderCode);
+
+        vm.recordLogs();
+
+        vm.prank(owner);
+        address wallet = builderFactory.deployBuilder(builderCode, builderAdmin);
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        // Find the BuilderDeployed event
+        bytes32 eventSig = keccak256("BuilderDeployed(uint48,address,address)");
+        bool found = false;
+        for (uint256 i = 0; i < entries.length; i++) {
+            if (entries[i].topics[0] == eventSig) {
+                found = true;
+
+                // Assert event properties match what we expect
+                uint48 emittedCode = uint48(uint256(entries[i].topics[1]));
+                assertEq(emittedCode, builderCode, "Emitted builderCode should match");
+
+                address emittedWallet = address(uint160(uint256(entries[i].topics[2])));
+                assertEq(emittedWallet, expectedWallet, "Emitted wallet should match expected");
+                assertEq(emittedWallet, wallet, "Emitted wallet should match returned wallet");
+
+                address emittedAdmin = abi.decode(entries[i].data, (address));
+                assertEq(emittedAdmin, builderAdmin, "Emitted builderAdmin should match");
+
+                break;
+            }
+        }
+
+        assertTrue(found, "BuilderDeployed event should be emitted");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BuilderDeployed` event to `BuilderFactory` contract
- Emit event in `deployBuilder()` function when a new builder wallet is created
- Event includes `builderCode` (indexed), `wallet` (indexed), and `builderAdmin` for off-chain tracking
- Test to ensure event gets emitted
- Test to ensure result of `predictBuilderWallet` matches emitted builder wallet property in event