### PR TITLE
feat: use utilization-dependent margin curve for loan positions

### DIFF
--- a/contracts/RiskEngine.sol
+++ b/contracts/RiskEngine.sol
@@ -1422,10 +1422,14 @@ contract RiskEngine {
             // if the width is 0, then this is a loan/credit
             if (tokenId.width(index) == 0) {
                 if (isLong == 0) {
-                    // buying power requirement for a Loan position is 100% + MAINT_MARGIN_RATE
+                    // buying power requirement for a Loan position is 100% + maintenanceLoanMargin
+                    uint256 maintenanceLoanMargin = _sellCollateralRatio(
+                        poolUtilization,
+                        MAINT_MARGIN_RATE
+                    );
                     required = Math.mulDivRoundingUp(
                         amountMoved,
-                        MAINT_MARGIN_RATE + DECIMALS,
+                        maintenanceLoanMargin + DECIMALS,
                         DECIMALS
                     );
                 } else {
@@ -1741,7 +1745,7 @@ contract RiskEngine {
 
         if (isLong == 0) {
             // compute the sell collateral ratio, which depends on the pool utilization
-            baseCollateralRatio = _sellCollateralRatio(utilization);
+            baseCollateralRatio = _sellCollateralRatio(utilization, SELLER_COLLATERAL_RATIO);
 
             // compute required as amount*collateralRatio
             // can use unsafe because denominator is always nonzero
@@ -2078,9 +2082,11 @@ contract RiskEngine {
     /// @notice Get the base collateral requirement for a short leg at a given pool utilization.
     /// @dev This is computed at the time the position is minted.
     /// @param utilization The pool utilization of this collateral vault at the time the position is minted
+    /// @param minRatio The minimum (base) ratio
     /// @return sellCollateralRatio The sell collateral ratio at `utilization`
     function _sellCollateralRatio(
-        int256 utilization
+        int256 utilization,
+        uint256 minRatio
     ) internal pure returns (uint256 sellCollateralRatio) {
         // the sell ratio is on a straight line defined between two points (x0,y0) and (x1,y1):
         //   (x0,y0) = (targetPoolUtilization,min_sell_ratio) and
@@ -2101,11 +2107,10 @@ contract RiskEngine {
                                    50%    90% 100%     UTILIZATION
         */
 
-        uint256 min_sell_ratio = SELLER_COLLATERAL_RATIO;
         /// if utilization is less than zero, this is the calculation for a strangle, which gets 2x the capital efficiency at low pool utilization
         if (utilization < 0) {
             unchecked {
-                min_sell_ratio /= 2;
+                minRatio /= 2;
                 utilization = -utilization;
             }
         }
@@ -2115,7 +2120,7 @@ contract RiskEngine {
         }
         // return the basal sell ratio if pool utilization is lower than target
         if (uint256(utilization) < TARGET_POOL_UTIL) {
-            return min_sell_ratio;
+            return minRatio;
         }
 
         // return 100% collateral ratio if utilization is above saturated pool utilization
@@ -2125,8 +2130,8 @@ contract RiskEngine {
 
         unchecked {
             return
-                min_sell_ratio +
-                ((DECIMALS - min_sell_ratio) * (uint256(utilization) - TARGET_POOL_UTIL)) /
+                minRatio +
+                ((DECIMALS - minRatio) * (uint256(utilization) - TARGET_POOL_UTIL)) /
                 (SATURATED_POOL_UTIL - TARGET_POOL_UTIL);
         }
     }

--- a/test/foundry/core/CollateralTracker.t.sol
+++ b/test/foundry/core/CollateralTracker.t.sol
@@ -262,7 +262,7 @@ contract RiskEngineHarness is RiskEngine {
     }
 
     function sellCollateralRatio(int256 utilization) external view returns (uint256) {
-        return _sellCollateralRatio(utilization);
+        return _sellCollateralRatio(utilization, 2_000_000);
     }
 
     function buyCollateralRatio(int256 utilization) external view returns (uint256) {
@@ -5494,6 +5494,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     /// @notice It should revert if a user tries to withdraw using a tokenId with no legs.
     function test_Fail_withdrawWhileInsolvent(address caller) public {
+        vm.assume(caller != address(0));
         _initWorld(0);
 
         // initalize a custom Panoptic pool
@@ -5543,6 +5544,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     /// @notice It should revert if a user tries to withdraw using a tokenId with no legs.
     function test_Fail_withdrawWhileInSafeMode(address caller) public {
+        vm.assume(caller != address(0));
         _initWorld(0);
 
         // initalize a custom Panoptic pool
@@ -5605,6 +5607,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
 
     /// @notice It should revert if a user tries to withdraw using a tokenId with no legs.
     function test_Fail_withdraw_credited_shares(address caller) public {
+        vm.assume(caller != address(0));
         _initWorld(0);
 
         // initalize a custom Panoptic pool
@@ -6645,6 +6648,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
     // access control on delegate/revoke/settlement functions
     function test_Fail_All_OnlyPanopticPool(uint256 x, address caller) public {
         _initWorld(x);
+        vm.assume(caller != address(0));
         vm.assume(caller != address(panopticPool));
 
         vm.prank(caller);
@@ -13208,6 +13212,7 @@ contract CollateralTrackerTest is Test, PositionUtils {
         TokenId _tokenId,
         uint128 positionSize
     ) internal {
+        vm.assume(caller != address(0));
         // take a snapshot at this storage state
         uint256 snapshot = vm.snapshot();
         vm.startPrank(address(panopticPool));

--- a/test/foundry/core/RiskEngine/RiskEngine.UtilMarginLoans.t.sol
+++ b/test/foundry/core/RiskEngine/RiskEngine.UtilMarginLoans.t.sol
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import {RiskEngineHarness} from "./RiskEngineHarness.sol";
+import {MockCollateralTracker} from "./mocks/MockCollateralTracker.sol";
+import {CollateralTrackerV2} from "@contracts/CollateralTracker.sol";
+import {LeftRightUnsigned} from "@types/LeftRight.sol";
+import {TokenId} from "@types/TokenId.sol";
+import {PositionBalance} from "@types/PositionBalance.sol";
+import {PositionFactory} from "./helpers/PositionFactory.sol";
+import {Constants} from "@libraries/Constants.sol";
+
+/// @notice Tests for utilization-dependent margin on loans (width==0 short legs)
+/// and the parameterized _sellCollateralRatio(util, minRatio).
+contract RiskEngineUtilMarginLoans is Test {
+    using PositionFactory for *;
+
+    RiskEngineHarness internal E;
+    MockCollateralTracker internal ct0;
+    MockCollateralTracker internal ct1;
+
+    uint256 constant DEC = 10_000_000;
+    uint256 constant MAINT = 2_000_000; // MAINT_MARGIN_RATE = 20%
+    uint256 constant SELLER = 2_000_000; // SELLER_COLLATERAL_RATIO = 20%
+    uint256 constant TARGET = 6_666_667; // TARGET_POOL_UTIL (scaled by 1000 internally)
+    uint256 constant SATURATED = 9_000_000; // SATURATED_POOL_UTIL
+
+    function setUp() public {
+        E = new RiskEngineHarness(5_000_000, 5_000_000);
+        ct0 = new MockCollateralTracker();
+        ct1 = new MockCollateralTracker();
+        ct0.setGlobal(1_000_000 ether, 1_000_000 ether);
+        ct1.setGlobal(1_000_000 ether, 1_000_000 ether);
+        ct0.setSharePrice(1, 1);
+        ct1.setSharePrice(1, 1);
+    }
+
+    // ─── _sellCollateralRatio with custom minRatio ───────────────────
+
+    function test_sellCollateralRatioCustom_belowTarget() public view {
+        // Below target utilization → returns minRatio unchanged
+        uint256 ratio = E.sellCollateralRatioCustom(3000, 3_000_000);
+        assertEq(ratio, 3_000_000, "below target should return minRatio");
+    }
+
+    function test_sellCollateralRatioCustom_aboveSaturated() public view {
+        // Above saturated → returns DECIMALS (100%)
+        uint256 ratio = E.sellCollateralRatioCustom(9500, 3_000_000);
+        assertEq(ratio, DEC, "above saturated should return 100%");
+    }
+
+    function test_sellCollateralRatioCustom_midpoint() public view {
+        // Between target and saturated, ratio interpolates between minRatio and DECIMALS
+        // Use utilization = 8000 (80%), which after *1000 = 8_000_000
+        uint256 ratio = E.sellCollateralRatioCustom(8000, 2_000_000);
+        // expected: 2_000_000 + (10_000_000 - 2_000_000) * (8_000_000 - 6_666_667) / (9_000_000 - 6_666_667)
+        // = 2_000_000 + 8_000_000 * 1_333_333 / 2_333_333
+        uint256 expected = uint256(2_000_000) + (uint256(8_000_000) * 1_333_333) / 2_333_333;
+        assertEq(ratio, expected, "midpoint interpolation");
+    }
+
+    function test_sellCollateralRatioCustom_differentMinRatios() public view {
+        // Same utilization but different minRatio should give different results
+        int256 util = 8000;
+        uint256 r1 = E.sellCollateralRatioCustom(util, 1_000_000); // 10%
+        uint256 r2 = E.sellCollateralRatioCustom(util, 3_000_000); // 30%
+        assertTrue(r1 < r2, "higher minRatio should give higher ratio at same util");
+    }
+
+    function test_sellCollateralRatioCustom_negativeUtil_halves() public view {
+        // Negative utilization (strangle) halves minRatio then uses absolute value
+        uint256 ratioNeg = E.sellCollateralRatioCustom(-3000, 4_000_000);
+        // minRatio/2 = 2_000_000, util=3000 < target → returns 2_000_000
+        assertEq(ratioNeg, 2_000_000, "negative util should halve minRatio");
+    }
+
+    // ─── Backward compatibility: _sellCollateralRatio with SELLER default ────
+
+    function test_sellCollateralRatio_defaultMatchesCustom() public view {
+        // The existing sellCollateralRatio(util) should match sellCollateralRatioCustom(util, SELLER)
+        for (int256 u = 0; u <= 10000; u += 2500) {
+            assertEq(
+                E.sellCollateralRatio(u),
+                E.sellCollateralRatioCustom(u, SELLER),
+                "default should match custom with SELLER_COLLATERAL_RATIO"
+            );
+        }
+    }
+
+    // ─── Loan margin (width==0, short) uses utilization-dependent curve ──────
+
+    function test_loanMargin_lowUtil_equalsBaseMaint() public view {
+        // At low utilization (0), loan margin = (MAINT + DEC) / DEC * amount = 120% of amount
+        uint64 pool = 1 + (10 << 48);
+        TokenId loan = PositionFactory.makeLeg(
+            pool,
+            0,
+            1,
+            0,
+            /*isLong*/ 0,
+            /*tokenType*/ 0,
+            0,
+            int24(0),
+            int24(0)
+        );
+
+        // poolUtilization=0 → _sellCollateralRatio(0, MAINT) = MAINT (below target)
+        // required = amount * (MAINT + DEC) / DEC
+        uint128 size = 1e18;
+        uint256 req = E.reqSingleNoPartner(loan, 0, size, int24(0), int16(0));
+
+        // expected: ceil(1e18 * (2_000_000 + 10_000_000) / 10_000_000) = ceil(1.2e18) = 1.2e18
+        uint256 expected = (uint256(size) * (MAINT + DEC) + DEC - 1) / DEC;
+        assertEq(req, expected, "low util loan should be 120% collateral");
+    }
+
+    function test_loanMargin_highUtil_exceedsBaseMaint() public view {
+        // At high utilization, loan margin should exceed the base 120%
+        uint64 pool = 1 + (10 << 48);
+        TokenId loan = PositionFactory.makeLeg(
+            pool,
+            0,
+            1,
+            0,
+            /*isLong*/ 0,
+            /*tokenType*/ 0,
+            0,
+            int24(0),
+            int24(0)
+        );
+
+        uint128 size = 1e18;
+        // util=9000 → saturated → _sellCollateralRatio = DECIMALS
+        // required = amount * (DEC + DEC) / DEC = 200% of amount
+        uint256 reqHigh = E.reqSingleNoPartner(loan, 0, size, int24(0), int16(9000));
+        uint256 reqLow = E.reqSingleNoPartner(loan, 0, size, int24(0), int16(0));
+
+        assertTrue(reqHigh > reqLow, "high util loan margin should exceed low util");
+
+        // At saturation: required = ceil(size * 2)
+        uint256 expectedSaturated = (uint256(size) * (DEC + DEC) + DEC - 1) / DEC;
+        assertEq(reqHigh, expectedSaturated, "saturated loan should be 200% collateral");
+    }
+
+    function test_loanMargin_midUtil_interpolated() public view {
+        uint64 pool = 1 + (10 << 48);
+        TokenId loan = PositionFactory.makeLeg(
+            pool,
+            0,
+            1,
+            0,
+            /*isLong*/ 0,
+            /*tokenType*/ 0,
+            0,
+            int24(0),
+            int24(0)
+        );
+
+        uint128 size = 1e18;
+        // util=8000 (80%) → between target and saturated
+        uint256 req = E.reqSingleNoPartner(loan, 0, size, int24(0), int16(8000));
+
+        uint256 reqLow = E.reqSingleNoPartner(loan, 0, size, int24(0), int16(0));
+        uint256 reqHigh = E.reqSingleNoPartner(loan, 0, size, int24(0), int16(9000));
+
+        assertTrue(req > reqLow, "mid util > low util");
+        assertTrue(req < reqHigh, "mid util < saturated");
+    }
+
+    // ─── Credit (width==0, long) still returns 0 ────────────────────
+
+    function test_creditLeg_stillZero() public view {
+        uint64 pool = 1 + (10 << 48);
+        TokenId credit = PositionFactory.makeLeg(
+            pool,
+            0,
+            1,
+            0,
+            /*isLong*/ 1,
+            /*tokenType*/ 0,
+            0,
+            int24(0),
+            int24(0)
+        );
+
+        uint256 req = E.reqSingleNoPartner(credit, 0, 1e18, int24(0), int16(5000));
+        assertEq(req, 0, "credit leg should require 0 collateral");
+    }
+
+    // ─── Short options (width>0) still use SELLER_COLLATERAL_RATIO ──
+
+    function test_shortOption_unaffected() public view {
+        uint64 pool = 1 + (10 << 48);
+        TokenId shortPut = PositionFactory.makeLeg(
+            pool,
+            0,
+            1,
+            0,
+            /*isLong*/ 0,
+            /*tokenType*/ 0,
+            0,
+            int24(0),
+            int24(10)
+        );
+
+        uint128 size = 1e18;
+        // Short option at util=0 should use SELLER_COLLATERAL_RATIO, not MAINT_MARGIN_RATE
+        // Since both are 2_000_000 in this config, compare with reqAtUtil
+        uint256 reqOption = E.reqSingleNoPartner(shortPut, 0, size, int24(0), int16(0));
+        assertTrue(reqOption >= 1, "short option should have nonzero requirement");
+    }
+
+    // ─── Fuzz: loan margin monotonically increases with utilization ──
+
+    function testFuzz_loanMargin_monotonic(int16 util1, int16 util2) public view {
+        // Bound utilizations to valid range
+        util1 = int16(bound(int256(util1), 0, 10000));
+        util2 = int16(bound(int256(util2), int256(util1), 10000));
+
+        uint64 pool = 1 + (10 << 48);
+        TokenId loan = PositionFactory.makeLeg(pool, 0, 1, 0, 0, 0, 0, int24(0), int24(0));
+
+        uint128 size = 1e18;
+        uint256 req1 = E.reqSingleNoPartner(loan, 0, size, int24(0), util1);
+        uint256 req2 = E.reqSingleNoPartner(loan, 0, size, int24(0), util2);
+
+        assertTrue(req2 >= req1, "loan margin should be monotonically non-decreasing with util");
+    }
+
+    // ─── Fuzz: _sellCollateralRatio monotonic for any minRatio ──────
+
+    function testFuzz_sellCollateralRatioCustom_monotonic(
+        int256 util1,
+        int256 util2,
+        uint256 minRatio
+    ) public view {
+        util1 = bound(util1, 0, 10000);
+        util2 = bound(util2, util1, 10000);
+        minRatio = bound(minRatio, 0, DEC);
+
+        uint256 r1 = E.sellCollateralRatioCustom(util1, minRatio);
+        uint256 r2 = E.sellCollateralRatioCustom(util2, minRatio);
+
+        assertTrue(r2 >= r1, "sell ratio should be monotonically non-decreasing");
+    }
+}

--- a/test/foundry/core/RiskEngine/RiskEngineHarness.sol
+++ b/test/foundry/core/RiskEngine/RiskEngineHarness.sol
@@ -21,7 +21,7 @@ contract RiskEngineHarness is RiskEngine {
     // Internal → public test shims
 
     function sellCollateralRatio(int256 util) external view returns (uint256) {
-        return _sellCollateralRatio(util);
+        return _sellCollateralRatio(util, 2_000_000);
     }
 
     function buyCollateralRatio(uint256 util) external view returns (uint256) {

--- a/test/foundry/core/RiskEngine/RiskEngineHarness.sol
+++ b/test/foundry/core/RiskEngine/RiskEngineHarness.sol
@@ -24,6 +24,13 @@ contract RiskEngineHarness is RiskEngine {
         return _sellCollateralRatio(util, 2_000_000);
     }
 
+    function sellCollateralRatioCustom(
+        int256 util,
+        uint256 minRatio
+    ) external view returns (uint256) {
+        return _sellCollateralRatio(util, minRatio);
+    }
+
     function buyCollateralRatio(uint256 util) external view returns (uint256) {
         return _buyCollateralRatio();
     }

--- a/test/foundry/coreV3/CollateralTracker.t.sol
+++ b/test/foundry/coreV3/CollateralTracker.t.sol
@@ -243,7 +243,7 @@ contract RiskEngineHarness is RiskEngine {
     }
 
     function sellCollateralRatio(int256 utilization) external view returns (uint256) {
-        return _sellCollateralRatio(utilization);
+        return _sellCollateralRatio(utilization, 2_000_000);
     }
 
     function buyCollateralRatio(int256 utilization) external view returns (uint256) {

--- a/test/foundry/coreV3/RiskEngine/RiskEngineHarness.sol
+++ b/test/foundry/coreV3/RiskEngine/RiskEngineHarness.sol
@@ -25,7 +25,7 @@ contract RiskEngineHarness is RiskEngine {
     // Internal → public test shims
 
     function sellCollateralRatio(int256 util) external view returns (uint256) {
-        return _sellCollateralRatio(util);
+        return _sellCollateralRatio(util, 2_000_000);
     }
 
     function buyCollateralRatio(uint256 util) external view returns (uint256) {


### PR DESCRIPTION
###  Summary

  - Loan positions (`width==0`, short) now use the same utilization-dependent collateral curve as short options, instead of a flat `MAINT_MARGIN_RATE`. At low utilization the requirement is unchanged (120%), but it scales up to 200% as the pool approaches saturation.
  - Parameterized `_sellCollateralRatio(utilization, minRatio)` so it can be reused with different base ratios (`SELLER_COLLATERAL_RATIO` for options, `MAINT_MARGIN_RATE` for loans).
  - No change to short option margin, long/credit positions, or buy collateral ratio.

###  Test plan

  - Unit tests for _sellCollateralRatio with custom minRatio (below target, above saturated, midpoint, negative util, backward compat)
  - Unit tests for loan margin at low/mid/high utilization
  - Credit leg still returns `0` collateral
  - Short options (`width>0`) unaffected
  - Fuzz: loan margin monotonically non-decreasing with utilization
  - Fuzz: `_sellCollateralRatio` monotonic for arbitrary minRatio
  - Existing integration test t`est_Success_collateralCheck_LoanPosition` passes (delegates to live RiskEngine)